### PR TITLE
Fix top contributors list showing empty

### DIFF
--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -111,8 +111,7 @@ class ContributionTypeViewSet(viewsets.ReadOnlyModelViewSet):
 
         # Get top contributors by summing their frozen global points for this type
         top_contributors = Contribution.objects.filter(
-            contribution_type=contribution_type,
-            state='accepted'
+            contribution_type=contribution_type
         ).values('user').annotate(
             total_points=Sum('frozen_global_points'),
             contribution_count=Count('id')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "berlin",
+  "name": "lisbon",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
The top_contributors query was filtering by state='accepted', but the Contribution model does not have a state field. This filter only exists on SubmittedContribution (for pending submissions). Removing the invalid filter resolves the empty list issue.