### PR TITLE
Rename Featured to Highlighted Contributions and add evidence display

### DIFF
--- a/backend/contributions/models.py
+++ b/backend/contributions/models.py
@@ -121,7 +121,8 @@ class Contribution(BaseModel):
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
-        related_name='contributions'
+        related_name='contributions',
+        help_text='Mission this contribution fulfills (optional)'
     )
     points = models.PositiveIntegerField(default=0)
     frozen_global_points = models.PositiveIntegerField(
@@ -252,7 +253,8 @@ class SubmittedContribution(BaseModel):
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
-        related_name='submissions'
+        related_name='submissions',
+        help_text='Mission that prompted this submission (optional)'
     )
     contribution_date = models.DateTimeField(
         help_text="Date when the contribution was made"

--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -184,6 +184,14 @@ class ContributionTypeViewSet(viewsets.ReadOnlyModelViewSet):
             limit=limit
         )
 
+        # Prefetch evidence items to avoid N+1 queries and enable evidence display
+        highlights = highlights.select_related(
+            'contribution__user',
+            'contribution__contribution_type'
+        ).prefetch_related(
+            'contribution__evidence_items'
+        )
+
         serializer = ContributionHighlightSerializer(highlights, many=True)
         return Response(serializer.data)
     
@@ -455,6 +463,8 @@ class ContributionViewSet(viewsets.ReadOnlyModelViewSet):
             'contribution__user__steward',
             'contribution__contribution_type',
             'contribution__contribution_type__category'
+        ).prefetch_related(
+            'contribution__evidence_items'
         ).order_by('-contribution__contribution_date')[:limit]
         
         serializer = ContributionHighlightSerializer(highlights, many=True)

--- a/backend/leaderboard/models.py
+++ b/backend/leaderboard/models.py
@@ -552,7 +552,7 @@ def ensure_builder_status(user, reference_date):
             points=20,
             contribution_date=timezone.now(),
             frozen_global_points=20
-        )
+        ))
 
     if not Contribution.objects.filter(user=user, contribution_type=builder_type).exists():
         contributions_to_create.append(Contribution(

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -538,7 +538,7 @@ npm run preview
 ### Component Card Wrappers
 **IMPORTANT**: When using reusable components in pages, do NOT wrap them in additional card containers.
 
-Components like `RecentContributions`, `FeaturedContributions`, `UserContributions`, etc. already include their own styling and structure. Adding wrapper cards creates unnecessary nesting and visual clutter.
+Components like `RecentContributions`, `HighlightedContributions`, `UserContributions`, etc. already include their own styling and structure. Adding wrapper cards creates unnecessary nesting and visual clutter.
 
 ```javascript
 // ❌ WRONG - Don't wrap components in cards
@@ -550,7 +550,7 @@ Components like `RecentContributions`, `FeaturedContributions`, `UserContributio
 <RecentContributions />
 
 // ✅ CORRECT - Components can have className for spacing
-<FeaturedContributions className="mb-6" />
+<HighlightedContributions className="mb-6" />
 ```
 
 The only exception is when you need to group multiple related elements that aren't already in a component.

--- a/frontend/src/components/ContributionCard.svelte
+++ b/frontend/src/components/ContributionCard.svelte
@@ -258,8 +258,8 @@
           <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/>
         </svg>
         <div class="flex-1">
-          <h4 class="text-sm font-semibold text-yellow-900 mb-1">Featured: {contribution.highlight.title}</h4>
-          <p class="text-sm text-yellow-800">{contribution.highlight.description}</p>
+          <h4 class="text-sm font-semibold text-yellow-900 mb-1">Highlighted: {contribution.highlight.title}</h4>
+          <div class="markdown-content text-sm text-yellow-800">{@html parseMarkdown(contribution.highlight.description)}</div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/ContributionsList.svelte
+++ b/frontend/src/components/ContributionsList.svelte
@@ -137,7 +137,7 @@
     }
     
     // Data is not grouped - group consecutive contributions of the same type
-    // but don't group if there's a featured/highlighted contribution
+    // but don't group if there's a highlighted contribution
     const grouped = [];
     let currentGroup = null;
     

--- a/frontend/src/components/GlobalDashboard.svelte
+++ b/frontend/src/components/GlobalDashboard.svelte
@@ -3,7 +3,7 @@
   import { push } from 'svelte-spa-router';
   import { format } from 'date-fns';
   import TopLeaderboard from './TopLeaderboard.svelte';
-  import FeaturedContributions from './FeaturedContributions.svelte';
+  import HighlightedContributions from './HighlightedContributions.svelte';
   import Avatar from './Avatar.svelte';
   import { leaderboardAPI, statsAPI, validatorsAPI, buildersAPI } from '../lib/api';
   
@@ -155,7 +155,7 @@
         />
       </div>
       
-      <!-- Featured Validators Contributions -->
+      <!-- Highlighted Validators Contributions -->
       <div class="space-y-4 mt-6 sm:mt-10">
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-2">
@@ -164,7 +164,7 @@
                 <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
               </svg>
             </div>
-            <h2 class="text-lg font-semibold text-gray-900">Featured Validators Contributions</h2>
+            <h2 class="text-lg font-semibold text-gray-900">Highlighted Validators Contributions</h2>
           </div>
           <button
             onclick={() => push('/validators/contributions/highlights')}
@@ -176,7 +176,7 @@
             </svg>
           </button>
         </div>
-        <FeaturedContributions 
+        <HighlightedContributions 
           showHeader={false}
           showViewAll={false}
           category="validator"
@@ -309,7 +309,7 @@
         />
       </div>
       
-      <!-- Featured Builders Contributions -->
+      <!-- Highlighted Builders Contributions -->
       <div class="space-y-4 mt-6 sm:mt-10">
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-2">
@@ -318,7 +318,7 @@
                 <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
               </svg>
             </div>
-            <h2 class="text-lg font-semibold text-gray-900">Featured Builders Contributions</h2>
+            <h2 class="text-lg font-semibold text-gray-900">Highlighted Builders Contributions</h2>
           </div>
           <button
             onclick={() => push('/builders/contributions/highlights')}
@@ -330,7 +330,7 @@
             </svg>
           </button>
         </div>
-        <FeaturedContributions
+        <HighlightedContributions
           showHeader={false}
           showViewAll={false}
           category="builder"

--- a/frontend/src/components/HighlightedContributions.svelte
+++ b/frontend/src/components/HighlightedContributions.svelte
@@ -4,12 +4,13 @@
   import { format } from 'date-fns';
   import { contributionsAPI, usersAPI } from '../lib/api';
   import { currentCategory } from '../stores/category.js';
+  import { parseMarkdown } from '../lib/markdownLoader.js';
   import Avatar from './Avatar.svelte';
   import Badge from './Badge.svelte';
   import ContributionCard from './ContributionCard.svelte';
 
   let {
-    title = 'Featured Contributions',
+    title = 'Highlighted Contributions',
     subtitle = null,
     limit = 3,
     userId = null,
@@ -29,6 +30,7 @@
   let highlights = $state([]);
   let loading = $state(true);
   let error = $state(null);
+  let expandedHighlights = $state(new Set());
 
   // Determine button colors based on theme
   const buttonClasses = $derived(
@@ -54,6 +56,15 @@
     } catch (e) {
       return dateString;
     }
+  };
+
+  const toggleExpanded = (highlightId) => {
+    if (expandedHighlights.has(highlightId)) {
+      expandedHighlights.delete(highlightId);
+    } else {
+      expandedHighlights.add(highlightId);
+    }
+    expandedHighlights = new Set(expandedHighlights); // Trigger reactivity
   };
 
   async function fetchHighlights() {
@@ -86,7 +97,7 @@
       highlights = response.data || [];
       loading = false;
     } catch (err) {
-      error = err.message || 'Failed to load featured contributions';
+      error = err.message || 'Failed to load highlighted contributions';
       loading = false;
     }
   }
@@ -151,7 +162,7 @@
       <div class="py-4">
         <div>
           <p class="text-sm text-gray-700 mb-3">
-            <span class="font-heading font-semibold text-gray-900">Get Highlighted!</span> Submit impactful or pioneering work to get featured.
+            <span class="font-heading font-semibold text-gray-900">Get Highlighted!</span> Submit impactful or pioneering work to get highlighted.
           </p>
           <button
             onclick={() => push('/submit-contribution')}
@@ -170,7 +181,7 @@
           <svg class="h-5 w-5 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
             <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
           </svg>
-          <p class="text-sm text-gray-500">No featured contributions yet</p>
+          <p class="text-sm text-gray-500">No highlighted contributions yet</p>
         </div>
       </div>
     {/if}
@@ -178,7 +189,7 @@
     <!-- Default card style (used in Dashboard) - Use ContributionCard -->
     <div class="space-y-3">
       {#each highlights as highlight}
-        <ContributionCard 
+        <ContributionCard
           contribution={{
             id: highlight.id,
             contribution_type: highlight.contribution_type,
@@ -217,8 +228,12 @@
             count: 1,
             category: highlight.category || category || $currentCategory
           }}
+          submission={{
+            evidence_items: highlight.contribution_details?.evidence_items || [],
+            notes: highlight.contribution_details?.notes
+          }}
           showUser={true}
-          showExpand={false}
+          showExpand={true}
           category={category || $currentCategory}
         />
       {/each}
@@ -235,10 +250,47 @@
         </div>
         <div class="space-y-3">
           {#each highlights as highlight}
-          <div class="border-l-4 border-yellow-400 pl-4 py-2">
-          <h3 class="font-semibold text-gray-900">{highlight.title}</h3>
-          <p class="text-sm text-gray-600 mt-1">{highlight.description}</p>
-          <div class="flex items-center gap-3 mt-2 text-xs text-gray-500">
+          {@const hasEvidence = highlight.contribution_details?.evidence_items?.length > 0}
+          {@const isExpanded = expandedHighlights.has(highlight.id)}
+          <div class="border-l-4 border-yellow-400 pl-4 py-2 relative">
+            {#if hasEvidence}
+              <button
+                onclick={() => toggleExpanded(highlight.id)}
+                class="absolute top-2 right-0 p-1 text-gray-400 hover:text-gray-600 transition-colors"
+                title="{isExpanded ? 'Hide' : 'Show'} evidence"
+              >
+                <svg
+                  class="w-4 h-4 transition-transform {isExpanded ? 'rotate-180' : ''}"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+            {/if}
+            <h3 class="font-semibold text-gray-900 pr-6">{highlight.title}</h3>
+            <div class="markdown-content text-sm text-gray-600 mt-1">{@html parseMarkdown(highlight.description)}</div>
+            {#if hasEvidence && isExpanded}
+              <div class="mt-2">
+                <h5 class="text-xs font-medium text-gray-700 mb-1">Evidence</h5>
+                <ul class="space-y-1">
+                  {#each highlight.contribution_details.evidence_items as evidence}
+                    <li class="text-xs text-gray-600">
+                      {#if evidence.description}
+                        • {evidence.description}
+                      {/if}
+                      {#if evidence.url}
+                        <a href={evidence.url} target="_blank" class="text-primary-600 underline ml-1">
+                          View URL
+                        </a>
+                      {/if}
+                    </li>
+                  {/each}
+                </ul>
+              </div>
+            {/if}
+            <div class="flex items-center gap-3 mt-2 text-xs text-gray-500">
             <Avatar
               user={{
                 name: highlight.user_name,
@@ -295,11 +347,48 @@
     <!-- Highlight style (used in ParticipantProfile) -->
     <div class="space-y-4">
       {#each highlights as highlight}
-        <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4">
+        {@const hasEvidence = highlight.contribution_details?.evidence_items?.length > 0}
+        {@const isExpanded = expandedHighlights.has(highlight.id)}
+        <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 relative">
+          {#if hasEvidence}
+            <button
+              onclick={() => toggleExpanded(highlight.id)}
+              class="absolute top-4 right-4 p-1 text-gray-400 hover:text-gray-600 transition-colors"
+              title="{isExpanded ? 'Hide' : 'Show'} evidence"
+            >
+              <svg
+                class="w-5 h-5 transition-transform {isExpanded ? 'rotate-180' : ''}"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+          {/if}
           <div class="flex justify-between items-start">
-            <div class="flex-1">
+            <div class="flex-1 pr-8">
               <h4 class="text-lg font-semibold text-gray-900">{highlight.title}</h4>
-              <p class="mt-2 text-sm text-gray-700">{highlight.description}</p>
+              <div class="markdown-content mt-2 text-sm text-gray-700">{@html parseMarkdown(highlight.description)}</div>
+              {#if hasEvidence && isExpanded}
+                <div class="mt-3 pt-3 border-t border-yellow-200">
+                  <h5 class="text-xs font-medium text-gray-700 mb-1">Evidence</h5>
+                  <ul class="space-y-1">
+                    {#each highlight.contribution_details.evidence_items as evidence}
+                      <li class="text-xs text-gray-600">
+                        {#if evidence.description}
+                          • {evidence.description}
+                        {/if}
+                        {#if evidence.url}
+                          <a href={evidence.url} target="_blank" class="text-primary-600 underline ml-1">
+                            View URL
+                          </a>
+                        {/if}
+                      </li>
+                    {/each}
+                  </ul>
+                </div>
+              {/if}
               <div class="mt-3 flex items-center gap-4 text-xs text-gray-600">
                 <div class="flex items-center gap-2">
                   <Avatar

--- a/frontend/src/components/SubmissionCard.svelte
+++ b/frontend/src/components/SubmissionCard.svelte
@@ -456,7 +456,7 @@
                     {#if createHighlight}
                       <div class="px-4 py-3 bg-white border-t border-yellow-300 space-y-3">
                         <p class="text-xs text-yellow-700 mb-2">
-                          Featured contributions are highlighted on the dashboard and earn special recognition
+                          Highlighted contributions are displayed on the dashboard and earn special recognition
                         </p>
                         
                         <div>
@@ -477,7 +477,7 @@
                           </label>
                           <textarea
                             bind:value={highlightDescription}
-                            placeholder="Describe why this contribution is being featured..."
+                            placeholder="Describe why this contribution is being highlighted..."
                             rows="3"
                             class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-yellow-500"
                           ></textarea>

--- a/frontend/src/routes/ContributionTypeDetail.svelte
+++ b/frontend/src/routes/ContributionTypeDetail.svelte
@@ -3,7 +3,7 @@
   import { format } from 'date-fns';
   import { marked } from 'marked';
   import RecentContributions from '../components/RecentContributions.svelte';
-  import FeaturedContributions from '../components/FeaturedContributions.svelte';
+  import HighlightedContributions from '../components/HighlightedContributions.svelte';
   import LeaderboardTable from '../components/LeaderboardTable.svelte';
   import StatCard from '../components/StatCard.svelte';
   import Icons from '../components/Icons.svelte';
@@ -456,10 +456,10 @@
       </div>
     {/if}
 
-    <!-- Featured User Contributions -->
-    <FeaturedContributions
+    <!-- Highlighted User Contributions -->
+    <HighlightedContributions
       contributionTypeId={params.id}
-      title="Featured Contributions"
+      title="Highlighted Contributions"
       cardStyle="compact"
       showViewAll={false}
       className="mb-6"

--- a/frontend/src/routes/Dashboard.svelte
+++ b/frontend/src/routes/Dashboard.svelte
@@ -3,7 +3,7 @@
   import { format } from 'date-fns';
   import StatCard from '../components/StatCard.svelte';
   import TopLeaderboard from '../components/TopLeaderboard.svelte';
-  import FeaturedContributions from '../components/FeaturedContributions.svelte';
+  import HighlightedContributions from '../components/HighlightedContributions.svelte';
   import RecentContributions from '../components/RecentContributions.svelte';
   import Avatar from '../components/Avatar.svelte';
   import { contributionsAPI, usersAPI, statsAPI, leaderboardAPI, validatorsAPI, buildersAPI } from '../lib/api';
@@ -240,7 +240,7 @@
       />
     </div>
     
-    <!-- Featured Highlights -->
+    <!-- Highlighted Contributions -->
     <div class="space-y-4">
       <div class="flex items-center justify-between">
         <div class="flex items-center gap-2">
@@ -249,7 +249,7 @@
               <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
             </svg>
           </div>
-          <h2 class="text-lg font-semibold text-gray-900">Featured Contributions</h2>
+          <h2 class="text-lg font-semibold text-gray-900">Highlighted Contributions</h2>
         </div>
         <button
           onclick={() => push($currentCategory === 'builder' ? '/builders/contributions/highlights' : $currentCategory === 'validator' ? '/validators/contributions/highlights' : '/contributions/highlights')}
@@ -261,7 +261,7 @@
           </svg>
         </button>
       </div>
-      <FeaturedContributions 
+      <HighlightedContributions
         showHeader={false}
         showViewAll={false}
         cardStyle="highlight"

--- a/frontend/src/routes/Highlights.svelte
+++ b/frontend/src/routes/Highlights.svelte
@@ -3,6 +3,8 @@
   import { push } from 'svelte-spa-router';
   import { format } from 'date-fns';
   import { contributionsAPI } from '../lib/api';
+  import { currentCategory } from '../stores/category.js';
+  import { parseMarkdown } from '../lib/markdownLoader.js';
   import Avatar from '../components/Avatar.svelte';
   
   // State management
@@ -26,8 +28,15 @@
     try {
       loading = true;
       error = null;
-      
-      const response = await contributionsAPI.getAllHighlights();
+
+      const params = {};
+
+      // Filter by current category
+      if ($currentCategory && $currentCategory !== 'global') {
+        params.category = $currentCategory;
+      }
+
+      const response = await contributionsAPI.getAllHighlights(params);
       highlights = response.data || [];
       
       // Extract unique contribution types from highlights
@@ -56,13 +65,20 @@
   onMount(() => {
     fetchHighlights();
   });
+
+  // Re-fetch when category changes
+  $effect(() => {
+    if ($currentCategory) {
+      fetchHighlights();
+    }
+  });
 </script>
 
 <div class="space-y-6 sm:space-y-8">
   <!-- Header -->
   <div class="flex justify-between items-center">
     <div>
-      <h1 class="text-2xl font-bold text-gray-900">Contributions > Featured</h1>
+      <h1 class="text-2xl font-bold text-gray-900">Contributions > Highlights</h1>
       <p class="mt-1 text-sm text-gray-500">
         Exceptional contributions from our community members
       </p>
@@ -106,69 +122,98 @@
       </svg>
       <h3 class="mt-2 text-sm font-medium text-gray-900">No highlights found</h3>
       <p class="mt-1 text-sm text-gray-500">
-        {selectedType === 'all' ? 'No featured contributions yet.' : `No highlights for ${selectedType}.`}
+        {selectedType === 'all' ? 'No highlighted contributions yet.' : `No highlights for ${selectedType}.`}
       </p>
     </div>
   {:else}
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       {#each filteredHighlights as highlight}
-        <div class="bg-white shadow rounded-lg p-6 hover:shadow-lg transition-shadow">
-          <div class="flex items-start justify-between mb-4">
-            <div class="flex items-center gap-2">
-              <svg class="w-5 h-5 text-yellow-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
-              </svg>
-              <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                {highlight.contribution_type_name}
+        {@const hasEvidence = highlight.contribution_details?.evidence_items?.length > 0}
+        {#snippet highlightCard()}
+          <div class="bg-white shadow rounded-lg p-6 hover:shadow-lg transition-shadow">
+            <div class="flex items-start justify-between mb-4">
+              <div class="flex items-center gap-2">
+                <svg class="w-5 h-5 text-yellow-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
+                </svg>
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                  {highlight.contribution_type_name}
+                </span>
+                {#if hasEvidence}
+                  <svg class="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" title="{highlight.contribution_details.evidence_items.length} evidence item{highlight.contribution_details.evidence_items.length > 1 ? 's' : ''}">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
+                  </svg>
+                {/if}
+              </div>
+              <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-purple-100 text-purple-800">
+                {highlight.contribution_points} pts
               </span>
             </div>
-            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-purple-100 text-purple-800">
-              {highlight.contribution_points} pts
-            </span>
-          </div>
 
-          <h3 class="text-lg font-semibold text-gray-900 mb-2">
-            {highlight.title}
-          </h3>
-          
-          <p class="text-sm text-gray-600 mb-4">
-            {highlight.description}
-          </p>
-          
-          <div class="flex items-center justify-between text-sm">
-            <div class="flex items-center gap-3">
-              <Avatar
-                user={{
-                  name: highlight.user_name,
-                  address: highlight.user_address,
-                  profile_image_url: highlight.user_profile_image_url,
-                  validator: highlight.user_validator,
-                  builder: highlight.user_builder,
-                  steward: highlight.user_steward,
-                  has_validator_waitlist: highlight.user_has_validator_waitlist,
-                  has_builder_welcome: highlight.user_has_builder_welcome
-                }}
-                size="xs"
-                clickable={true}
-              />
-              <button 
-                class="text-primary-600 hover:text-primary-700 font-medium"
-                onclick={() => push(`/participant/${highlight.user_address}`)}
-              >
-                {highlight.user_name || `${highlight.user_address.slice(0, 6)}...${highlight.user_address.slice(-4)}`}
-              </button>
-              <span class="text-gray-400">•</span>
-              <span class="text-gray-500">{formatDate(highlight.contribution_date)}</span>
+            <h3 class="text-lg font-semibold text-gray-900 mb-2">
+              {highlight.title}
+            </h3>
+
+            <div class="markdown-content text-sm text-gray-600 mb-4">
+              {@html parseMarkdown(highlight.description)}
             </div>
-            
-            <button
-              onclick={() => push(`/contribution-type/${highlight.contribution_type_id}`)}
-              class="text-xs text-gray-500 hover:text-gray-700"
-            >
-              View Type →
-            </button>
+
+            {#if hasEvidence}
+              <div class="mb-4 pt-3 border-t border-gray-200">
+                <h5 class="text-xs font-medium text-gray-700 mb-1">Evidence</h5>
+                <ul class="space-y-1">
+                  {#each highlight.contribution_details.evidence_items as evidence}
+                    <li class="text-xs text-gray-600">
+                      {#if evidence.description}
+                        • {evidence.description}
+                      {/if}
+                      {#if evidence.url}
+                        <a href={evidence.url} target="_blank" class="text-primary-600 underline ml-1">
+                          View URL
+                        </a>
+                      {/if}
+                    </li>
+                  {/each}
+                </ul>
+              </div>
+            {/if}
+
+            <div class="flex items-center justify-between text-sm">
+              <div class="flex items-center gap-3">
+                <Avatar
+                  user={{
+                    name: highlight.user_name,
+                    address: highlight.user_address,
+                    profile_image_url: highlight.user_profile_image_url,
+                    validator: highlight.user_validator,
+                    builder: highlight.user_builder,
+                    steward: highlight.user_steward,
+                    has_validator_waitlist: highlight.user_has_validator_waitlist,
+                    has_builder_welcome: highlight.user_has_builder_welcome
+                  }}
+                  size="xs"
+                  clickable={true}
+                />
+                <button
+                  class="text-primary-600 hover:text-primary-700 font-medium"
+                  onclick={() => push(`/participant/${highlight.user_address}`)}
+                >
+                  {highlight.user_name || `${highlight.user_address.slice(0, 6)}...${highlight.user_address.slice(-4)}`}
+                </button>
+                <span class="text-gray-400">•</span>
+                <span class="text-gray-500">{formatDate(highlight.contribution_date)}</span>
+              </div>
+
+              <button
+                onclick={() => push(`/contribution-type/${highlight.contribution_type_id}`)}
+                class="text-xs text-gray-500 hover:text-gray-700"
+              >
+                View Type →
+              </button>
+            </div>
           </div>
-        </div>
+        {/snippet}
+        {@render highlightCard()}
       {/each}
     </div>
   {/if}

--- a/frontend/src/routes/Profile.svelte
+++ b/frontend/src/routes/Profile.svelte
@@ -3,7 +3,7 @@
   import { push, querystring } from 'svelte-spa-router';
   import { format } from 'date-fns';
   import RecentContributions from '../components/RecentContributions.svelte';
-  import FeaturedContributions from '../components/FeaturedContributions.svelte';
+  import HighlightedContributions from '../components/HighlightedContributions.svelte';
   import ValidatorStatus from '../components/ValidatorStatus.svelte';
   import ProfileStats from '../components/ProfileStats.svelte';
   import ContributionBreakdown from '../components/ContributionBreakdown.svelte';
@@ -970,10 +970,10 @@
         {#if !isValidatorOnly}
           <!-- Highlights Section -->
           <div class="px-4 mt-6">
-            <FeaturedContributions
+            <HighlightedContributions
               userId={participant.address}
               limit={5}
-              title="Featured Contributions"
+              title="Highlighted Contributions"
               cardStyle="highlight"
               showViewAll={false}
               isOwnProfile={isOwnProfile}
@@ -1036,11 +1036,11 @@
             />
           </div>
           
-          <!-- Featured Section -->
-          <FeaturedContributions
+          <!-- Highlighted Section -->
+          <HighlightedContributions
             userId={participant.address}
             limit={3}
-            title="Featured"
+            title="Highlights"
             cardStyle="compact"
             showViewAll={false}
             isOwnProfile={isOwnProfile}
@@ -1116,11 +1116,11 @@
             </div>
           {/if}
           
-          <!-- Featured Section -->
-          <FeaturedContributions
+          <!-- Highlighted Section -->
+          <HighlightedContributions
             userId={participant.address}
             limit={3}
-            title="Featured"
+            title="Highlights"
             cardStyle="compact"
             showViewAll={false}
             isOwnProfile={isOwnProfile}
@@ -1210,11 +1210,11 @@
             />
           </div>
           
-          <!-- Featured Section -->
-          <FeaturedContributions
+          <!-- Highlighted Section -->
+          <HighlightedContributions
             userId={participant.address}
             limit={3}
-            title="Featured"
+            title="Highlights"
             cardStyle="compact"
             showViewAll={false}
             isOwnProfile={isOwnProfile}

--- a/frontend/src/routes/Waitlist.svelte
+++ b/frontend/src/routes/Waitlist.svelte
@@ -18,7 +18,7 @@
   let topWaitlistUsers = $state([]);  // Top 10 for Race to Testnet
   let newestWaitlistUsers = $state([]);
   let recentlyGraduated = $state([]);
-  let featuredContributions = $state([]);
+  let highlightedContributions = $state([]);
   let topLoading = $state(true);  // Loading for top section
   let error = $state(null);
   let statistics = $state({
@@ -35,14 +35,14 @@
   
   let statsLoading = $state(true);
   let graduatesLoading = $state(true);
-  let featuredLoading = $state(true);
+  let highlightedLoading = $state(true);
   
   onMount(async () => {
     await Promise.all([
       fetchTopWaitlistUsers(),  // Fast: only top 10
       fetchNewestWaitlistUsers(),  // Get 5 newest for sidebar
       fetchRecentlyGraduated(),
-      fetchFeaturedContributions(),
+      fetchHighlightedContributions(),
       fetchStats()  // Fetch stats separately
     ]);
   });
@@ -149,24 +149,24 @@
     }
   }
   
-  async function fetchFeaturedContributions() {
+  async function fetchHighlightedContributions() {
     try {
-      featuredLoading = true;
+      highlightedLoading = true;
       
-      // Fetch featured contributions from waitlist users only
+      // Fetch highlighted contributions from waitlist users only
       const response = await contributionsAPI.getHighlights({
         waitlist_only: true,
         limit: 5
       });
       
       if (response.data) {
-        featuredContributions = response.data;
+        highlightedContributions = response.data;
       }
       
-      featuredLoading = false;
+      highlightedLoading = false;
     } catch (err) {
-      console.error('Failed to load featured contributions:', err);
-      featuredLoading = false;
+      console.error('Failed to load highlighted contributions:', err);
+      highlightedLoading = false;
     }
   }
   
@@ -376,9 +376,9 @@
     </div>
   </div>
   
-  <!-- Second Row: Featured Contributions and Newest Participants -->
+  <!-- Second Row: Highlighted Contributions and Newest Participants -->
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-    <!-- Featured Contributions -->
+    <!-- Highlighted Contributions -->
     <div class="space-y-4">
       <div class="flex items-center justify-between">
         <div class="flex items-center gap-2">
@@ -387,7 +387,7 @@
               <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"></path>
             </svg>
           </div>
-          <h2 class="text-lg font-semibold text-gray-900">Featured Contributions</h2>
+          <h2 class="text-lg font-semibold text-gray-900">Highlighted Contributions</h2>
         </div>
         <button
           onclick={() => push('/validators/contributions/highlights')}
@@ -400,17 +400,17 @@
         </button>
       </div>
       
-      {#if featuredLoading}
+      {#if highlightedLoading}
         <div class="flex justify-center items-center p-8">
           <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
         </div>
-      {:else if featuredContributions.length === 0}
+      {:else if highlightedContributions.length === 0}
         <div class="bg-gray-50 rounded-lg p-6 text-center">
-          <p class="text-gray-500">No featured contributions yet.</p>
+          <p class="text-gray-500">No highlighted contributions yet.</p>
         </div>
       {:else}
         <div class="space-y-3">
-          {#each featuredContributions.slice(0, 3) as highlight}
+          {#each highlightedContributions.slice(0, 3) as highlight}
             <ContributionCard 
               contribution={highlight.contribution}
               submission={{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "santiago",
+  "name": "havana",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary
- Renamed "Featured Contributions" to "Highlighted Contributions" throughout the codebase for consistency
- Added evidence display to highlighted contribution cards with expand/collapse functionality
- Added category filtering support to the Highlights page

## Changes

### Frontend
- Renamed `FeaturedContributions.svelte` → `HighlightedContributions.svelte`
- Added expandable evidence sections with chevron button (top right of cards)
- Added markdown parsing for highlight descriptions
- Updated all components and routes to use "Highlighted" terminology
- Added category filtering on Highlights page with reactive updates

### Backend
- Added `prefetch_related('contribution__evidence_items')` to highlights endpoints
- Fixed `LightContributionSerializer` to properly serialize evidence items
- Fixed syntax error in `leaderboard/models.py` (missing closing parenthesis)

## UI Changes
- Evidence items now display with description and clickable "View URL" links
- Chevron button appears in top right of highlight cards (only when evidence exists)
- Click chevron to expand/collapse evidence section
- Evidence shown in both "compact" and "highlight" card styles