### PR TITLE
Add user reassignment for company submissions

### DIFF
--- a/backend/contributions/serializers.py
+++ b/backend/contributions/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from .models import ContributionType, Contribution, SubmittedContribution, Evidence, ContributionHighlight
 from users.serializers import UserSerializer
+from users.models import User
 import decimal
 
 
@@ -149,6 +150,13 @@ class ContributionHighlightSerializer(serializers.ModelSerializer):
 class StewardSubmissionReviewSerializer(serializers.Serializer):
     """Serializer for steward review actions on submissions."""
     action = serializers.ChoiceField(choices=['accept', 'reject', 'more_info'])
+    
+    # User field to assign the contribution to a different user than the submitter
+    user = serializers.PrimaryKeyRelatedField(
+        queryset=User.objects.all(),
+        required=False,
+        help_text="User to assign the contribution to (defaults to original submitter)"
+    )
     
     # Fields for acceptance
     contribution_type = serializers.PrimaryKeyRelatedField(

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -122,6 +122,9 @@ export const stewardAPI = {
   // Review a submission (accept, reject, or request more info)
   reviewSubmission: (id, data) => api.post(`/steward-submissions/${id}/review/`, data),
   
+  // Get all users for reassignment dropdown
+  getUsers: () => api.get('/steward-submissions/users/'),
+  
   // Get steward statistics
   getStats: () => api.get('/steward-submissions/stats/')
 };


### PR DESCRIPTION
## Summary
- Stewards can now reassign contributions to different users when accepting submissions
- Adds a dropdown to select any user in the system (sorted alphabetically by name)
- The contribution is created for the selected user while the submission record remains with the original submitter

## Changes
- Added optional `user` field to the steward review serializer
- Backend creates contributions for the selected user (or defaults to original submitter)
- Added `/steward-submissions/users/` endpoint to fetch all users for the dropdown
- Frontend shows user selection dropdown when accepting submissions
- Fixed contribution preview to show the correct assigned user (not the submitter)

## Use Case
This is particularly useful for company submissions where multiple team members' work needs to be properly attributed. A company steward can submit on behalf of the team and then assign the contribution points to the appropriate team member.

## Testing
1. Navigate to steward submissions page
2. When accepting a submission, select a different user from the dropdown
3. Accept the submission
4. Verify the contribution is created for the selected user
5. Verify the preview shows the correct user