### PR TITLE
Add mission filtering to AllContributions

### DIFF
--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -206,7 +206,7 @@ class ContributionViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ContributionSerializer
     permission_classes = [permissions.AllowAny]  # Allow read-only access without authentication
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
-    filterset_fields = ['user', 'contribution_type']
+    filterset_fields = ['user', 'contribution_type', 'mission']
     search_fields = ['notes', 'user__email', 'user__name', 'contribution_type__name']
     ordering_fields = ['contribution_date', 'created_at', 'points', 'frozen_global_points']
     ordering = ['-contribution_date']

--- a/frontend/src/components/Missions.svelte
+++ b/frontend/src/components/Missions.svelte
@@ -258,7 +258,12 @@
       <div class="px-4 py-3 border-b last:border-b-0 hover:bg-gray-50 transition-colors">
         <!-- Title row with badges and submit button -->
         <div class="flex items-center gap-3 mb-2 flex-wrap">
-          <h3 class="text-base font-bold font-heading text-gray-900">{mission.name}</h3>
+          <button
+            onclick={() => push(`/all-contributions?mission=${mission.id}&category=${$currentCategory !== 'global' ? $currentCategory : 'validator'}`)}
+            class="text-base font-bold font-heading text-gray-900 {colors.titleTextHover} transition-colors text-left"
+          >
+            {mission.name}
+          </button>
 
           {#if mission.contribution_type_details}
             <Badge


### PR DESCRIPTION
## Summary
Enable users to filter contributions by mission in the AllContributions view and make mission titles clickable.

- Backend: Added mission filtering to ContributionViewSet
- Frontend: Mission filtering state management and URL parameters in AllContributions
- Frontend: Mission titles are now clickable, navigating to filtered contributions

## Testing
Test selecting a mission from dropdown, applying filters, and clicking mission titles to verify filtering works correctly.