### PR TITLE
feat: show validators sorted by newest first uptime in dashboards

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -98,6 +98,11 @@ export const statsAPI = {
   getUserStats: (address) => api.get(`/leaderboard/user_stats/by-address/${address}/`)
 };
 
+// Validators API
+export const validatorsAPI = {
+  getNewestValidators: (limit = 5) => api.get('/validators/newest/', { params: { limit } })
+};
+
 // Convenience exports for profile functions
 export const getCurrentUser = async () => {
   const response = await usersAPI.getCurrentUser();


### PR DESCRIPTION
## Summary
- Added backend endpoint `/api/v1/validators/newest/` to get validators sorted by their first uptime contribution date
- Updated Dashboard and GlobalDashboard components to use the new endpoint when displaying validators
- Validators who joined most recently now appear at the top of "Newest Validators" sections

## Implementation Details
- Backend endpoint uses the same efficient query pattern as ActiveValidatorsView metrics
- Returns validators sorted by newest first (most recent joiners at the top)
- Endpoint allows public access without authentication for read-only data
- Frontend simplified by removing manual extraction logic

## Test Plan
- [x] Test new backend endpoint returns validators sorted correctly
- [x] Verify Dashboard shows newest validators first in validator category
- [x] Verify GlobalDashboard shows newest validators first
- [ ] Test that builders and other categories still work as expected
- [ ] Verify no authentication is needed for viewing newest validators