### PR TITLE
Auto-grants builder-welcome and builder contributions (with Builder profile) to users who have builder-category contributions but haven't completed the builder journey

### DIFF
--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -832,7 +832,13 @@ class StewardSubmissionViewSet(viewsets.ModelViewSet):
                 notes=submission.notes,
                 mission=submission.mission
             )
-            
+
+            # Auto-grant builder status if accepting builder contribution for non-builder
+            if (contribution_type.category and contribution_type.category.slug == 'builder'
+                and not hasattr(contribution_user, 'builder')):
+                from leaderboard.models import ensure_builder_status
+                ensure_builder_status(contribution_user, submission.contribution_date)
+
             # Copy evidence items
             for evidence in submission.evidence_items.all():
                 Evidence.objects.create(


### PR DESCRIPTION
- Leaderboard recalculation: identifies users with builder contributions (excluding builder-welcome/builder) but no Builder profile, creates missing contributions with earliest contribution date
- Submission review: when accepting a builder contribution for a non-builder user, auto-grants builder-welcome and builder contributions