### PR TITLE
Add active validators column to validator leaderboard

### DIFF
--- a/frontend/src/components/LeaderboardTable.svelte
+++ b/frontend/src/components/LeaderboardTable.svelte
@@ -1,6 +1,7 @@
 <script>
   import { push } from 'svelte-spa-router';
   import Avatar from './Avatar.svelte';
+  import { currentCategory } from '../stores/category.js';
 
   let {
     entries = [],
@@ -60,6 +61,11 @@
             <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Points
             </th>
+            {#if $currentCategory === 'validator'}
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Active Validators
+              </th>
+            {/if}
           </tr>
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
@@ -99,6 +105,23 @@
               <td class="px-6 py-4 whitespace-nowrap">
                 <div class="text-sm text-gray-900 font-medium">{entry.total_points}</div>
               </td>
+              {#if $currentCategory === 'validator'}
+                <td class="px-6 py-4 whitespace-nowrap">
+                  {#if entry.active_validators_count === null}
+                    <span class="inline-block font-semibold rounded-full px-2.5 py-1.5 text-xs bg-gray-100 text-gray-500">
+                      No validator
+                    </span>
+                  {:else}
+                    <a
+                      href="/validators/participants"
+                      onclick={(e) => { e.preventDefault(); push('/validators/participants'); }}
+                      class="inline-block font-semibold rounded-full px-2.5 py-1.5 text-xs bg-blue-100 text-blue-800 hover:bg-blue-200 cursor-pointer transition-colors"
+                    >
+                      {entry.active_validators_count} active
+                    </a>
+                  {/if}
+                </td>
+              {/if}
             </tr>
           {/each}
         </tbody>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "havana",
+  "name": "monterrey",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary
- Added "Active Validators" column to the validator leaderboard showing each participant's active validator wallet count
- Optimized database queries using annotated counts to avoid N+1 performance issues
- Displays contextual badges: gray "No validator" for users without wallets, blue "X active" for users with wallets

## Implementation Details
- Backend: Added `active_validators_count` field to `LeaderboardEntrySerializer` with queryset annotation
- Frontend: New column displays in validator category only with blue clickable badge linking to Validators view
- Returns null when no validator wallets exist to distinguish from "0 active" state

## Test Plan
- Verify validator leaderboard displays the new column with correct counts
- Confirm "No validator" gray badge shows for users without linked validator wallets
- Confirm blue badge shows for users with validators (both "0 active" and "X active")
- Click badge to confirm navigation to validators view works