### PR TITLE
Fix case-sensitive address lookup in users API endpoint

### DIFF
--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -22,10 +22,12 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
     
     def get_object(self):
         """
-        Override to allow users to access their own profile
-        even if they're marked as not visible.
+        Override to use case-insensitive address lookup and allow users to access 
+        their own profile even if they're marked as not visible.
         """
-        obj = super().get_object()
+        lookup_value = self.kwargs[self.lookup_field]  # Gets address from URL
+        obj = get_object_or_404(User, address__iexact=lookup_value)  # Case-insensitive
+        
         # If the user is accessing their own profile, allow it
         if self.request.user.is_authenticated and obj.id == self.request.user.id:
             return obj


### PR DESCRIPTION
## Summary
- Fixed case-sensitive Ethereum address lookup in the main users API endpoint
- Ensures consistent behavior between `/api/v1/users/{address}/` and `/api/v1/users/by-address/{address}/` endpoints

## Changes
- Modified `UserViewSet.get_object()` to use case-insensitive address lookup with `address__iexact`
- Replaced DRF's default exact matching with explicit case-insensitive query
- Maintained all existing functionality including visibility override for authenticated users

## Bug Fixed
Previously, these requests had inconsistent behavior:
- `/api/v1/users/0xcfd7704137ab7688a74a0fb40ac7331914131165/` ✅ (exact case match)
- `/api/v1/users/0xcFd7704137AB7688A74A0FB40ac7331914131165/` ❌ (case mismatch)
- `/api/v1/users/by-address/0xcFd7704137AB7688A74A0FB40ac7331914131165/` ✅ (already case-insensitive)

Now all three work consistently, as Ethereum addresses should be treated case-insensitively.

## Test Plan
- [x] Verify both lowercase and mixed-case addresses return same user data
- [x] Confirm visibility override still works for authenticated users
- [x] Validate 404 behavior for non-existent addresses remains unchanged
- [x] Check that all existing functionality is preserved