### PR TITLE
Add admin shortcut to update/recreate leaderboard with category support

### DIFF
--- a/backend/templates/admin/index.html
+++ b/backend/templates/admin/index.html
@@ -30,6 +30,15 @@
                     <td></td>
                     <td></td>
                 </tr>
+                <tr>
+                    <th scope="row">
+                        <a href="{% url 'admin:update_leaderboard' %}">
+                            📊 {% trans 'Update/Recreate Leaderboard' %}
+                        </a>
+                    </th>
+                    <td></td>
+                    <td></td>
+                </tr>
             </tbody>
         </table>
     </div>

--- a/backend/templates/admin/leaderboard/update_leaderboard.html
+++ b/backend/templates/admin/leaderboard/update_leaderboard.html
@@ -1,0 +1,40 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+    &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+    &rsaquo; <a href="{% url 'admin:leaderboard_leaderboardentry_changelist' %}">Leaderboard Entries</a>
+    &rsaquo; {% trans 'Update Leaderboard' %}
+</div>
+{% endblock %}
+
+{% block content %}
+<h1>Update Leaderboard</h1>
+
+<div class="module">
+    <div style="padding: 20px;">
+        <p><strong>This action will:</strong></p>
+        <ul style="margin-left: 20px;">
+            <li>Recalculate all contribution multipliers based on their creation dates</li>
+            <li>Update frozen global points for all contributions</li>
+            <li>Delete and recreate all leaderboard entries</li>
+            <li>Update rankings for both global and category-specific leaderboards</li>
+        </ul>
+        
+        <p style="margin-top: 20px;">
+            <strong>Note:</strong> This process may take a few moments depending on the number of contributions in the system.
+        </p>
+        
+        <form method="post" style="margin-top: 20px;">
+            {% csrf_token %}
+            <div class="submit-row">
+                <input type="submit" value="Update Leaderboard" class="default" />
+                <a href="{% url 'admin:leaderboard_leaderboardentry_changelist' %}" class="button cancel-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- Added admin shortcut to easily update/recreate the leaderboard from the admin dashboard
- Fixed the update_leaderboard management command to properly create category-specific leaderboard entries
- Now correctly creates separate leaderboard entries for Validator, Builder, and Steward categories

## Changes
1. **Admin Interface**:
   - Added "📊 Update/Recreate Leaderboard" quick action in admin dashboard
   - Created custom admin view with confirmation page
   - Triggers the update_leaderboard management command

2. **Leaderboard Update Command**:
   - Fixed to create both global and category-specific leaderboard entries
   - Now iterates through all categories (Validator, Builder, Steward)
   - Updates ranks for each category separately
   - Previously was only creating global entries, missing category-specific ones

## Results
- Successfully creates 31 Validator leaderboard entries (was 0 before)
- Properly calculates and assigns category-specific points
- Updates rankings for both global and per-category leaderboards

## Test Plan
- [x] Admin shortcut appears in Quick Actions
- [x] Clicking the shortcut shows confirmation page
- [x] Running the update creates category-specific entries
- [x] Validator leaderboard entries are created (31 entries)
- [x] Rankings are properly calculated per category