### PR TITLE
Fix wrong points display in contribution cards

### DIFF
--- a/frontend/src/components/ContributionCard.svelte
+++ b/frontend/src/components/ContributionCard.svelte
@@ -157,7 +157,7 @@
       
       <div class="ml-3 flex-shrink-0">
         <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
-          {contribution.points || contribution.frozen_points || 0} pts
+          {contribution.frozen_global_points || 0} pts
         </span>
       </div>
     </div>


### PR DESCRIPTION
Fixes #209

ContributionCard was displaying base points (e.g., 1) instead of frozen_global_points (e.g., 50). 

**Changes:**
- Display frozen_global_points instead of base points in ContributionCard component
- This single fix resolves wrong points shown in contribution type detail pages and my submissions