### PR TITLE
feat: add expandable evidence sections to contribution cards

### DIFF
--- a/frontend/src/components/ContributionsList.svelte
+++ b/frontend/src/components/ContributionsList.svelte
@@ -61,7 +61,9 @@
               typeId: contrib.contribution_type_details?.id || contrib.contribution_type,
               count: 1,
               end_date: contrib.contribution_date,
-              users: contrib.user_details ? [contrib.user_details] : []
+              users: contrib.user_details ? [contrib.user_details] : [],
+              evidence_items: contrib.evidence_items,
+              notes: contrib.notes
             });
           } else {
             // Non-highlighted contribution - add to current subgroup
@@ -81,7 +83,9 @@
                 typeId: contrib.contribution_type_details?.id || contrib.contribution_type,
                 count: 1,
                 end_date: contrib.contribution_date,
-                users: contrib.user_details ? [contrib.user_details] : []
+                users: contrib.user_details ? [contrib.user_details] : [],
+                evidence_items: contrib.evidence_items,
+                notes: contrib.notes
               };
             } else {
               // Add to existing subgroup
@@ -140,7 +144,9 @@
           typeId: typeId,
           count: 1,
           end_date: contrib.contribution_date,
-          users: []
+          users: [],
+          evidence_items: contrib.evidence_items,
+          notes: contrib.notes
         };
         
         if (contrib.user_details) {
@@ -262,7 +268,15 @@
   {:else}
     <div class="space-y-3">
       {#each processedContributions as contribution}
-        <ContributionCard {contribution} {showUser} />
+        <ContributionCard 
+          {contribution} 
+          {showUser}
+          submission={{
+            notes: contribution.notes,
+            evidence_items: contribution.evidence_items
+          }}
+          showExpand={contribution.evidence_items?.length > 0 || contribution.notes}
+        />
       {/each}
     </div>
     

--- a/frontend/src/routes/Waitlist.svelte
+++ b/frontend/src/routes/Waitlist.svelte
@@ -385,6 +385,11 @@
           {#each featuredContributions.slice(0, 3) as highlight}
             <ContributionCard 
               contribution={highlight.contribution}
+              submission={{
+                notes: highlight.contribution?.notes,
+                evidence_items: highlight.contribution?.evidence_items
+              }}
+              showExpand={highlight.contribution?.evidence_items?.length > 0 || highlight.contribution?.notes}
               showUser={true}
               compact={true}
               highlighted={true}


### PR DESCRIPTION
## Summary
- Add expandable evidence display functionality to ContributionCard components throughout the application
- Evidence items and notes are now passed to contribution cards and can be expanded by users for more detailed information
- Update both ContributionsList and Waitlist components to support evidence display

## Test plan
- [ ] Verify that contribution cards with evidence items show expand/collapse functionality
- [ ] Test that evidence items and notes display correctly when expanded
- [ ] Confirm that cards without evidence don't show expand controls
- [ ] Check that the feature works correctly in both the contributions list and waitlist featured contributions