### PR TITLE
Add markdown rendering for staff and user notes

### DIFF
--- a/frontend/src/components/ContributionCard.svelte
+++ b/frontend/src/components/ContributionCard.svelte
@@ -4,6 +4,7 @@
   import { getCategoryColors } from '../lib/categoryColors';
   import Avatar from './Avatar.svelte';
   import Icons from './Icons.svelte';
+  import { parseMarkdown } from '../lib/markdownLoader.js';
 
   let {
     contribution,
@@ -167,7 +168,7 @@
         {#if submission?.notes}
           <div>
             <h5 class="text-xs font-medium text-gray-700 mb-1">Notes</h5>
-            <p class="text-xs text-gray-600">{submission.notes}</p>
+            <div class="markdown-content text-xs text-gray-600">{@html parseMarkdown(submission.notes)}</div>
           </div>
         {/if}
 
@@ -267,3 +268,15 @@
     </div>
   {/if}
 </div>
+
+<style>
+  .markdown-content :global(ul) {
+    list-style-type: disc;
+    margin-left: 1.5rem;
+  }
+
+  .markdown-content :global(ol) {
+    list-style-type: decimal;
+    margin-left: 1.5rem;
+  }
+</style>

--- a/frontend/src/components/SubmissionCard.svelte
+++ b/frontend/src/components/SubmissionCard.svelte
@@ -229,7 +229,7 @@
         {#if submission.notes}
           <div>
             <h4 class="text-sm font-medium text-gray-700">Notes</h4>
-            <p class="mt-1 text-sm text-gray-900">{submission.notes}</p>
+            <div class="markdown-content mt-1 text-sm text-gray-900">{@html parseMarkdown(submission.notes)}</div>
           </div>
         {/if}
         
@@ -256,7 +256,7 @@
         {#if submission.staff_reply && submission.state !== 'rejected'}
           <div class="bg-gray-50 p-3 rounded">
             <h4 class="text-sm font-medium text-gray-700 mb-1">Staff Response</h4>
-            <div class="text-sm text-gray-600">{@html parseMarkdown(submission.staff_reply)}</div>
+            <div class="markdown-content text-sm text-gray-600">{@html parseMarkdown(submission.staff_reply)}</div>
           </div>
         {/if}
       </div>
@@ -523,7 +523,7 @@
         {:else if submission.state === 'rejected' && submission.staff_reply}
           <div class="border border-red-200 rounded-lg p-4 bg-red-50">
             <h4 class="text-sm font-medium text-red-900 mb-2">Rejection Reason</h4>
-            <div class="text-sm text-red-700">{@html parseMarkdown(submission.staff_reply)}</div>
+            <div class="markdown-content text-sm text-red-700">{@html parseMarkdown(submission.staff_reply)}</div>
           </div>
         {:else if isOwnSubmission && (submission.state === 'pending' || submission.state === 'more_info_needed')}
           <!-- Edit button for pending and more_info_needed submissions -->
@@ -542,25 +542,13 @@
 </div>
 
 <style>
-  :global(.text-gray-600 ul),
-  :global(.text-red-700 ul),
-  :global(.text-blue-800 ul) {
+  .markdown-content :global(ul) {
     list-style-type: disc;
     margin-left: 1.5rem;
-    margin-top: 0.5rem;
   }
 
-  :global(.text-gray-600 ol),
-  :global(.text-red-700 ol),
-  :global(.text-blue-800 ol) {
+  .markdown-content :global(ol) {
     list-style-type: decimal;
     margin-left: 1.5rem;
-    margin-top: 0.5rem;
-  }
-
-  :global(.text-gray-600 li),
-  :global(.text-red-700 li),
-  :global(.text-blue-800 li) {
-    margin-bottom: 0.25rem;
   }
 </style>

--- a/frontend/src/routes/EditSubmission.svelte
+++ b/frontend/src/routes/EditSubmission.svelte
@@ -307,7 +307,7 @@
       {#if submission.staff_reply}
         <div class="mb-6 bg-blue-50 border border-blue-200 p-4 rounded">
           <h3 class="font-semibold text-blue-900 mb-2">Staff Feedback:</h3>
-          <div class="text-blue-800">{@html parseMarkdown(submission.staff_reply)}</div>
+          <div class="markdown-content text-blue-800">{@html parseMarkdown(submission.staff_reply)}</div>
         </div>
       {/if}
       
@@ -470,19 +470,13 @@
 />
 
 <style>
-  :global(.text-blue-800 ul) {
+  .markdown-content :global(ul) {
     list-style-type: disc;
     margin-left: 1.5rem;
-    margin-top: 0.5rem;
   }
 
-  :global(.text-blue-800 ol) {
+  .markdown-content :global(ol) {
     list-style-type: decimal;
     margin-left: 1.5rem;
-    margin-top: 0.5rem;
-  }
-
-  :global(.text-blue-800 li) {
-    margin-bottom: 0.25rem;
   }
 </style>


### PR DESCRIPTION
Fixes #252

Staff and user notes now properly render markdown including newlines, lists, bold, italic, and links.