### PR TITLE
Add admin action to rebuild leaderboards and improve sidebar navigation

### DIFF
--- a/backend/leaderboard/admin.py
+++ b/backend/leaderboard/admin.py
@@ -1,5 +1,8 @@
 from django.contrib import admin
-from .models import LeaderboardEntry
+from django.contrib import messages
+from .models import LeaderboardEntry, GlobalLeaderboardMultiplier
+from contributions.models import Category, Contribution
+from users.models import User
 
 
 @admin.register(LeaderboardEntry)
@@ -9,7 +12,85 @@ class LeaderboardEntryAdmin(admin.ModelAdmin):
     search_fields = ('user__email', 'user__name')
     readonly_fields = ('total_points', 'rank', 'created_at', 'updated_at')
     ordering = ('rank', '-total_points')
+    actions = ['recreate_all_leaderboards']
     
     def has_add_permission(self, request):
         # Don't allow manual creation of leaderboard entries
         return False
+    
+    def recreate_all_leaderboards(self, request, queryset):
+        """
+        Admin action to recreate all leaderboard entries (global and category-specific).
+        This will:
+        1. Delete all existing leaderboard entries
+        2. Recreate entries based on current contributions
+        3. Update all ranks
+        """
+        try:
+            # Delete all existing leaderboard entries
+            deleted_count = LeaderboardEntry.objects.all().delete()[0]
+            
+            # Get all users who have contributions
+            users_with_contributions = User.objects.filter(
+                contributions__isnull=False
+            ).distinct()
+            
+            # Counter for created entries
+            created_count = 0
+            
+            # For each user, create their leaderboard entries
+            for user in users_with_contributions:
+                # Calculate and create global leaderboard entry
+                global_points = Contribution.objects.filter(
+                    user=user
+                ).values_list('frozen_global_points', flat=True)
+                global_total = sum(global_points)
+                
+                if global_total > 0:
+                    LeaderboardEntry.objects.create(
+                        user=user,
+                        category=None,  # Global
+                        total_points=global_total
+                    )
+                    created_count += 1
+                
+                # Create category-specific leaderboard entries
+                categories = Category.objects.all()
+                for category in categories:
+                    cat_contributions = Contribution.objects.filter(
+                        user=user,
+                        contribution_type__category=category
+                    )
+                    cat_points = sum(c.frozen_global_points for c in cat_contributions)
+                    
+                    if cat_points > 0:
+                        LeaderboardEntry.objects.create(
+                            user=user,
+                            category=category,
+                            total_points=cat_points
+                        )
+                        created_count += 1
+            
+            # Update all ranks (global and per-category)
+            # Update global leaderboard ranks
+            LeaderboardEntry.update_category_ranks(category=None)
+            
+            # Update each category's leaderboard ranks
+            for category in Category.objects.all():
+                LeaderboardEntry.update_category_ranks(category=category)
+            
+            # Show success message
+            self.message_user(
+                request,
+                f"Successfully recreated leaderboards. Deleted {deleted_count} old entries, created {created_count} new entries.",
+                messages.SUCCESS
+            )
+            
+        except Exception as e:
+            self.message_user(
+                request,
+                f"Error recreating leaderboards: {str(e)}",
+                messages.ERROR
+            )
+    
+    recreate_all_leaderboards.short_description = "Recreate all leaderboards (global and categories)"

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -49,7 +49,19 @@
   
   // Check if a route is active
   function isActive(path) {
-    return $location === path;
+    // Direct match
+    if ($location === path) return true;
+    
+    // Special case: contribution-type pages should highlight the contributions item
+    if (path.includes('/contributions') && $location.startsWith('/contribution-type/')) {
+      // Determine which contributions section based on current category
+      const category = $currentCategory;
+      if (category === 'builder' && path === '/builders/contributions') return true;
+      if (category === 'validator' && path === '/validators/contributions') return true;
+      if (category === 'global' && path === '/contributions') return true;
+    }
+    
+    return false;
   }
   
   // Function to change category and navigate


### PR DESCRIPTION
## Summary
- Added admin action to recreate all leaderboard entries from current contributions
- Improved sidebar navigation highlighting for contribution-type detail pages
- Fixed navigation state for better UX

## Changes

### Backend Admin Enhancement
- Added `recreate_all_leaderboards` admin action in `leaderboard/admin.py`
- Allows admins to rebuild all leaderboard entries (global and category-specific)
- Useful for fixing inconsistencies or after data corrections
- Provides clear feedback on entries deleted and created

### Frontend Navigation Fix
- Enhanced `isActive()` function in `Sidebar.svelte`
- Now properly highlights the Contributions menu item when viewing contribution-type detail pages
- Checks category context to highlight the correct section (builders/validators/global)

## Test Plan
- [ ] Admin can access the recreate leaderboards action in Django admin
- [ ] Running the action successfully rebuilds leaderboard entries
- [ ] Sidebar correctly highlights Contributions when on `/contribution-type/*` pages
- [ ] Navigation highlighting works correctly for all category contexts