### PR TITLE
Always fetch operator address on every validator sync

### DIFF
--- a/backend/validators/genlayer_validators_service.py
+++ b/backend/validators/genlayer_validators_service.py
@@ -394,11 +394,12 @@ class GenLayerValidatorsService:
         # Track if anything changed
         has_changes = is_new
 
-        # Fetch operator address if new or not yet set
-        if is_new or not wallet.operator_address:
-            operator_address = self.fetch_operator_for_wallet(address)
-            if operator_address:
-                wallet.operator_address = operator_address.lower()
+        # Always fetch operator address to capture updates (like identity)
+        operator_address = self.fetch_operator_for_wallet(address)
+        if operator_address:
+            new_operator_address = operator_address.lower()
+            if wallet.operator_address != new_operator_address:
+                wallet.operator_address = new_operator_address
                 has_changes = True
 
         # Try to link to existing Validator model if not already linked


### PR DESCRIPTION
## Summary
Ensures operator addresses are consistently captured for all validators on every sync run, matching the pattern used for identity and stake metadata. Fixes validators that may have empty operator_address due to previous factory contract failures or unavailability.

## Changes
- Always fetch operator address from factory contract during sync
- Compare to existing value and only update if changed
- No impact on manually linked validators (auto-linking only triggers when no operator FK exists)

## Testing
Verify that validators previously missing operator_address now get populated on next sync run.