### PR TITLE
Fix uptime tracking leaderboard points calculation

### DIFF
--- a/backend/contributions/tests.py
+++ b/backend/contributions/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/backend/contributions/tests/__init__.py
+++ b/backend/contributions/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for contributions app

--- a/backend/contributions/tests/test_add_daily_uptime.py
+++ b/backend/contributions/tests/test_add_daily_uptime.py
@@ -1,0 +1,280 @@
+from django.test import TestCase
+from django.core.management import call_command
+from django.utils import timezone
+from django.contrib.auth import get_user_model
+from datetime import datetime, timedelta
+import pytz
+from io import StringIO
+from decimal import Decimal
+
+from contributions.models import Contribution, ContributionType
+from leaderboard.models import LeaderboardEntry, GlobalLeaderboardMultiplier
+
+User = get_user_model()
+
+
+class AddDailyUptimeCommandTest(TestCase):
+    """Test the add_daily_uptime management command."""
+    
+    def setUp(self):
+        """Set up test data."""
+        # Create uptime contribution type
+        self.uptime_type = ContributionType.objects.create(
+            name='Uptime',
+            description='Daily validator uptime',
+            min_points=1,
+            max_points=10
+        )
+        
+        # Create a multiplier for uptime
+        self.multiplier = GlobalLeaderboardMultiplier.objects.create(
+            contribution_type=self.uptime_type,
+            multiplier_value=Decimal('2.0'),
+            valid_from=timezone.now() - timedelta(days=30),
+            description='Default uptime multiplier'
+        )
+        
+        # Create test users
+        self.user1 = User.objects.create_user(
+            email='validator1@test.com',
+            password='testpass123',
+            name='Validator 1',
+            address='0x1234567890123456789012345678901234567890'
+        )
+        
+        self.user2 = User.objects.create_user(
+            email='validator2@test.com',
+            password='testpass123',
+            name='Validator 2',
+            address='0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+        )
+        
+        self.user_without_uptime = User.objects.create_user(
+            email='novalidator@test.com',
+            password='testpass123',
+            name='Not a Validator',
+            address='0x9999999999999999999999999999999999999999'
+        )
+    
+    def test_command_creates_daily_uptime_contributions(self):
+        """Test that the command creates daily uptime contributions from first uptime to today."""
+        # Create an initial uptime contribution 5 days ago
+        five_days_ago = timezone.now() - timedelta(days=5)
+        initial_contribution = Contribution.objects.create(
+            user=self.user1,
+            contribution_type=self.uptime_type,
+            points=1,
+            contribution_date=five_days_ago,
+            multiplier_at_creation=Decimal('2.0'),
+            frozen_global_points=2
+        )
+        
+        # Run the command
+        out = StringIO()
+        call_command('add_daily_uptime', stdout=out, verbosity=2)
+        
+        # Check that contributions were created for each day
+        contributions = Contribution.objects.filter(
+            user=self.user1,
+            contribution_type=self.uptime_type
+        ).count()
+        
+        # Should have 6 contributions (initial + 5 days up to today)
+        self.assertGreaterEqual(contributions, 6)
+        
+        # Verify output
+        output = out.getvalue()
+        self.assertIn('Daily uptime generation completed!', output)
+        self.assertIn('Users with uptime: 1', output)
+    
+    def test_leaderboard_updates_correctly(self):
+        """Test that the leaderboard is updated with correct total points."""
+        # Create initial uptime 3 days ago
+        three_days_ago = timezone.now() - timedelta(days=3)
+        Contribution.objects.create(
+            user=self.user1,
+            contribution_type=self.uptime_type,
+            points=1,
+            contribution_date=three_days_ago,
+            multiplier_at_creation=Decimal('2.0'),
+            frozen_global_points=2
+        )
+        
+        # Run the command
+        call_command('add_daily_uptime', verbosity=0)
+        
+        # Check leaderboard entry
+        leaderboard_entry = LeaderboardEntry.objects.get(user=self.user1)
+        
+        # Should have 4 days worth of points (3 days + today) * 2 points each = 8 points
+        self.assertGreaterEqual(leaderboard_entry.total_points, 8)
+    
+    def test_multiple_users_with_uptime(self):
+        """Test that multiple users get their uptime updated correctly."""
+        # Create initial uptimes for both users
+        two_days_ago = timezone.now() - timedelta(days=2)
+        
+        Contribution.objects.create(
+            user=self.user1,
+            contribution_type=self.uptime_type,
+            points=1,
+            contribution_date=two_days_ago,
+            multiplier_at_creation=Decimal('2.0'),
+            frozen_global_points=2
+        )
+        
+        Contribution.objects.create(
+            user=self.user2,
+            contribution_type=self.uptime_type,
+            points=1,
+            contribution_date=two_days_ago - timedelta(days=1),  # User2 started earlier
+            multiplier_at_creation=Decimal('2.0'),
+            frozen_global_points=2
+        )
+        
+        # Run the command
+        call_command('add_daily_uptime', verbosity=0)
+        
+        # Check both users have leaderboard entries
+        entry1 = LeaderboardEntry.objects.get(user=self.user1)
+        entry2 = LeaderboardEntry.objects.get(user=self.user2)
+        
+        # User1 should have at least 3 days of uptime (2 days ago + 1 day + today)
+        self.assertGreaterEqual(entry1.total_points, 6)
+        
+        # User2 should have more points since they started earlier
+        self.assertGreater(entry2.total_points, entry1.total_points)
+    
+    def test_no_duplicate_contributions(self):
+        """Test that running the command multiple times doesn't create duplicates."""
+        # Create initial uptime
+        yesterday = timezone.now() - timedelta(days=1)
+        Contribution.objects.create(
+            user=self.user1,
+            contribution_type=self.uptime_type,
+            points=1,
+            contribution_date=yesterday,
+            multiplier_at_creation=Decimal('2.0'),
+            frozen_global_points=2
+        )
+        
+        # Run the command twice
+        call_command('add_daily_uptime', verbosity=0)
+        first_count = Contribution.objects.filter(
+            user=self.user1,
+            contribution_type=self.uptime_type
+        ).count()
+        
+        call_command('add_daily_uptime', verbosity=0)
+        second_count = Contribution.objects.filter(
+            user=self.user1,
+            contribution_type=self.uptime_type
+        ).count()
+        
+        # Count should be the same
+        self.assertEqual(first_count, second_count)
+    
+    def test_dry_run_mode(self):
+        """Test that dry run mode doesn't create any contributions."""
+        # Create initial uptime
+        yesterday = timezone.now() - timedelta(days=1)
+        Contribution.objects.create(
+            user=self.user1,
+            contribution_type=self.uptime_type,
+            points=1,
+            contribution_date=yesterday,
+            multiplier_at_creation=Decimal('2.0'),
+            frozen_global_points=2
+        )
+        
+        initial_count = Contribution.objects.count()
+        
+        # Run in dry-run mode
+        out = StringIO()
+        call_command('add_daily_uptime', dry_run=True, stdout=out)
+        
+        # No new contributions should be created
+        self.assertEqual(Contribution.objects.count(), initial_count)
+        
+        # Check output mentions dry run
+        output = out.getvalue()
+        self.assertIn('DRY RUN', output)
+    
+    def test_users_without_uptime_are_skipped(self):
+        """Test that users without any uptime contributions are skipped."""
+        # Run the command (user_without_uptime has no contributions)
+        out = StringIO()
+        call_command('add_daily_uptime', stdout=out, verbosity=2)
+        
+        # Check that no contributions were created for user_without_uptime
+        contributions = Contribution.objects.filter(
+            user=self.user_without_uptime,
+            contribution_type=self.uptime_type
+        ).count()
+        
+        self.assertEqual(contributions, 0)
+        
+        # Check that no leaderboard entry was created
+        self.assertFalse(
+            LeaderboardEntry.objects.filter(user=self.user_without_uptime).exists()
+        )
+    
+    def test_force_mode_with_missing_multiplier(self):
+        """Test that force mode uses default multiplier when none exists."""
+        # Create initial uptime with existing multiplier first
+        yesterday = timezone.now() - timedelta(days=1)
+        Contribution.objects.create(
+            user=self.user1,
+            contribution_type=self.uptime_type,
+            points=1,
+            contribution_date=yesterday,
+            multiplier_at_creation=Decimal('2.0'),
+            frozen_global_points=2
+        )
+        
+        # Now delete the multiplier for future dates
+        GlobalLeaderboardMultiplier.objects.all().delete()
+        
+        # Run with force flag
+        out = StringIO()
+        call_command('add_daily_uptime', force=True, stdout=out, verbosity=2)
+        
+        # Check that contributions were created with default multiplier
+        new_contributions = Contribution.objects.filter(
+            user=self.user1,
+            contribution_type=self.uptime_type,
+            multiplier_at_creation=Decimal('1.0')
+        ).count()
+        
+        self.assertGreater(new_contributions, 0)
+        
+        output = out.getvalue()
+        self.assertIn('using default of 1.0', output)
+    
+    def test_custom_points_value(self):
+        """Test that custom points value is applied correctly."""
+        # Create initial uptime
+        yesterday = timezone.now() - timedelta(days=1)
+        Contribution.objects.create(
+            user=self.user1,
+            contribution_type=self.uptime_type,
+            points=1,
+            contribution_date=yesterday,
+            multiplier_at_creation=Decimal('2.0'),
+            frozen_global_points=2
+        )
+        
+        # Run with custom points value
+        call_command('add_daily_uptime', points=5, verbosity=0)
+        
+        # Check that new contributions have 5 points
+        today = timezone.now().date()
+        todays_contribution = Contribution.objects.filter(
+            user=self.user1,
+            contribution_type=self.uptime_type,
+            contribution_date__date=today
+        ).first()
+        
+        self.assertIsNotNone(todays_contribution)
+        self.assertEqual(todays_contribution.points, 5)
+        self.assertEqual(todays_contribution.frozen_global_points, 10)  # 5 * 2.0 multiplier

--- a/backend/leaderboard/tests.py
+++ b/backend/leaderboard/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/backend/leaderboard/tests/__init__.py
+++ b/backend/leaderboard/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for leaderboard app

--- a/backend/leaderboard/tests/test_models.py
+++ b/backend/leaderboard/tests/test_models.py
@@ -1,0 +1,297 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from decimal import Decimal
+from datetime import timedelta
+
+from leaderboard.models import (
+    LeaderboardEntry, 
+    GlobalLeaderboardMultiplier,
+    update_all_ranks,
+    update_user_leaderboard_entry
+)
+from contributions.models import Contribution, ContributionType
+
+User = get_user_model()
+
+
+class LeaderboardEntryTest(TestCase):
+    """Test the LeaderboardEntry model and its methods."""
+    
+    def setUp(self):
+        """Set up test data."""
+        # Create test users
+        self.user1 = User.objects.create_user(
+            email='user1@test.com',
+            password='testpass123',
+            name='User 1',
+            address='0x1111111111111111111111111111111111111111'
+        )
+        
+        self.user2 = User.objects.create_user(
+            email='user2@test.com',
+            password='testpass123',
+            name='User 2',
+            address='0x2222222222222222222222222222222222222222'
+        )
+        
+        # Create contribution types
+        self.uptime_type = ContributionType.objects.create(
+            name='Uptime',
+            description='Daily validator uptime',
+            min_points=1,
+            max_points=10
+        )
+        
+        self.blog_type = ContributionType.objects.create(
+            name='Blog Post',
+            description='Blog post contribution',
+            min_points=10,
+            max_points=100
+        )
+        
+        # Create multipliers
+        GlobalLeaderboardMultiplier.objects.create(
+            contribution_type=self.uptime_type,
+            multiplier_value=Decimal('2.0'),
+            valid_from=timezone.now() - timedelta(days=30)
+        )
+        
+        GlobalLeaderboardMultiplier.objects.create(
+            contribution_type=self.blog_type,
+            multiplier_value=Decimal('3.0'),
+            valid_from=timezone.now() - timedelta(days=30)
+        )
+    
+    def test_update_points_without_ranking(self):
+        """Test that update_points_without_ranking correctly updates points without changing ranks."""
+        # Create contributions for user1
+        Contribution.objects.create(
+            user=self.user1,
+            contribution_type=self.uptime_type,
+            points=1,
+            frozen_global_points=2,
+            multiplier_at_creation=Decimal('2.0'),
+            contribution_date=timezone.now()
+        )
+        
+        Contribution.objects.create(
+            user=self.user1,
+            contribution_type=self.blog_type,
+            points=10,
+            frozen_global_points=30,
+            multiplier_at_creation=Decimal('3.0'),
+            contribution_date=timezone.now()
+        )
+        
+        # Get leaderboard entry (it was created by the signal)
+        entry = LeaderboardEntry.objects.get(user=self.user1)
+        
+        # Record the initial rank (it should be 1 since it's the only user)
+        initial_rank = entry.rank
+        
+        # Update points without ranking
+        total_points = entry.update_points_without_ranking()
+        
+        # Check that points are correctly calculated (2 + 30 = 32)
+        self.assertEqual(total_points, 32)
+        self.assertEqual(entry.total_points, 32)
+        
+        # Rank should remain the same since we didn't update ranks
+        entry.refresh_from_db()
+        self.assertEqual(entry.rank, initial_rank)
+    
+    def test_update_points_without_ranking_multiple_users(self):
+        """Test batch updating multiple users' points without ranking."""
+        # Create contributions for both users
+        for i in range(3):
+            Contribution.objects.create(
+                user=self.user1,
+                contribution_type=self.uptime_type,
+                points=1,
+                frozen_global_points=2,
+                multiplier_at_creation=Decimal('2.0'),
+                contribution_date=timezone.now() - timedelta(days=i)
+            )
+            
+            Contribution.objects.create(
+                user=self.user2,
+                contribution_type=self.uptime_type,
+                points=1,
+                frozen_global_points=2,
+                multiplier_at_creation=Decimal('2.0'),
+                contribution_date=timezone.now() - timedelta(days=i)
+            )
+        
+        # Add extra contribution for user2
+        Contribution.objects.create(
+            user=self.user2,
+            contribution_type=self.blog_type,
+            points=20,
+            frozen_global_points=60,
+            multiplier_at_creation=Decimal('3.0'),
+            contribution_date=timezone.now()
+        )
+        
+        # Get the leaderboard entries (created by signals)
+        entry1 = LeaderboardEntry.objects.get(user=self.user1)
+        entry2 = LeaderboardEntry.objects.get(user=self.user2)
+        
+        # Record initial ranks
+        initial_rank1 = entry1.rank
+        initial_rank2 = entry2.rank
+        
+        # Update both users' points without ranking
+        points1 = entry1.update_points_without_ranking()
+        points2 = entry2.update_points_without_ranking()
+        
+        # Check points
+        self.assertEqual(points1, 6)  # 3 * 2
+        self.assertEqual(points2, 66)  # 3 * 2 + 60
+        
+        # Ranks should not have changed since we didn't call update_all_ranks
+        entry1.refresh_from_db()
+        entry2.refresh_from_db()
+        self.assertEqual(entry1.rank, initial_rank1)
+        self.assertEqual(entry2.rank, initial_rank2)
+        
+        # Now update ranks
+        update_all_ranks()
+        
+        # Refresh from database
+        entry1.refresh_from_db()
+        entry2.refresh_from_db()
+        
+        # Now check ranks are assigned correctly
+        self.assertEqual(entry1.rank, 2)  # Lower points = rank 2
+        self.assertEqual(entry2.rank, 1)  # Higher points = rank 1
+    
+    def test_update_points_with_no_contributions(self):
+        """Test update_points_without_ranking when user has no contributions."""
+        # Create leaderboard entry without contributions
+        entry = LeaderboardEntry.objects.create(user=self.user1)
+        
+        # Update points
+        total_points = entry.update_points_without_ranking()
+        
+        # Should be 0
+        self.assertEqual(total_points, 0)
+        self.assertEqual(entry.total_points, 0)
+    
+    def test_update_user_leaderboard_entry_triggers_ranking(self):
+        """Test that update_user_leaderboard_entry updates both points and ranks."""
+        # Create contributions
+        Contribution.objects.create(
+            user=self.user1,
+            contribution_type=self.uptime_type,
+            points=5,
+            frozen_global_points=10,
+            multiplier_at_creation=Decimal('2.0'),
+            contribution_date=timezone.now()
+        )
+        
+        Contribution.objects.create(
+            user=self.user2,
+            contribution_type=self.uptime_type,
+            points=10,
+            frozen_global_points=20,
+            multiplier_at_creation=Decimal('2.0'),
+            contribution_date=timezone.now()
+        )
+        
+        # Update user1's leaderboard (this should trigger ranking)
+        update_user_leaderboard_entry(self.user1)
+        
+        # Check that entry exists with correct points and rank
+        entry1 = LeaderboardEntry.objects.get(user=self.user1)
+        self.assertEqual(entry1.total_points, 10)
+        self.assertIsNotNone(entry1.rank)
+        
+        # Update user2's leaderboard
+        update_user_leaderboard_entry(self.user2)
+        
+        # Check rankings are correct
+        entry1.refresh_from_db()
+        entry2 = LeaderboardEntry.objects.get(user=self.user2)
+        
+        self.assertEqual(entry2.total_points, 20)
+        self.assertEqual(entry1.rank, 2)  # user1 has less points
+        self.assertEqual(entry2.rank, 1)  # user2 has more points
+    
+    def test_invisible_users_no_rank(self):
+        """Test that invisible users don't get ranked."""
+        # Create contributions for both first (while both are visible)
+        Contribution.objects.create(
+            user=self.user1,
+            contribution_type=self.uptime_type,
+            points=5,
+            frozen_global_points=10,
+            multiplier_at_creation=Decimal('2.0'),
+            contribution_date=timezone.now()
+        )
+        
+        Contribution.objects.create(
+            user=self.user2,
+            contribution_type=self.uptime_type,
+            points=10,
+            frozen_global_points=20,
+            multiplier_at_creation=Decimal('2.0'),
+            contribution_date=timezone.now()
+        )
+        
+        # Now make user2 invisible
+        self.user2.visible = False
+        self.user2.save()
+        
+        # Get the leaderboard entries (they were created by the signal)
+        entry1 = LeaderboardEntry.objects.get(user=self.user1)
+        entry2 = LeaderboardEntry.objects.get(user=self.user2)
+        
+        # Update ranks
+        update_all_ranks()
+        
+        # Refresh from database
+        entry1.refresh_from_db()
+        entry2.refresh_from_db()
+        
+        # User1 should have rank 1 (only visible user)
+        self.assertEqual(entry1.rank, 1)
+        
+        # User2 should have no rank (invisible)
+        self.assertIsNone(entry2.rank)
+    
+    def test_ranking_order_with_equal_points(self):
+        """Test that users with equal points are ranked by name."""
+        # Create a third user
+        user3 = User.objects.create_user(
+            email='user3@test.com',
+            password='testpass123',
+            name='AAA User',  # Alphabetically first
+            address='0x3333333333333333333333333333333333333333',
+            visible=True
+        )
+        
+        # Give all users the same points
+        for user in [self.user1, self.user2, user3]:
+            Contribution.objects.create(
+                user=user,
+                contribution_type=self.uptime_type,
+                points=5,
+                frozen_global_points=10,
+                multiplier_at_creation=Decimal('2.0'),
+                contribution_date=timezone.now()
+            )
+        
+        # Update ranks
+        update_all_ranks()
+        
+        # Get entries
+        entry1 = LeaderboardEntry.objects.get(user=self.user1)
+        entry2 = LeaderboardEntry.objects.get(user=self.user2)
+        entry3 = LeaderboardEntry.objects.get(user=user3)
+        
+        # All should have consecutive ranks based on name ordering
+        # AAA User should be rank 1, User 1 should be rank 2, User 2 should be rank 3
+        self.assertEqual(entry3.rank, 1)  # AAA User
+        self.assertEqual(entry1.rank, 2)  # User 1
+        self.assertEqual(entry2.rank, 3)  # User 2


### PR DESCRIPTION
## Summary
Fixes the issue where validators were only getting 1 point total regardless of how many days of uptime were added when running the `add_daily_uptime` management command.

## Problem
The `bulk_create()` method in Django doesn't trigger `post_save` signals, which meant that leaderboard entries were never being updated with the accumulated points from new uptime contributions.

## Solution
- Added `update_points_without_ranking()` instance method to `LeaderboardEntry` model for efficient batch updates
- Modified `add_daily_uptime` command to explicitly update each user's leaderboard entry after bulk creating contributions
- Optimized by updating ranks once at the end instead of after each user

## Changes
- ✅ Add instance method to LeaderboardEntry for updating points without triggering rank recalculation
- ✅ Fix add_daily_uptime command to properly update leaderboard entries
- ✅ Add comprehensive test coverage for uptime tracking
- ✅ Add tests for the new LeaderboardEntry methods

## Test plan
- [x] Run `python manage.py test contributions.tests.test_add_daily_uptime` - All tests pass
- [x] Run `python manage.py test leaderboard.tests.test_models` - All tests pass
- [x] Manually test the add_daily_uptime command to verify points accumulate correctly
- [x] Verify that leaderboard rankings update properly after running the command

Fixes #2