### PR TITLE
Fix small navigation and UI issues

### DIFF
--- a/frontend/src/lib/auth.js
+++ b/frontend/src/lib/auth.js
@@ -225,13 +225,18 @@ export async function signInWithEthereum() {
       verifyAuth();
     }, 100);
     
-    // Check for redirect after login
+    // Check for redirect after login, default to user's public profile
     const redirectPath = sessionStorage.getItem('redirectAfterLogin');
     if (redirectPath) {
       sessionStorage.removeItem('redirectAfterLogin');
       // Import push dynamically to avoid circular dependencies
       import('svelte-spa-router').then(({ push }) => {
         push(redirectPath);
+      });
+    } else {
+      // Default to user's public profile
+      import('svelte-spa-router').then(({ push }) => {
+        push(`/participant/${address}`);
       });
     }
     

--- a/frontend/src/routes/Profile.svelte
+++ b/frontend/src/routes/Profile.svelte
@@ -1319,7 +1319,7 @@
                   </li>
                 </ul>
                 <button
-                  onclick={() => push('/profile')}
+                  onclick={() => push('/validators/waitlist/join')}
                   class="w-full flex items-center justify-center px-4 py-3 bg-sky-600 text-white rounded-lg hover:bg-sky-700 transition-colors font-semibold group-hover:shadow-md"
                 >
                   <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/routes/ProfileEdit.svelte
+++ b/frontend/src/routes/ProfileEdit.svelte
@@ -244,11 +244,6 @@
 </script>
 
 <div class="container mx-auto px-4 py-8">
-  <div class="mb-5">
-    <a href="/" onclick={(e) => { e.preventDefault(); push('/'); }} class="text-primary-600 hover:text-primary-700">
-      ← Back to Dashboard
-    </a>
-  </div>
 
   {#if journeySuccessMessage}
     <div class="bg-green-50 border-l-4 border-green-400 p-4 mb-6">
@@ -621,7 +616,7 @@
                 onclick={startValidatorJourney}
                 class="px-3 py-1.5 bg-sky-600 text-white rounded text-sm hover:bg-sky-700 transition-colors"
               >
-                Start Validator Journey →
+                Join the Waitlist →
               </button>
             </div>
           {/if}


### PR DESCRIPTION
## Summary
- Redirect to user's public profile after login for better user experience
- Fix "Join the Waitlist" button navigation in profile page
- Update button text for consistency across the app
- Remove unnecessary "Back to Dashboard" link

## Changes
1. **Login redirect**: After successful login, users are now redirected to their public profile page (`/participant/:address`) instead of staying on the current page
2. **Waitlist button fix**: The "Join the Waitlist" button in the profile page now correctly navigates to `/validators/waitlist/join` instead of `/profile`
3. **Consistent button text**: Changed "Start Validator Journey" to "Join the Waitlist" in the profile edit page for consistency
4. **Cleaner navigation**: Removed the "Back to Dashboard" link from the profile edit page to simplify navigation

## Test plan
- [ ] Login and verify redirect to user's public profile
- [ ] Click "Join the Waitlist" button on profile page and verify it goes to `/validators/waitlist/join`
- [ ] Check profile edit page shows "Join the Waitlist" instead of "Start Validator Journey"
- [ ] Verify "Back to Dashboard" link is removed from profile edit page

Fixes #87