### PR TITLE
Fix validators/participants page data loading and performance issues

### DIFF
--- a/frontend/src/components/AuthButton.svelte
+++ b/frontend/src/components/AuthButton.svelte
@@ -2,7 +2,7 @@
 <script>
   import { onMount } from 'svelte';
   import { push } from 'svelte-spa-router';
-  import { authState, signInWithEthereum, logout, verifyAuth } from '../lib/auth';
+  import { authState, signInWithEthereum, logout } from '../lib/auth';
   import { userStore } from '../lib/userStore';
   
   // Use $: to access the store values reactively
@@ -26,12 +26,9 @@
     }, 5000);
   }
   
-  onMount(async () => {
-    try {
-      await verifyAuth();
-    } catch (err) {
-      console.error('Auth verification error:', err);
-    }
+  onMount(() => {
+    // Auth verification is already done in auth.js on module load
+    // No need to verify again here
     
     return () => {
       if (errorTimeout) clearTimeout(errorTimeout);

--- a/frontend/src/lib/auth.js
+++ b/frontend/src/lib/auth.js
@@ -10,7 +10,8 @@ const createAuthStore = () => {
     isAuthenticated: false,
     address: null,
     loading: false,
-    error: null
+    error: null,
+    hasVerified: false  // Track if we've verified in this session
   };
   
   // Try to load from localStorage
@@ -20,6 +21,7 @@ const createAuthStore = () => {
       const { isAuthenticated, address } = JSON.parse(savedAuth);
       initialState.isAuthenticated = isAuthenticated;
       initialState.address = address;
+      // If we have saved auth, we still need to verify once per session
     }
   } catch (e) {
     console.error('Error loading auth state from localStorage:', e);
@@ -39,12 +41,15 @@ const createAuthStore = () => {
       return currentState;
     },
     setAuthenticated: (isAuthenticated, address = null) => {
-      update(state => ({ ...state, isAuthenticated, address }));
+      update(state => ({ ...state, isAuthenticated, address, hasVerified: true }));
       if (isAuthenticated && address) {
         localStorage.setItem('tally-auth', JSON.stringify({ isAuthenticated, address }));
       } else {
         localStorage.removeItem('tally-auth');
       }
+    },
+    resetVerification: () => {
+      update(state => ({ ...state, hasVerified: false }));
     },
     setLoading: (loading) => update(state => ({ ...state, loading })),
     setError: (error) => {
@@ -240,11 +245,38 @@ export async function signInWithEthereum() {
   }
 }
 
+// Track verification promise to prevent duplicate calls
+let verificationInProgress = null;
+
 /**
- * Verify authentication status
+ * Verify authentication status - only once per session
  * @returns {Promise<boolean>} Authentication status
  */
 export async function verifyAuth() {
+  const state = authState.get();
+  
+  // If we've already verified in this session, return the current state
+  if (state.hasVerified) {
+    return Promise.resolve(state.isAuthenticated);
+  }
+  
+  // If verification is already in progress, return the existing promise
+  if (verificationInProgress) {
+    return verificationInProgress;
+  }
+  
+  // Start new verification
+  verificationInProgress = performVerification();
+  
+  try {
+    const result = await verificationInProgress;
+    return result;
+  } finally {
+    verificationInProgress = null;
+  }
+}
+
+async function performVerification() {
   try {
     console.log('Verifying auth at:', API_ENDPOINTS.VERIFY);
     const response = await authAxios.get(API_ENDPOINTS.VERIFY);
@@ -284,6 +316,8 @@ export async function logout() {
   } finally {
     // Clear auth state using our store method
     authState.setAuthenticated(false, null);
+    // Reset verification flag so next session will verify
+    authState.resetVerification();
     // Clear user data from store
     userStore.clearUser();
   }

--- a/frontend/src/lib/validators.js
+++ b/frontend/src/lib/validators.js
@@ -1,6 +1,6 @@
 // Shared utility for fetching and processing validator data
 import { validatorsAPI, usersAPI, leaderboardAPI } from './api';
-import { getBannedValidators } from './blockchain';
+import { getBannedValidators, getActiveValidators } from './blockchain';
 
 /**
  * Fetches all validator data including active, banned, and user information
@@ -76,11 +76,9 @@ export async function fetchValidatorsData(category = 'validator', onRpcDataReady
   // Fetch RPC data in the background
   if (onRpcDataReady) {
     Promise.all([
-      validatorsAPI.getActiveValidators(),
+      getActiveValidators(),  // Call directly from frontend blockchain.js
       getBannedValidators()
-    ]).then(([activeRes, bannedValidators]) => {
-      const activeValidators = activeRes.data || [];
-      
+    ]).then(([activeValidators, bannedValidators]) => {
       // Filter out invalid addresses from RPC data (banned validators)
       const isValidAddress = (addr) => {
         return addr && 

--- a/frontend/src/lib/validators.js
+++ b/frontend/src/lib/validators.js
@@ -4,48 +4,26 @@ import { getBannedValidators } from './blockchain';
 
 /**
  * Fetches all validator data including active, banned, and user information
+ * Shows data immediately from API, then enhances with RPC data
  * @param {string} category - Optional category filter for leaderboard data
+ * @param {function} onRpcDataReady - Callback when RPC data is ready
  * @returns {Object} Object containing validators array and stats
  */
-export async function fetchValidatorsData(category = 'validator') {
-  // Fetch active validators from backend and banned validators from blockchain in parallel
-  const [activeRes, bannedValidators, usersRes] = await Promise.all([
-    validatorsAPI.getActiveValidators(),
-    getBannedValidators(),
-    usersAPI.getUsers()
-  ]);
-  
-  const activeValidators = activeRes.data || [];
+export async function fetchValidatorsData(category = 'validator', onRpcDataReady = null) {
+  // First, fetch all users without pagination (set high page_size)
+  const usersRes = await usersAPI.getUsers({ page_size: 1000 });
   const allUsers = usersRes.data.results || [];
   
-  // Filter out invalid addresses from RPC data (banned validators)
-  const isValidAddress = (addr) => {
-    return addr && 
-           addr.toLowerCase() !== '0x0000000000000000000000000000000000000000' &&
-           addr.toLowerCase() !== '0x000' &&
-           addr !== '0x0';
-  };
-  
-  // Backend API already filters active validators, only filter RPC banned validators
-  const filteredBannedValidators = bannedValidators.filter(isValidAddress);
-  
   // Get leaderboard data for category
-  const leaderboardParams = category !== 'global' ? { category } : {};
+  const leaderboardParams = category !== 'global' ? { category, page_size: 1000 } : { page_size: 1000 };
   const leaderboardRes = await leaderboardAPI.getLeaderboard(leaderboardParams);
-  const leaderboardEntries = leaderboardRes.data || [];
+  const leaderboardEntries = leaderboardRes.data.results || leaderboardRes.data || [];
   
-  // Create a map for quick lookups (ensure all addresses are lowercase for comparison)
-  const activeValidatorsSet = new Set(activeValidators.map(addr => addr.toLowerCase()));
-  const bannedValidatorsSet = new Set(filteredBannedValidators.map(addr => addr.toLowerCase()));
-  
-  // Process all users who have validator profiles
+  // Process initial data with users who have validator profiles
   const validatorsWithStatus = allUsers
     .filter(user => user.validator && user.address) // Only users with validator profiles
     .map(user => {
       const addressLower = user.address.toLowerCase();
-      const isActive = activeValidatorsSet.has(addressLower);
-      const isBanned = bannedValidatorsSet.has(addressLower);
-      const isWhitelisted = isActive || isBanned; // Either active or banned means they're on the whitelist
       
       // Find leaderboard entry
       const leaderboardEntry = leaderboardEntries.find(entry => {
@@ -55,67 +33,22 @@ export async function fetchValidatorsData(category = 'validator') {
       
       return {
         address: user.address,
-        isActive,
-        isBanned,
-        isWhitelisted,
+        isActive: false, // Will be updated when RPC data arrives
+        isBanned: false, // Will be updated when RPC data arrives
+        isWhitelisted: false, // Will be updated when RPC data arrives
         user: user,
         score: leaderboardEntry?.total_points || null,
         rank: leaderboardEntry?.rank || null,
         nodeVersion: user.validator?.node_version || null,
         matchesTarget: user.validator?.matches_target || false,
-        targetVersion: user.validator?.target_version || null
+        targetVersion: user.validator?.target_version || null,
+        pendingRpcData: true // Flag to show data is being loaded
       };
     });
   
-  // Also include validators from blockchain that don't have user profiles yet
-  const allValidatorAddresses = [...new Set([...activeValidators, ...filteredBannedValidators])];
-  const usersWithProfiles = new Set(allUsers.map(u => u.address?.toLowerCase()).filter(Boolean));
-  
-  const validatorsWithoutProfiles = allValidatorAddresses
-    .filter(address => !usersWithProfiles.has(address.toLowerCase()))
-    .map(address => {
-      const addressLower = address.toLowerCase();
-      const isActive = activeValidatorsSet.has(addressLower);
-      const isBanned = bannedValidatorsSet.has(addressLower);
-      
-      // Find leaderboard entry
-      const leaderboardEntry = leaderboardEntries.find(entry => {
-        const userAddress = entry.user_details?.address || entry.user?.address;
-        return userAddress && userAddress.toLowerCase() === addressLower;
-      });
-      
-      return {
-        address,
-        isActive,
-        isBanned,
-        isWhitelisted: true, // They're on blockchain so they're whitelisted
-        user: null,
-        score: leaderboardEntry?.total_points || null,
-        rank: leaderboardEntry?.rank || null,
-        nodeVersion: null,
-        matchesTarget: false,
-        targetVersion: null
-      };
-    });
-  
-  // Combine and sort
-  const allValidators = [...validatorsWithStatus, ...validatorsWithoutProfiles].sort((a, b) => {
-    // Whitelisted validators first
-    if (a.isWhitelisted !== b.isWhitelisted) {
-      return a.isWhitelisted ? -1 : 1;
-    }
-    
-    // Active validators first
-    if (a.isActive !== b.isActive) {
-      return a.isActive ? -1 : 1;
-    }
-    
-    // Then banned
-    if (a.isBanned !== b.isBanned) {
-      return a.isBanned ? -1 : 1;
-    }
-    
-    // Then by rank if available
+  // Sort initial data by rank/score
+  const initialValidators = validatorsWithStatus.sort((a, b) => {
+    // By rank if available
     if (a.rank && b.rank) {
       return a.rank - b.rank;
     }
@@ -131,20 +64,158 @@ export async function fetchValidatorsData(category = 'validator') {
     return (a.address || '').localeCompare(b.address || '');
   });
   
-  // Calculate stats
-  const stats = {
-    totalValidators: activeValidators.length,
-    totalBanned: filteredBannedValidators.length,
+  // Calculate initial stats
+  const initialStats = {
+    totalValidators: 0, // Will be updated when RPC data arrives
+    totalBanned: 0, // Will be updated when RPC data arrives
     totalWithProfiles: validatorsWithStatus.length,
-    totalWhitelisted: allValidators.filter(v => v.isWhitelisted).length,
-    totalNotWhitelisted: allValidators.filter(v => !v.isWhitelisted).length
+    totalWhitelisted: 0, // Will be updated when RPC data arrives
+    totalNotWhitelisted: validatorsWithStatus.length // Initially all are not whitelisted
   };
   
+  // Fetch RPC data in the background
+  if (onRpcDataReady) {
+    Promise.all([
+      validatorsAPI.getActiveValidators(),
+      getBannedValidators()
+    ]).then(([activeRes, bannedValidators]) => {
+      const activeValidators = activeRes.data || [];
+      
+      // Filter out invalid addresses from RPC data (banned validators)
+      const isValidAddress = (addr) => {
+        return addr && 
+               addr.toLowerCase() !== '0x0000000000000000000000000000000000000000' &&
+               addr.toLowerCase() !== '0x000' &&
+               addr.toLowerCase() !== '0x0';
+      };
+      
+      const filteredBannedValidators = bannedValidators.filter(isValidAddress);
+      
+      // Create sets for quick lookups
+      const activeValidatorsSet = new Set(activeValidators.map(addr => addr.toLowerCase()));
+      const bannedValidatorsSet = new Set(filteredBannedValidators.map(addr => addr.toLowerCase()));
+      
+      // Update existing validators with RPC data
+      const updatedValidators = initialValidators.map(validator => {
+        const addressLower = validator.address.toLowerCase();
+        const isActive = activeValidatorsSet.has(addressLower);
+        const isBanned = bannedValidatorsSet.has(addressLower);
+        const isWhitelisted = isActive || isBanned;
+        
+        return {
+          ...validator,
+          isActive,
+          isBanned,
+          isWhitelisted,
+          pendingRpcData: false
+        };
+      });
+      
+      // Find validators from blockchain that don't have user profiles yet
+      const allValidatorAddresses = [...new Set([...activeValidators, ...filteredBannedValidators])];
+      const usersWithProfiles = new Set(allUsers.map(u => u.address?.toLowerCase()).filter(Boolean));
+      
+      const validatorsWithoutProfiles = allValidatorAddresses
+        .filter(address => !usersWithProfiles.has(address.toLowerCase()))
+        .map(address => {
+          const addressLower = address.toLowerCase();
+          const isActive = activeValidatorsSet.has(addressLower);
+          const isBanned = bannedValidatorsSet.has(addressLower);
+          
+          // Find leaderboard entry
+          const leaderboardEntry = leaderboardEntries.find(entry => {
+            const userAddress = entry.user_details?.address || entry.user?.address;
+            return userAddress && userAddress.toLowerCase() === addressLower;
+          });
+          
+          return {
+            address,
+            isActive,
+            isBanned,
+            isWhitelisted: true,
+            user: null,
+            score: leaderboardEntry?.total_points || null,
+            rank: leaderboardEntry?.rank || null,
+            nodeVersion: null,
+            matchesTarget: false,
+            targetVersion: null,
+            pendingRpcData: false
+          };
+        });
+      
+      // Combine and sort all validators
+      const allValidators = [...updatedValidators, ...validatorsWithoutProfiles].sort((a, b) => {
+        // Whitelisted validators first
+        if (a.isWhitelisted !== b.isWhitelisted) {
+          return a.isWhitelisted ? -1 : 1;
+        }
+        
+        // Active validators first
+        if (a.isActive !== b.isActive) {
+          return a.isActive ? -1 : 1;
+        }
+        
+        // Then banned
+        if (a.isBanned !== b.isBanned) {
+          return a.isBanned ? -1 : 1;
+        }
+        
+        // Then by rank if available
+        if (a.rank && b.rank) {
+          return a.rank - b.rank;
+        }
+        if (a.rank) return -1;
+        if (b.rank) return 1;
+        
+        // Then by score
+        if (a.score !== b.score) {
+          return (b.score || 0) - (a.score || 0);
+        }
+        
+        // Finally by address
+        return (a.address || '').localeCompare(b.address || '');
+      });
+      
+      // Calculate updated stats
+      const stats = {
+        totalValidators: activeValidators.length,
+        totalBanned: filteredBannedValidators.length,
+        totalWithProfiles: updatedValidators.filter(v => v.user).length,
+        totalWhitelisted: allValidators.filter(v => v.isWhitelisted).length,
+        totalNotWhitelisted: allValidators.filter(v => !v.isWhitelisted).length
+      };
+      
+      // Call the callback with enhanced data
+      onRpcDataReady({
+        validators: allValidators,
+        stats,
+        activeValidators,
+        bannedValidators: filteredBannedValidators
+      });
+    }).catch(error => {
+      console.error('Error fetching RPC data:', error);
+      // Even on error, remove the pending flag
+      const updatedValidators = initialValidators.map(v => ({
+        ...v,
+        pendingRpcData: false
+      }));
+      
+      if (onRpcDataReady) {
+        onRpcDataReady({
+          validators: updatedValidators,
+          stats: initialStats,
+          activeValidators: [],
+          bannedValidators: []
+        });
+      }
+    });
+  }
+  
   return {
-    validators: allValidators,
-    stats,
-    activeValidators,
-    bannedValidators: filteredBannedValidators
+    validators: initialValidators,
+    stats: initialStats,
+    activeValidators: [],
+    bannedValidators: []
   };
 }
 
@@ -152,6 +223,15 @@ export async function fetchValidatorsData(category = 'validator') {
  * Get status display properties for a validator
  */
 export function getValidatorStatus(validator) {
+  // If RPC data is still pending, show loading state
+  if (validator.pendingRpcData) {
+    return {
+      text: 'Loading...',
+      class: 'bg-gray-100 text-gray-500',
+      color: 'gray'
+    };
+  }
+  
   if (!validator.isWhitelisted) {
     return {
       text: 'Not in Whitelist',

--- a/frontend/src/routes/Validators.svelte
+++ b/frontend/src/routes/Validators.svelte
@@ -27,15 +27,33 @@
       loading = true;
       error = null;
       
-      // Use the shared validators utility
-      const result = await fetchValidatorsData($currentCategory);
+      // Define callback for when RPC data is ready
+      const handleRpcDataReady = (enhancedData) => {
+        // Update validators with enhanced RPC data
+        if ($currentCategory === 'validator') {
+          validators = enhancedData.validators;
+        } else {
+          validators = enhancedData.validators.filter(v => {
+            if (!v.user) return false;
+            if ($currentCategory === 'builder') {
+              return v.user.builder !== null;
+            }
+            if ($currentCategory === 'steward') {
+              return v.user.steward !== null;
+            }
+            return false;
+          });
+        }
+        stats = enhancedData.stats;
+      };
       
-      // Filter based on category
+      // Use the shared validators utility with callback
+      const result = await fetchValidatorsData($currentCategory, handleRpcDataReady);
+      
+      // Show initial data immediately
       if ($currentCategory === 'validator') {
-        // Show all validators (whitelisted and non-whitelisted)
         validators = result.validators;
       } else {
-        // For other categories, filter by category type
         validators = result.validators.filter(v => {
           if (!v.user) return false;
           if ($currentCategory === 'builder') {

--- a/frontend/src/routes/Validators.svelte
+++ b/frontend/src/routes/Validators.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { onMount } from 'svelte';
   import { push } from 'svelte-spa-router';
   import { fetchValidatorsData, getValidatorStatus } from '../lib/validators';
   import { currentCategory, categoryTheme } from '../stores/category.js';
@@ -11,13 +10,12 @@
   let error = $state(null);
   let stats = $state({});
   
-  onMount(async () => {
-    await fetchValidators();
-  });
+  let previousCategory = null;
   
-  // Re-fetch when category changes
+  // Fetch validators when component mounts or category changes
   $effect(() => {
-    if ($currentCategory) {
+    if ($currentCategory && $currentCategory !== previousCategory) {
+      previousCategory = $currentCategory;
       fetchValidators();
     }
   });


### PR DESCRIPTION
## Summary
- Fix issue where only 4 participants were showing instead of all participants
- Load all participants without pagination (page_size=1000)
- Show data immediately from API and progressively enhance with RPC data
- Call getValidatorsAtCurrentEpoch directly from frontend instead of backend API
- Eliminate duplicate network calls on page load
- Fix duplicate auth verification calls (once per session instead of per page)

## Changes
1. **Load all participants**: Set page_size=1000 to fetch all users at once
2. **Progressive loading**: Show validators immediately from API, then enhance with blockchain status (Active/Banned) when RPC data arrives
3. **Direct RPC calls**: Use getActiveValidators() from blockchain.js instead of backend API
4. **Fix duplicate calls**: Remove onMount and use single $effect with category tracking
5. **Auth optimization**: Only verify auth once per session using hasVerified flag in store

## Test plan
- [ ] Visit /validators/participants and verify all participants load
- [ ] Check network tab - each API call should only happen once
- [ ] Verify auth endpoint (/api/auth/verify/) is only called once per session
- [ ] Test that validators show immediately with "Loading..." status, then update to Active/Banned/Inactive
- [ ] Test category switching still works correctly

Fixes #84

🤖 Generated with [Claude Code](https://claude.ai/code)