### PR TITLE
Fix stale Python bytecode in Docker images

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,4 +1,5 @@
-# Python
+# Python - exclude ALL __pycache__ directories (not just root level)
+**/__pycache__/
 __pycache__/
 *.py[cod]
 *$py.class

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,6 +22,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy project
 COPY . .
 
+# Remove any cached Python bytecode that might have been copied
+# This ensures fresh .py files are always used
+RUN find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+RUN find . -name "*.pyc" -delete 2>/dev/null || true
+
 # Make startup script executable
 RUN chmod +x startup.sh
 


### PR DESCRIPTION
Prevent cached .pyc files from executing old code by excluding nested __pycache__ directories in .dockerignore and explicitly removing .pyc files during Docker build.

This fixes the issue where old authentication print statements continued appearing in production logs despite deploying new code that removes these statements.