### PR TITLE
Fix mission filtering and top contributors visibility

### DIFF
--- a/frontend/src/routes/AllContributions.svelte
+++ b/frontend/src/routes/AllContributions.svelte
@@ -215,6 +215,7 @@
         bind:selectedContributionType
         bind:selectedMission
         defaultContributionType={appliedTypeId ? Number(appliedTypeId) : null}
+        defaultMission={appliedMissionId ? Number(appliedMissionId) : null}
         onlySubmittable={false}
       />
     </div>


### PR DESCRIPTION
## Summary
- Fix mission preselection in AllContributions by passing defaultMission prop to ContributionSelection component
- Fix top contributors query by filtering only accepted contributions and removing dead code
- Optimize database queries in top_contributors endpoint

## Test plan
- Navigate to Contributions page and click on a mission name to verify it preselects in AllContributions
- Navigate to a contribution type detail page with accepted contributions and verify top contributors display