### PR TITLE
Add Google Analytics integration

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -12,5 +12,9 @@ VITE_VALIDATOR_CONTRACT_ADDRESS=0x10eCB157734c8152f1d84D00040c8AA46052CB27
 # Blockchain Explorer
 VITE_EXPLORER_URL=https://explorer-asimov.genlayer.com
 
+# Google Analytics
+VITE_GOOGLE_ANALYTICS_ID=G-ZZC3YMGQL2
+
 # Production values (to be set in Amplify environment variables)
 # VITE_API_URL=https://your-app-runner-url.amazonaws.com
+# VITE_GOOGLE_ANALYTICS_ID=G-5X6PRBXWJ7

--- a/frontend/src/lib/analytics.js
+++ b/frontend/src/lib/analytics.js
@@ -1,0 +1,42 @@
+/**
+ * Google Analytics initialization
+ *
+ * Loads and initializes Google Analytics using the tracking ID from environment variables.
+ * Only initializes if VITE_GOOGLE_ANALYTICS_ID is set.
+ */
+
+/**
+ * Initialize Google Analytics
+ * Dynamically loads gtag.js script and configures tracking
+ */
+export function initializeAnalytics() {
+  const trackingId = import.meta.env.VITE_GOOGLE_ANALYTICS_ID;
+
+  // Only initialize if tracking ID is configured
+  if (!trackingId) {
+    console.log('Google Analytics: No tracking ID configured');
+    return;
+  }
+
+  // Create and inject the gtag.js script
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${trackingId}`;
+  document.head.appendChild(script);
+
+  // Initialize dataLayer and gtag function
+  window.dataLayer = window.dataLayer || [];
+
+  // Make gtag available globally
+  window.gtag = function() {
+    window.dataLayer.push(arguments);
+  };
+
+  // Initialize with current timestamp
+  window.gtag('js', new Date());
+
+  // Configure with tracking ID
+  window.gtag('config', trackingId);
+
+  console.log(`Google Analytics initialized with ID: ${trackingId}`);
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,6 +3,11 @@ import { mount } from 'svelte';
 import App from './App.svelte';
 import './styles.css';
 
+// Initialize Google Analytics (async, non-blocking)
+import('./lib/analytics.js')
+  .then(({ initializeAnalytics }) => initializeAnalytics())
+  .catch(err => console.warn('Analytics not loaded:', err.message));
+
 // Create the app using Svelte 5's mount function
 const app = mount(App, {
   target: document.getElementById('app')


### PR DESCRIPTION
## Summary
- Add Google Analytics tracking with environment-based configuration
- Created `frontend/src/lib/analytics.js` for GA initialization
- Updated `frontend/src/main.js` to load analytics asynchronously (non-blocking)
- Added `VITE_GOOGLE_ANALYTICS_ID` environment variable to `.env.example`

## Implementation Details
- Analytics loads asynchronously to prevent blocking page render
- Graceful degradation if ad blockers prevent loading
- Uses dev tracking ID `G-ZZC3YMGQL2` by default
- Production tracking ID `G-5X6PRBXWJ7` documented in `.env.example`

## Test Plan
- [x] Verify site loads properly with analytics enabled
- [x] Verify site loads properly even when ad blockers block analytics.js
- [x] Check browser console for GA initialization message
- [ ] Test in production with production tracking ID