### PR TITLE
Fix highlight avatar colors to show role-based themes

### DIFF
--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -445,6 +445,9 @@ class ContributionViewSet(viewsets.ReadOnlyModelViewSet):
         # Order by contribution date descending and apply limit
         highlights = queryset.select_related(
             'contribution__user',
+            'contribution__user__validator',
+            'contribution__user__builder',
+            'contribution__user__steward',
             'contribution__contribution_type',
             'contribution__contribution_type__category'
         ).order_by('-contribution__contribution_date')[:limit]

--- a/frontend/src/components/FeaturedContributions.svelte
+++ b/frontend/src/components/FeaturedContributions.svelte
@@ -180,7 +180,12 @@
             user_details: {
               name: highlight.user_name,
               address: highlight.user_address,
-              profile_image_url: highlight.user_profile_image_url
+              profile_image_url: highlight.user_profile_image_url,
+              validator: highlight.user_validator,
+              builder: highlight.user_builder,
+              steward: highlight.user_steward,
+              has_validator_waitlist: highlight.user_has_validator_waitlist,
+              has_builder_welcome: highlight.user_has_builder_welcome
             },
             users: [{
               name: highlight.user_name,
@@ -216,11 +221,16 @@
           <h3 class="font-semibold text-gray-900">{highlight.title}</h3>
           <p class="text-sm text-gray-600 mt-1">{highlight.description}</p>
           <div class="flex items-center gap-3 mt-2 text-xs text-gray-500">
-            <Avatar 
+            <Avatar
               user={{
                 name: highlight.user_name,
                 address: highlight.user_address,
-                profile_image_url: highlight.user_profile_image_url
+                profile_image_url: highlight.user_profile_image_url,
+                validator: highlight.user_validator,
+                builder: highlight.user_builder,
+                steward: highlight.user_steward,
+                has_validator_waitlist: highlight.user_has_validator_waitlist,
+                has_builder_welcome: highlight.user_has_builder_welcome
               }}
               size="xs"
               clickable={true}
@@ -252,11 +262,16 @@
               <p class="mt-2 text-sm text-gray-700">{highlight.description}</p>
               <div class="mt-3 flex items-center gap-4 text-xs text-gray-600">
                 <div class="flex items-center gap-2">
-                  <Avatar 
+                  <Avatar
                     user={{
                       name: highlight.user_name,
                       address: highlight.user_address,
-                      profile_image_url: highlight.user_profile_image_url
+                      profile_image_url: highlight.user_profile_image_url,
+                      validator: highlight.user_validator,
+                      builder: highlight.user_builder,
+                      steward: highlight.user_steward,
+                      has_validator_waitlist: highlight.user_has_validator_waitlist,
+                      has_builder_welcome: highlight.user_has_builder_welcome
                     }}
                     size="xs"
                     clickable={true}

--- a/frontend/src/routes/Highlights.svelte
+++ b/frontend/src/routes/Highlights.svelte
@@ -137,11 +137,16 @@
           
           <div class="flex items-center justify-between text-sm">
             <div class="flex items-center gap-3">
-              <Avatar 
+              <Avatar
                 user={{
                   name: highlight.user_name,
                   address: highlight.user_address,
-                  profile_image_url: highlight.user_profile_image_url
+                  profile_image_url: highlight.user_profile_image_url,
+                  validator: highlight.user_validator,
+                  builder: highlight.user_builder,
+                  steward: highlight.user_steward,
+                  has_validator_waitlist: highlight.user_has_validator_waitlist,
+                  has_builder_welcome: highlight.user_has_builder_welcome
                 }}
                 size="xs"
                 clickable={true}


### PR DESCRIPTION
Resolves #198

Highlights were not using role-based avatar colors (validator blue, builder orange, etc).

**Backend:**
- Add role fields to ContributionHighlightSerializer
- Optimize queries with select_related

**Frontend:**
- Pass role data to Avatar in Highlights.svelte and FeaturedContributions.svelte

Validators now show sky blue, builders show orange, stewards show green.