### PR TITLE
Standardize ContributionCard component with avatars and evidence indicators

### DIFF
--- a/frontend/src/components/ContributionsList.svelte
+++ b/frontend/src/components/ContributionsList.svelte
@@ -146,7 +146,8 @@
         if (contrib.user_details) {
           currentGroup.users = [{
             address: contrib.user_details.address,
-            name: contrib.user_details.name
+            name: contrib.user_details.name,
+            profile_image_url: contrib.user_details.profile_image_url
           }];
         }
         
@@ -166,7 +167,8 @@
           if (!userExists) {
             currentGroup.users.push({
               address: contrib.user_details.address,
-              name: contrib.user_details.name
+              name: contrib.user_details.name,
+              profile_image_url: contrib.user_details.profile_image_url
             });
           }
         }

--- a/frontend/src/components/FeaturedContributions.svelte
+++ b/frontend/src/components/FeaturedContributions.svelte
@@ -5,6 +5,7 @@
   import { contributionsAPI, usersAPI } from '../lib/api';
   import { currentCategory } from '../stores/category.js';
   import Avatar from './Avatar.svelte';
+  import ContributionCard from './ContributionCard.svelte';
 
   let {
     title = 'Featured Contributions',
@@ -160,46 +161,43 @@
       </div>
     {/if}
   {:else if cardStyle === 'default'}
-    <!-- Default card style (used in Dashboard) -->
+    <!-- Default card style (used in Dashboard) - Use ContributionCard -->
     <div class="space-y-3">
       {#each highlights as highlight}
-        <div class="bg-white shadow rounded-lg p-4 hover:shadow-lg transition-shadow">
-          <div class="flex items-start justify-between">
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2 mb-2">
-                <svg class="w-4 h-4 text-yellow-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
-                </svg>
-                <h3 class="text-base font-semibold text-gray-900 truncate">{highlight.title}</h3>
-              </div>
-              <p class="text-sm text-gray-600 mb-2 line-clamp-2">{highlight.description}</p>
-              <div class="flex items-center gap-3 text-xs">
-                <Avatar 
-                  user={{
-                    name: highlight.user_name,
-                    address: highlight.user_address,
-                    profile_image_url: highlight.user_profile_image_url
-                  }}
-                  size="xs"
-                  clickable={true}
-                />
-                <button 
-                  class="text-primary-600 hover:text-primary-700 font-medium"
-                  onclick={() => push(`/participant/${highlight.user_address}`)}
-                >
-                  {highlight.user_name || `${highlight.user_address.slice(0, 6)}...${highlight.user_address.slice(-4)}`}
-                </button>
-                <span class="text-gray-400">•</span>
-                <span class="text-gray-500">{formatDate(highlight.contribution_date)}</span>
-              </div>
-            </div>
-            <div class="ml-3 flex-shrink-0">
-              <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
-                {highlight.contribution_points} pts
-              </span>
-            </div>
-          </div>
-        </div>
+        <ContributionCard 
+          contribution={{
+            id: highlight.id,
+            contribution_type: highlight.contribution_type,
+            contribution_type_name: highlight.contribution_type_name,
+            contribution_type_details: {
+              id: highlight.contribution_type,
+              name: highlight.contribution_type_name,
+              category: highlight.category || category || $currentCategory
+            },
+            contribution_date: highlight.contribution_date,
+            points: highlight.contribution_points,
+            frozen_points: highlight.contribution_points,
+            user_details: {
+              name: highlight.user_name,
+              address: highlight.user_address,
+              profile_image_url: highlight.user_profile_image_url
+            },
+            users: [{
+              name: highlight.user_name,
+              address: highlight.user_address,
+              profile_image_url: highlight.user_profile_image_url
+            }],
+            highlight: {
+              title: highlight.title,
+              description: highlight.description
+            },
+            count: 1,
+            category: highlight.category || category || $currentCategory
+          }}
+          showUser={true}
+          showExpand={false}
+          category={category || $currentCategory}
+        />
       {/each}
     </div>
   {:else if cardStyle === 'compact'}


### PR DESCRIPTION
## Summary
- Standardized the ContributionCard component to display consistently across the application
- Added avatar support and evidence indicators to improve visual consistency
- Fixed issue #85: Use same ContributionCard component everywhere

## Changes Made

### ContributionCard Enhancements
- **Always show avatars** - Displays user avatars (size `xs`) for all contributions
- **Added paperclip icon** - Visual indicator when evidence items exist, with tooltip showing count
- **Category override prop** - Allows specifying category for mixed-type lists (e.g., Profile page)
- **Compact variant** - Reduced padding option for dense lists
- **Grouped contributions support** - Shows up to 3 overlapping avatars for multiple users

### FeaturedContributions Updates
- Updated default card style to use ContributionCard component
- Maintained separate component for highlight-only displays
- Preserved compact and highlight styles for specific use cases

### Bug Fixes
- Fixed missing `profile_image_url` in ContributionsList when creating user arrays
- Ensured avatars display correctly in Recent Contributions and other lists

## Visual Changes
- Avatars now appear consistently across all contribution displays
- Evidence indicator (paperclip icon) shows when contributions have supporting evidence
- Grouped contributions show overlapping avatars with "+N more" for additional users
- Maintains category-based color theming (validator: sky, builder: orange)

## Test Plan
- [x] Build completes successfully
- [ ] Avatars display in Recent Contributions
- [ ] Evidence indicators show correctly
- [ ] Grouped contributions display multiple avatars
- [ ] Featured contributions use ContributionCard
- [ ] Submission reviews show ContributionCard after acceptance