### PR TITLE
Add CRON_SYNC_TOKEN to App Runner deployment

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -79,3 +79,7 @@ GITHUB_ENCRYPTION_KEY=your_encryption_key_here
 # Select "reCAPTCHA v2" > "I'm not a robot" Checkbox
 RECAPTCHA_PUBLIC_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 RECAPTCHA_PRIVATE_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+
+# Cron Sync Token
+# Used for authenticating cron job requests to sync validators
+CRON_SYNC_TOKEN=your_cron_sync_token_here

--- a/backend/deploy-apprunner.sh
+++ b/backend/deploy-apprunner.sh
@@ -211,7 +211,8 @@ if aws apprunner describe-service --service-arn arn:aws:apprunner:$REGION:$ACCOU
           "GITHUB_ENCRYPTION_KEY": "$SSM_PREFIX/prod/github_encryption_key",
           "GITHUB_REPO_TO_STAR": "$SSM_PREFIX/prod/github_repo_to_star",
           "RECAPTCHA_PUBLIC_KEY": "$SSM_PREFIX/prod/recaptcha_public_key",
-          "RECAPTCHA_PRIVATE_KEY": "$SSM_PREFIX/prod/recaptcha_private_key"
+          "RECAPTCHA_PRIVATE_KEY": "$SSM_PREFIX/prod/recaptcha_private_key",
+          "CRON_SYNC_TOKEN": "$SSM_PREFIX/prod/cron_sync_token"
         },
         "StartCommand": "./startup.sh gunicorn --bind 0.0.0.0:8000 --timeout 180 --workers 2 tally.wsgi:application"
       },
@@ -223,8 +224,6 @@ if aws apprunner describe-service --service-arn arn:aws:apprunner:$REGION:$ACCOU
     }
   },
   "InstanceConfiguration": {
-    "Cpu": "0.25 vCPU",
-    "Memory": "0.5 GB",
     "InstanceRoleArn": "arn:aws:iam::$ACCOUNT_ID:role/AppRunnerInstanceRole"
   },
   "HealthCheckConfiguration": {
@@ -293,7 +292,8 @@ else
           "GITHUB_ENCRYPTION_KEY": "$SSM_PREFIX/prod/github_encryption_key",
           "GITHUB_REPO_TO_STAR": "$SSM_PREFIX/prod/github_repo_to_star",
           "RECAPTCHA_PUBLIC_KEY": "$SSM_PREFIX/prod/recaptcha_public_key",
-          "RECAPTCHA_PRIVATE_KEY": "$SSM_PREFIX/prod/recaptcha_private_key"
+          "RECAPTCHA_PRIVATE_KEY": "$SSM_PREFIX/prod/recaptcha_private_key",
+          "CRON_SYNC_TOKEN": "$SSM_PREFIX/prod/cron_sync_token"
         },
         "StartCommand": "./startup.sh gunicorn --bind 0.0.0.0:8000 --timeout 180 --workers 2 tally.wsgi:application"
       },
@@ -305,8 +305,6 @@ else
     }
   },
   "InstanceConfiguration": {
-    "Cpu": "0.25 vCPU",
-    "Memory": "0.5 GB",
     "InstanceRoleArn": "arn:aws:iam::$ACCOUNT_ID:role/AppRunnerInstanceRole"
   },
   "HealthCheckConfiguration": {


### PR DESCRIPTION
## Summary
- Add CRON_SYNC_TOKEN as a runtime environment secret for cron job authentication
- Remove hardcoded CPU and Memory configuration to allow management via AWS console

The CRON_SYNC_TOKEN secret is now injected from AWS SSM Parameter Store at `/tally/prod/cron_sync_token`. Instance sizing can be adjusted directly from the App Runner dashboard without modifying the deployment script.