### PR TITLE
fix: enable HTTPS detection for Swagger in production/staging

### DIFF
--- a/backend/tally/settings.py
+++ b/backend/tally/settings.py
@@ -275,3 +275,11 @@ VALIDATOR_RPC_URL = get_required_env('VALIDATOR_RPC_URL')
 # AWS Health Check IPs - Allow these IPs to bypass ALLOWED_HOSTS
 # Required environment variable with AWS internal/metadata service IPs
 ALLOWED_CIDR_NETS = get_required_env('ALLOWED_CIDR_NETS').split(',')
+
+# HTTPS/SSL Settings for production
+# These settings help Django detect HTTPS when behind a proxy/load balancer
+# Always trust the X-Forwarded-Proto header when it's present (for both staging and production)
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+# Use forwarded headers for generating URLs
+USE_X_FORWARDED_HOST = True
+USE_X_FORWARDED_PORT = True

--- a/frontend/src/routes/Profile.svelte
+++ b/frontend/src/routes/Profile.svelte
@@ -495,9 +495,9 @@
                   {#if loadingBalance}
                     Loading...
                   {:else if balance}
-                    {balance.formatted} ETH
+                    {balance.formatted} GEN
                   {:else}
-                    0 ETH
+                    0 GEN
                   {/if}
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- Configure Django to properly detect HTTPS when running behind a proxy/load balancer
- Trust X-Forwarded-Proto headers to determine the correct protocol
- Fixes Swagger UI showing HTTP URLs when the application is served over HTTPS

## Changes
- Added `SECURE_PROXY_SSL_HEADER` setting to trust X-Forwarded-Proto header
- Enabled `USE_X_FORWARDED_HOST` and `USE_X_FORWARDED_PORT` for proper URL generation
- Settings apply regardless of DEBUG value (works in both staging and production)

## Test plan
- [ ] Deploy to staging environment
- [ ] Access Swagger UI at /swagger/
- [ ] Verify that API request URLs show HTTPS protocol
- [ ] Test API calls from Swagger UI work correctly