### PR TITLE
Add bulk rejection feature for steward submissions

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -185,6 +185,10 @@ export const stewardAPI = {
   // Assign submission to a steward
   assignSubmission: (id, data) => api.post(`/steward-submissions/${id}/assign/`, data),
 
+  // Bulk reject multiple submissions
+  bulkRejectSubmissions: (submissionIds, staffReply) =>
+    api.post('/steward-submissions/bulk-reject/', { submission_ids: submissionIds, staff_reply: staffReply }),
+
   // Working Groups
   getWorkingGroups: () => api.get('/stewards/working-groups/'),
   getWorkingGroup: (id) => api.get(`/stewards/working-groups/${id}/`),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "barcelona-v1",
+  "name": "berlin",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary
- Added ability for stewards to bulk reject multiple noisy submissions at once
- Includes checkbox selection per submission, bulk action bar, and confirmation dialog with custom rejection message
- Backend validates submissions are pending/more_info_needed before rejecting

## Changes
- Backend: New `bulk_reject` endpoint that rejects multiple submissions in a single request
- Frontend API: New `bulkRejectSubmissions` method
- Frontend: Selection state, handlers, dialog UI, and checkboxes on pending submissions