### PR TITLE
Fix: Add active state highlight to Profile button in sidebar

### DIFF
--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -256,7 +256,11 @@
         <div class="border-t border-gray-200 mb-3"></div>
         <button
           onclick={handleProfileClick}
-          class="w-full flex items-center px-3 py-2 mb-1 rounded-md transition-colors hover:bg-gray-50"
+          class="w-full flex items-center px-3 py-2 mb-1 rounded-md transition-colors {
+            getActiveSection() === 'profile'
+              ? `${$categoryTheme.buttonLight} ${$categoryTheme.text}`
+              : 'hover:bg-gray-50'
+          }"
         >
           <Icon 
             name="profile"
@@ -431,7 +435,11 @@
           <div class="border-t border-gray-200 mb-3"></div>
           <button
             onclick={handleProfileClick}
-            class="w-full flex items-center px-3 py-2 mb-1 rounded-md transition-colors hover:bg-gray-50"
+            class="w-full flex items-center px-3 py-2 mb-1 rounded-md transition-colors {
+              getActiveSection() === 'profile'
+                ? `${$categoryTheme.buttonLight} ${$categoryTheme.text}`
+                : 'hover:bg-gray-50'
+            }"
           >
             <Icon 
               name="profile"


### PR DESCRIPTION
## Summary
- Added active background highlighting to the Profile button in the sidebar navigation
- Profile button now shows the correct active state when users are on profile-related pages

## Changes
- Updated the Profile button's class binding to check if the active section is 'profile'
- Applied the same category theme highlighting used by other navigation sections
- Fixed both desktop and mobile sidebar versions

## Test Plan
- [x] Navigate to `/participant/:address` - Profile button should be highlighted
- [x] Navigate to `/my-submissions` - Profile button should be highlighted  
- [x] Navigate to other sections - Profile button should not be highlighted
- [x] Test on both desktop and mobile views