### PR TITLE
Restrict contribution submissions to users with required roles

### DIFF
--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -657,6 +657,25 @@ class SubmittedContributionViewSet(viewsets.ModelViewSet):
                     status=status.HTTP_400_BAD_REQUEST
                 )
 
+        # Validate category restrictions based on user role
+        contribution_type_id = data.get('contribution_type')
+        if contribution_type_id:
+            try:
+                contribution_type = ContributionType.objects.select_related('category').get(id=contribution_type_id)
+                if contribution_type.category:
+                    if contribution_type.category.slug == 'builder' and not hasattr(request.user, 'builder'):
+                        return Response(
+                            {'error': 'You must complete the Builder Welcome journey before submitting builder contributions.'},
+                            status=status.HTTP_403_FORBIDDEN
+                        )
+                    if contribution_type.category.slug == 'validator' and not hasattr(request.user, 'validator'):
+                        return Response(
+                            {'error': 'You must complete the Validator Waitlist journey before submitting validator contributions.'},
+                            status=status.HTTP_403_FORBIDDEN
+                        )
+            except ContributionType.DoesNotExist:
+                pass
+
         serializer = self.get_serializer(data=data)
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)

--- a/frontend/src/lib/components/ContributionSelection.svelte
+++ b/frontend/src/lib/components/ContributionSelection.svelte
@@ -15,8 +15,13 @@
 		providedContributionTypes = null,  // Allow passing types from parent
 		disabled = false,  // Disable selection when locked (e.g., mission)
 		selectedMission = $bindable(null),  // Currently selected mission
+		isValidator = true,
+		isBuilder = true,
 		onSelectionChange = () => {}
 	} = $props();
+
+	let validatorTabDisabled = $derived(!isValidator && !stewardMode);
+	let builderTabDisabled = $derived(!isBuilder && !stewardMode);
 
 	let contributionTypes = $state([]);
 	let missions = $state([]);  // All missions
@@ -268,8 +273,10 @@
 				type="button"
 				class="category-btn"
 				class:active={selectedCategory === 'validator'}
+				class:disabled={validatorTabDisabled}
 				style={selectedCategory === 'validator' ? 'background: #e0f2fe; color: #0369a1;' : ''}
-				onclick={() => selectCategory('validator')}
+				onclick={() => !validatorTabDisabled && selectCategory('validator')}
+				disabled={validatorTabDisabled}
 			>
 				Validator
 			</button>
@@ -277,12 +284,26 @@
 				type="button"
 				class="category-btn"
 				class:active={selectedCategory === 'builder'}
+				class:disabled={builderTabDisabled}
 				style={selectedCategory === 'builder' ? 'background: #ffedd5; color: #c2410c;' : ''}
-				onclick={() => selectCategory('builder')}
+				onclick={() => !builderTabDisabled && selectCategory('builder')}
+				disabled={builderTabDisabled}
 			>
 				Builder
 			</button>
 		</div>
+
+		{#if validatorTabDisabled || builderTabDisabled}
+			<div class="category-locked-message">
+				{#if validatorTabDisabled && builderTabDisabled}
+					Complete a journey to submit contributions: <a href="#/validators/waitlist">Validator Waitlist</a> or <a href="#/builders/welcome">Builder Welcome</a>
+				{:else if validatorTabDisabled}
+					<a href="#/validators/waitlist">Complete the Validator Waitlist journey</a> to submit validator contributions.
+				{:else}
+					<a href="#/builders/welcome">Complete the Builder Welcome journey</a> to submit builder contributions.
+				{/if}
+			</div>
+		{/if}
 
 		<!-- Contribution Type Dropdown/Search -->
 		<div class="contribution-type-selector">
@@ -493,6 +514,31 @@
 	.category-btn.active {
 		font-weight: 600;
 		position: relative;
+	}
+
+	.category-btn.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.category-btn.disabled:hover {
+		background: transparent;
+	}
+
+	.category-locked-message {
+		padding: 0.75rem 1rem;
+		background: #fef3c7;
+		border: 1px solid #f59e0b;
+		border-radius: 0.375rem;
+		margin-top: 0.75rem;
+		font-size: 0.875rem;
+		color: #92400e;
+	}
+
+	.category-locked-message a {
+		color: #d97706;
+		font-weight: 500;
+		text-decoration: underline;
 	}
 
 	.contribution-type-selector {

--- a/frontend/src/routes/SubmitContribution.svelte
+++ b/frontend/src/routes/SubmitContribution.svelte
@@ -1,6 +1,7 @@
 <script>
   import { push, querystring } from 'svelte-spa-router';
   import { authState } from '../lib/auth.js';
+  import { userStore } from '../lib/userStore';
   import { onMount } from 'svelte';
   import api, { contributionsAPI } from '../lib/api.js';
   import ContributionSelection from '../lib/components/ContributionSelection.svelte';
@@ -346,6 +347,8 @@
           defaultContributionType={formData.contribution_type}
           onlySubmittable={true}
           stewardMode={false}
+          isValidator={!!$userStore.user?.validator}
+          isBuilder={!!$userStore.user?.builder}
           onSelectionChange={handleSelectionChange}
         />
       </div>


### PR DESCRIPTION
Enforce role-based restrictions on contribution submissions. Non-validators cannot submit validator contributions, and non-builders cannot submit builder contributions.

Backend validation checks user roles (validator/builder model instances) and returns 403 with descriptive errors. Frontend disables tabs and shows links to complete the appropriate journey.

Changes across 3 files:
- backend/contributions/views.py: role validation in SubmittedContributionViewSet.create()
- frontend/src/lib/components/ContributionSelection.svelte: disabled state and UI message
- frontend/src/routes/SubmitContribution.svelte: pass user roles to component