### PR TITLE
Filter onboarding contributions from public lists

### DIFF
--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -227,11 +227,13 @@ class ContributionViewSet(viewsets.ReadOnlyModelViewSet):
         category = self.request.query_params.get('category')
         if category:
             queryset = queryset.filter(contribution_type__category__slug=category)
-            # Note: We do NOT exclude builder-welcome here because users should see
-            # their builder-welcome contribution in their recent contributions list.
-            # Builder-welcome is only excluded from:
-            # - Leaderboard calculations (in leaderboard/models.py)
-            # - ContributionType listings (in ContributionTypeViewSet above)
+
+        # Exclude onboarding contributions (builder-welcome and validator-waitlist)
+        # EXCEPT when viewing a specific user's profile (user_address is present)
+        if not user_address:
+            queryset = queryset.exclude(
+                contribution_type__slug__in=['builder-welcome', 'validator-waitlist']
+            )
 
         return queryset
 


### PR DESCRIPTION
## Summary
- Excludes builder-welcome and validator-waitlist contributions from public contribution lists and dashboard metrics
- These contributions only appear on individual user profile pages
- Replaces finalize_queryset with list method override in LeaderboardViewSet for cleaner implementation

## Changes
- **Contribution lists**: Filter out onboarding contributions except when `user_address` parameter is present
- **Dashboard stats**: Exclude onboarding contributions from total contribution counts (global and per-category)
- **Leaderboard**: Use list method override instead of finalize_queryset

## Impact
- Cleaner public contribution lists and metrics
- Users can still see their complete history on profile pages