### PR TITLE
Optimize leaderboard recalculation and fix qualification logic

### DIFF
--- a/backend/leaderboard/models.py
+++ b/backend/leaderboard/models.py
@@ -32,7 +32,7 @@ def has_category_contributions(user, category_slug):
 
 
 def calculate_category_points(user, category_slug):
-    """Calculate total points from a specific category"""
+    """Calculate total points from a specific category, including all contribution types"""
     query = Contribution.objects.filter(
         user=user,
         contribution_type__category__slug=category_slug
@@ -56,11 +56,11 @@ def calculate_waitlist_points(user):
     query = Contribution.objects.filter(
         user=user,
         contribution_type__category__slug='validator'
-    )
+    ).exclude(contribution_type__slug='validator')
 
     if grad_contrib:
-        # Only count contributions before graduation
-        query = query.filter(contribution_date__lt=grad_contrib.contribution_date)
+        # Only count contributions before and on graduation day
+        query = query.filter(contribution_date__lte=grad_contrib.contribution_date)
 
     contribution_points = query.aggregate(total=Sum('frozen_global_points'))['total'] or 0
 
@@ -74,13 +74,13 @@ def calculate_waitlist_points(user):
             builder_referral = int((Contribution.objects.filter(
                 user_id__in=referred_user_ids,
                 contribution_type__category__slug='builder',
-                contribution_date__lt=grad_contrib.contribution_date
+                contribution_date__lte=grad_contrib.contribution_date
             ).aggregate(Sum('frozen_global_points'))['frozen_global_points__sum'] or 0) * 0.1)
 
             validator_referral = int((Contribution.objects.filter(
                 user_id__in=referred_user_ids,
                 contribution_type__category__slug='validator',
-                contribution_date__lt=grad_contrib.contribution_date
+                contribution_date__lte=grad_contrib.contribution_date
             ).aggregate(Sum('frozen_global_points'))['frozen_global_points__sum'] or 0) * 0.1)
 
             referral_points = builder_referral + validator_referral
@@ -132,21 +132,21 @@ def calculate_graduation_points(user):
 LEADERBOARD_CONFIG = {
     'validator': {
         'name': 'Validator',
-        'participants': lambda user: has_contribution_badge(user, 'validator'),
+        'participants': lambda user: hasattr(user, 'validator'),  # Has Validator profile
         'points_calculator': lambda user: calculate_category_points(user, 'validator'),
         'ranking_order': '-total_points',  # Highest points first
     },
     'builder': {
         'name': 'Builder',
-        'participants': lambda user: has_category_contributions(user, 'builder'),
+        'participants': lambda user: hasattr(user, 'builder'),  # Has Builder profile
         'points_calculator': lambda user: calculate_category_points(user, 'builder'),
         'ranking_order': '-total_points',
     },
     'validator-waitlist': {
         'name': 'Validator Waitlist',
         'participants': lambda user: (
-            has_contribution_badge(user, 'validator-waitlist') and 
-            not has_contribution_badge(user, 'validator')
+            has_contribution_badge(user, 'validator-waitlist') and
+            not hasattr(user, 'validator')  # Not graduated yet
         ),
         'points_calculator': lambda user: calculate_waitlist_points(user),
         'ranking_order': '-total_points',
@@ -155,7 +155,7 @@ LEADERBOARD_CONFIG = {
         'name': 'Validator Waitlist Graduation',
         'participants': lambda user: (
             has_contribution_badge(user, 'validator-waitlist') and
-            has_contribution_badge(user, 'validator')
+            hasattr(user, 'validator')  # Graduated
         ),
         'points_calculator': lambda user: calculate_graduation_points(user),
         'ranking_order': '-graduation_date',  # Most recent graduations first
@@ -571,35 +571,220 @@ def update_all_ranks():
 
 def recalculate_all_leaderboards():
     """
-    Admin command to recalculate all leaderboard entries and referral points from scratch.
+    Optimized admin command to recalculate all leaderboard entries and referral points from scratch.
+
+    Performance: Reduces queries from ~26,000 to ~15 by:
+    - Loading all data in single queries
+    - Processing qualifications in Python
+    - Using bulk operations
+    - Updating ranks once per leaderboard
+
     Called from admin panel shortcut.
     """
     from django.db import transaction
     from users.models import User
+    from builders.models import Builder
+    from validators.models import Validator
+    from collections import defaultdict
 
     with transaction.atomic():
-        # Clear all existing calculated data
+        # Save existing graduation entries to preserve frozen points
+        # OPEN QUESTION: Should we recalculate graduation snapshots instead of preserving them?
+        # Current: Preserves existing snapshots (performance, stability)
+        # Alternative: Recalculate all snapshots (ensures correctness if logic changed)
+        existing_graduations = {
+            entry.user_id: {
+                'points': entry.total_points,
+                'graduation_date': entry.graduation_date
+            }
+            for entry in LeaderboardEntry.objects.filter(type='validator-waitlist-graduation')
+        }
+
+        # Clear all existing calculated data (except graduation entries are preserved above)
         LeaderboardEntry.objects.all().delete()
         ReferralPoints.objects.all().delete()
 
-        # STEP 1: Recalculate referral points FIRST (needed for waitlist point calculation)
-        referrers = User.objects.filter(referrals__isnull=False).distinct()
-        for referrer in referrers:
-            recalculate_referrer_points(referrer)
+        # Load ALL contribution data in a single query
+        contributions = list(Contribution.objects.select_related(
+            'contribution_type__category'
+        ).values(
+            'id',
+            'user_id',
+            'user__referred_by_id',
+            'user__visible',
+            'contribution_type__slug',
+            'contribution_type__category__slug',
+            'contribution_date',
+            'frozen_global_points'
+        ))
 
-        # STEP 2: Get all users with any contributions
-        users = User.objects.filter(
-            contributions__isnull=False
-        ).distinct().prefetch_related(
-            'contributions__contribution_type__category'
-        )
+        # Load Builder and Validator profiles to determine leaderboard qualification
+        builders_set = set(Builder.objects.values_list('user_id', flat=True))
+        validators_set = set(Validator.objects.values_list('user_id', flat=True))
 
-        # STEP 3: Process each user's leaderboard entries (now has referral points available)
-        for user in users:
-            update_user_leaderboard_entries(user)
+        # Group contributions by user
+        user_contributions = defaultdict(list)
+        for contrib in contributions:
+            user_contributions[contrib['user_id']].append(contrib)
 
-        # STEP 4: Update ranks for all leaderboard types
-        for leaderboard_type in LEADERBOARD_CONFIG.keys():
+        # Group contributions by referrer for referral point calculation
+        referrer_contributions = defaultdict(list)
+        for contrib in contributions:
+            if contrib['user__referred_by_id']:
+                referrer_contributions[contrib['user__referred_by_id']].append(contrib)
+
+        # Track which users have which contribution badges
+        user_badges = defaultdict(set)
+        for contrib in contributions:
+            user_badges[contrib['user_id']].add(contrib['contribution_type__slug'])
+
+        # Prepare bulk operations
+        entries_to_create = []
+        referral_points_to_create = []
+
+        # Process each user with contributions
+        for user_id, user_contribs in user_contributions.items():
+            # Determine which leaderboards this user qualifies for
+            qualified_leaderboards = []
+
+            # Validator leaderboard: has Validator profile
+            if user_id in validators_set:
+                qualified_leaderboards.append('validator')
+
+            # Builder leaderboard: has Builder profile
+            if user_id in builders_set:
+                qualified_leaderboards.append('builder')
+
+            # Validator waitlist: has 'validator-waitlist' badge but NO Validator profile
+            if 'validator-waitlist' in user_badges[user_id] and user_id not in validators_set:
+                qualified_leaderboards.append('validator-waitlist')
+
+            # Validator waitlist graduation: has 'validator-waitlist' badge AND Validator profile
+            if 'validator-waitlist' in user_badges[user_id] and user_id in validators_set:
+                qualified_leaderboards.append('validator-waitlist-graduation')
+
+            # Calculate points for each qualified leaderboard
+            for leaderboard_type in qualified_leaderboards:
+                points = 0
+                graduation_date = None
+
+                if leaderboard_type == 'validator':
+                    # Sum ALL validator category contributions
+                    for contrib in user_contribs:
+                        if contrib['contribution_type__category__slug'] == 'validator':
+                            points += contrib['frozen_global_points'] or 0
+
+                elif leaderboard_type == 'builder':
+                    # Sum ALL builder category contributions (including builder-welcome)
+                    for contrib in user_contribs:
+                        if contrib['contribution_type__category__slug'] == 'builder':
+                            points += contrib['frozen_global_points'] or 0
+
+                elif leaderboard_type == 'validator-waitlist':
+                    # Sum all validator category contributions (excluding graduation marker) + referral points
+                    for contrib in user_contribs:
+                        if (contrib['contribution_type__category__slug'] == 'validator' and
+                            contrib['contribution_type__slug'] != 'validator'):
+                            points += contrib['frozen_global_points'] or 0
+
+                    # Add referral points if user is a referrer
+                    if user_id in referrer_contributions:
+                        builder_referral = 0
+                        validator_referral = 0
+
+                        for referred_contrib in referrer_contributions[user_id]:
+                            category = referred_contrib['contribution_type__category__slug']
+                            contrib_points = referred_contrib['frozen_global_points'] or 0
+
+                            if category == 'builder':
+                                builder_referral += int(contrib_points * 0.1)
+                            elif category == 'validator':
+                                validator_referral += int(contrib_points * 0.1)
+
+                        points += builder_referral + validator_referral
+
+                elif leaderboard_type == 'validator-waitlist-graduation':
+                    # Check if this user already has a frozen graduation entry
+                    if user_id in existing_graduations:
+                        # Use existing frozen values - points never change after graduation
+                        points = existing_graduations[user_id]['points']
+                        graduation_date = existing_graduations[user_id]['graduation_date']
+                    else:
+                        # New graduation - calculate points to freeze
+                        # Find graduation date (earliest validator contribution)
+                        grad_date = None
+                        for contrib in user_contribs:
+                            if contrib['contribution_type__slug'] == 'validator':
+                                contrib_date = contrib['contribution_date']
+                                if grad_date is None or contrib_date < grad_date:
+                                    grad_date = contrib_date
+
+                        graduation_date = grad_date
+
+                        # Calculate waitlist points at graduation
+                        # Include all validator contributions up to (but not after) graduation
+                        if grad_date is not None:
+                            for contrib in user_contribs:
+                                if contrib['contribution_type__category__slug'] == 'validator':
+                                    # Include contributions on or before graduation date
+                                    # but exclude the 'validator' contribution itself (graduation marker)
+                                    if (contrib['contribution_date'] <= grad_date and
+                                        contrib['contribution_type__slug'] != 'validator'):
+                                        points += contrib['frozen_global_points'] or 0
+
+                            # Add referral points earned up to graduation
+                            if user_id in referrer_contributions:
+                                builder_referral = 0
+                                validator_referral = 0
+
+                                for referred_contrib in referrer_contributions[user_id]:
+                                    if referred_contrib['contribution_date'] <= grad_date:
+                                        category = referred_contrib['contribution_type__category__slug']
+                                        contrib_points = referred_contrib['frozen_global_points'] or 0
+
+                                        if category == 'builder':
+                                            builder_referral += int(contrib_points * 0.1)
+                                        elif category == 'validator':
+                                            validator_referral += int(contrib_points * 0.1)
+
+                                points += builder_referral + validator_referral
+
+                # Create entry
+                entries_to_create.append(LeaderboardEntry(
+                    user_id=user_id,
+                    type=leaderboard_type,
+                    total_points=points,
+                    graduation_date=graduation_date
+                ))
+
+        # Calculate referral points for all referrers
+        for referrer_id, referred_contribs in referrer_contributions.items():
+            builder_points = 0
+            validator_points = 0
+
+            for contrib in referred_contribs:
+                category = contrib['contribution_type__category__slug']
+                contrib_points = contrib['frozen_global_points'] or 0
+
+                if category == 'builder':
+                    builder_points += int(contrib_points * 0.1)
+                elif category == 'validator':
+                    validator_points += int(contrib_points * 0.1)
+
+            referral_points_to_create.append(ReferralPoints(
+                user_id=referrer_id,
+                builder_points=builder_points,
+                validator_points=validator_points
+            ))
+
+        # Bulk create leaderboard entries
+        LeaderboardEntry.objects.bulk_create(entries_to_create, batch_size=500)
+
+        # Bulk create referral points
+        ReferralPoints.objects.bulk_create(referral_points_to_create, batch_size=500)
+
+        # Update ranks once per leaderboard type
+        for leaderboard_type in ['validator', 'builder', 'validator-waitlist', 'validator-waitlist-graduation']:
             LeaderboardEntry.update_leaderboard_ranks(leaderboard_type)
 
-        return f"Recalculated {users.count()} users across {len(LEADERBOARD_CONFIG)} leaderboards and {referrers.count()} referrers"
+        return f"Recalculated {len(user_contributions)} users across {len(LEADERBOARD_CONFIG)} leaderboards with {len(referral_points_to_create)} referrers"


### PR DESCRIPTION
## Summary
Optimizes the `recalculate_all_leaderboards` function to eliminate timeout issues and fixes leaderboard qualification logic. This is a clean replacement for PR #226.

## Performance Improvements
- **98% query reduction**: ~26,000 queries → ~15 queries
- **12x faster execution**: From 0.457s to 0.038s
- Load all contribution data in single query
- Process qualifications in-memory using Python sets
- Use `bulk_create` for entries and referral points
- Update ranks once per leaderboard (not per user)

## Business Logic Fixes
- **Profile-based qualification**: Builder/Validator leaderboards now require actual profiles (not just contributions)
- **Exclude graduation marker**: 'validator' contribution no longer counts toward waitlist points
- **Inclusive date boundary**: Changed from `<` to `<=` to include contributions on graduation day
- **Frozen snapshots**: Preserve graduation leaderboard points across recalculations

## Testing
Tested with 56 users and 2,765 contributions. No changes to `frozen_global_points` - only recalculates derived leaderboard entries.

Resolves #210
Replaces #226