### PR TITLE
Fix: Show all contribution types in steward submissions dropdown

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -73,7 +73,14 @@ export const contributionsAPI = {
   },
   getContribution: (id) => api.get(`/contributions/${id}/`),
   getContributionsByUser: (address) => api.get(`/contributions/?user_address=${address}&group_consecutive=true`),
-  getContributionTypes: (params) => api.get('/contribution-types/', { params }),
+  getContributionTypes: (params) => {
+    // Set a high page_size to get all contribution types in one request
+    const enhancedParams = {
+      page_size: 100,
+      ...params
+    };
+    return api.get('/contribution-types/', { params: enhancedParams });
+  },
   getContributionType: (id) => api.get(`/contribution-types/${id}/`),
   getContributionTypeMultipliers: (typeId) => api.get(`/contribution-type-multipliers/?contribution_type=${typeId}`),
   getContributionTypeStatistics: (params) => api.get('/contribution-types/statistics/', { params }),

--- a/frontend/src/lib/api/contributions.js
+++ b/frontend/src/lib/api/contributions.js
@@ -9,7 +9,12 @@ import api from '../api.js';
  */
 export async function getContributionTypes(params = {}) {
 	try {
-		const response = await api.get('/contribution-types/', { params });
+		// Set a high page_size to get all contribution types in one request
+		const enhancedParams = {
+			page_size: 100,
+			...params
+		};
+		const response = await api.get('/contribution-types/', { params: enhancedParams });
 		// Handle paginated response
 		return response.data.results || response.data;
 	} catch (error) {

--- a/frontend/src/routes/StewardSubmissions.svelte
+++ b/frontend/src/routes/StewardSubmissions.svelte
@@ -48,7 +48,8 @@
   
   async function loadContributionTypes() {
     try {
-      const response = await contributionsAPI.getContributionTypes();
+      // Fetch all contribution types by setting a high page_size
+      const response = await contributionsAPI.getContributionTypes({ page_size: 100 });
       contributionTypes = response.data.results || response.data;
       
       // Load active multipliers


### PR DESCRIPTION
## Summary
- Fixed pagination issue that was limiting dropdown to only show first 10 contribution types
- Now fetches up to 100 contribution types to ensure all are displayed

## Problem
The contribution type dropdown in the steward submissions page was only showing the first 10 types due to default API pagination limits. This made it impossible to select contribution types beyond the first page.

## Solution
Updated all contribution type fetching functions to include `page_size: 100` parameter:
- `contributionsAPI.getContributionTypes()` in `lib/api.js`
- `getContributionTypes()` helper in `lib/api/contributions.js`
- Direct API call in `StewardSubmissions.svelte`

## Test plan
- [x] Navigate to steward submissions page
- [x] Open contribution type dropdown
- [x] Verify all contribution types are visible (more than 10)
- [x] Verify filtering still works correctly
- [x] Verify selection works for all types