### PR TITLE
Implement GitHub-style search bar for steward submissions

### DIFF
--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -774,15 +774,29 @@ class SubmittedContributionViewSet(viewsets.ModelViewSet):
 class StewardSubmissionFilterSet(FilterSet):
     """Custom filterset for steward submission filtering."""
     username_search = CharFilter(method='filter_username')
+    exclude_username = CharFilter(method='filter_exclude_username')
     assigned_to = CharFilter(method='filter_assigned_to')
-    exclude_medium_blogpost = BooleanFilter(method='filter_exclude_medium_blogpost')
+    exclude_content = CharFilter(method='filter_exclude_content')
+    include_content = CharFilter(method='filter_include_content')
     exclude_empty_evidence = BooleanFilter(method='filter_exclude_empty_evidence')
+    only_empty_evidence = BooleanFilter(method='filter_only_empty_evidence')
+    exclude_state = CharFilter(method='filter_exclude_state')
     min_accepted_contributions = NumberFilter(method='filter_min_accepted_contributions')
 
     def filter_username(self, queryset, name, value):
         """Filter by submitter name, email, or address (case-insensitive partial match)."""
         if value:
             return queryset.filter(
+                Q(user__name__icontains=value) |
+                Q(user__email__icontains=value) |
+                Q(user__address__icontains=value)
+            )
+        return queryset
+
+    def filter_exclude_username(self, queryset, name, value):
+        """Exclude submissions from users matching the search."""
+        if value:
+            return queryset.exclude(
                 Q(user__name__icontains=value) |
                 Q(user__email__icontains=value) |
                 Q(user__address__icontains=value)
@@ -797,21 +811,44 @@ class StewardSubmissionFilterSet(FilterSet):
             return queryset.filter(assigned_to_id=value)
         return queryset
 
-    def filter_exclude_medium_blogpost(self, queryset, name, value):
-        """Exclude submissions that have Medium blog post URLs in evidence or notes."""
+    def filter_exclude_state(self, queryset, name, value):
+        """Exclude submissions with specific state."""
         if value:
-            # Subquery: check if submission has any evidence with medium.com URL
-            has_medium_evidence = Evidence.objects.filter(
-                submitted_contribution=OuterRef('pk'),
-                url__icontains='medium.com'
-            )
-            # Exclude submissions where:
-            # - Any evidence URL contains medium.com OR
-            # - Notes contain medium.com
-            return queryset.exclude(
-                Exists(has_medium_evidence) |
-                Q(notes__icontains='medium.com')
-            )
+            return queryset.exclude(state=value)
+        return queryset
+
+    def filter_exclude_content(self, queryset, name, value):
+        """Exclude submissions containing text in notes or evidence. Supports comma-separated values."""
+        if value:
+            for term in value.split(','):
+                term = term.strip()
+                if term:
+                    has_matching_evidence = Evidence.objects.filter(
+                        submitted_contribution=OuterRef('pk')
+                    ).filter(
+                        Q(url__icontains=term) | Q(notes__icontains=term)
+                    )
+                    queryset = queryset.exclude(
+                        Exists(has_matching_evidence) |
+                        Q(notes__icontains=term)
+                    )
+        return queryset
+
+    def filter_include_content(self, queryset, name, value):
+        """Include ONLY submissions containing text in notes or evidence. Supports comma-separated values."""
+        if value:
+            for term in value.split(','):
+                term = term.strip()
+                if term:
+                    has_matching_evidence = Evidence.objects.filter(
+                        submitted_contribution=OuterRef('pk')
+                    ).filter(
+                        Q(url__icontains=term) | Q(notes__icontains=term)
+                    )
+                    queryset = queryset.filter(
+                        Exists(has_matching_evidence) |
+                        Q(notes__icontains=term)
+                    )
         return queryset
 
     def filter_exclude_empty_evidence(self, queryset, name, value):
@@ -826,6 +863,20 @@ class StewardSubmissionFilterSet(FilterSet):
             # - No evidence item has a URL AND
             # - Notes don't contain a URL (http:// or https://)
             return queryset.exclude(
+                ~Exists(has_url_evidence) &
+                ~Q(notes__icontains='http://') &
+                ~Q(notes__icontains='https://')
+            )
+        return queryset
+
+    def filter_only_empty_evidence(self, queryset, name, value):
+        """Include ONLY submissions without URL evidence (inverse of exclude_empty_evidence)."""
+        if value:
+            has_url_evidence = Evidence.objects.filter(
+                submitted_contribution=OuterRef('pk'),
+                url__gt=''
+            )
+            return queryset.filter(
                 ~Exists(has_url_evidence) &
                 ~Q(notes__icontains='http://') &
                 ~Q(notes__icontains='https://')

--- a/frontend/src/components/StewardSearchBar.svelte
+++ b/frontend/src/components/StewardSearchBar.svelte
@@ -1,0 +1,409 @@
+<script>
+  import { onMount } from 'svelte';
+
+  let {
+    value = $bindable(''),
+    contributionTypes = [],
+    stewardsList = [],
+    placeholder = 'type:blog-post assigned:me exclude:medium.com...',
+    onSearch = () => {}
+  } = $props();
+
+  let inputRef = $state(null);
+  let containerRef = $state(null);
+  let showAutocomplete = $state(false);
+  let showHelp = $state(false);
+  let suggestions = $state([]);
+  let selectedIndex = $state(-1);
+  let debounceTimeout = null;
+
+  const TAGS = [
+    { name: 'type', description: 'Filter by contribution type', values: () => contributionTypes.map(t => t.name.toLowerCase().replace(/\s+/g, '-')) },
+    { name: 'from', description: 'Search by user name/email/address', values: () => [] },
+    { name: 'assigned', description: 'Filter by assignment', values: () => ['me', 'unassigned', ...stewardsList.map(s => s.name || s.address?.slice(0, 10))] },
+    { name: 'exclude', description: 'Exclude submissions containing text', values: () => ['medium.com'] },
+    { name: 'include', description: 'Only show submissions containing text', values: () => [] },
+    { name: 'has', description: 'Filter by presence', values: () => ['url', 'evidence'] },
+    { name: 'no', description: 'Filter by absence', values: () => ['url', 'evidence'] },
+    { name: 'min-contributions', description: 'Min accepted contributions', values: () => ['1', '2', '3', '4', '5'] },
+    { name: 'sort', description: 'Sort order', values: () => ['created', '-created', 'date', '-date'] }
+  ];
+
+  function getCurrentWord() {
+    if (!inputRef) return { word: '', start: 0, end: 0 };
+
+    const cursorPos = inputRef.selectionStart;
+    const text = value;
+
+    let start = cursorPos;
+    let end = cursorPos;
+
+    while (start > 0 && text[start - 1] !== ' ') start--;
+    while (end < text.length && text[end] !== ' ') end++;
+
+    return { word: text.slice(start, end), start, end };
+  }
+
+  function updateSuggestions() {
+    const { word } = getCurrentWord();
+
+    if (!word) {
+      suggestions = TAGS.map(t => `${t.name}:`);
+      return;
+    }
+
+    const colonIndex = word.indexOf(':');
+
+    if (colonIndex === -1) {
+      // Suggesting tag names
+      const prefix = word.replace(/^-/, '').toLowerCase();
+      suggestions = TAGS
+        .filter(t => t.name.startsWith(prefix))
+        .map(t => word.startsWith('-') ? `-${t.name}:` : `${t.name}:`);
+    } else {
+      // Suggesting tag values
+      const tagName = word.slice(0, colonIndex).replace(/^-/, '').toLowerCase();
+      const valuePrefix = word.slice(colonIndex + 1).toLowerCase();
+      const tag = TAGS.find(t => t.name === tagName);
+
+      if (tag) {
+        const values = tag.values();
+        suggestions = values
+          .filter(v => v.toLowerCase().startsWith(valuePrefix))
+          .map(v => `${word.slice(0, colonIndex + 1)}${v}`);
+      } else {
+        suggestions = [];
+      }
+    }
+
+    selectedIndex = suggestions.length > 0 ? 0 : -1;
+  }
+
+  function handleInput(event) {
+    value = event.target.value;
+    showAutocomplete = true;
+    updateSuggestions();
+
+    clearTimeout(debounceTimeout);
+    debounceTimeout = setTimeout(() => {
+      onSearch(value);
+    }, 500);
+  }
+
+  function selectSuggestion(suggestion) {
+    const { start, end } = getCurrentWord();
+    const before = value.slice(0, start);
+    const after = value.slice(end);
+
+    value = before + suggestion + (after.startsWith(' ') ? after : ' ' + after.trimStart());
+    showAutocomplete = false;
+
+    // Focus input and move cursor
+    if (inputRef) {
+      inputRef.focus();
+      const newPos = before.length + suggestion.length + 1;
+      setTimeout(() => inputRef.setSelectionRange(newPos, newPos), 0);
+    }
+
+    clearTimeout(debounceTimeout);
+    debounceTimeout = setTimeout(() => {
+      onSearch(value);
+    }, 500);
+  }
+
+  function handleKeydown(event) {
+    if (!showAutocomplete || suggestions.length === 0) {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        onSearch(value);
+      }
+      return;
+    }
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        selectedIndex = Math.min(selectedIndex + 1, suggestions.length - 1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        selectedIndex = Math.max(selectedIndex - 1, 0);
+        break;
+      case 'Tab':
+      case 'Enter':
+        event.preventDefault();
+        if (selectedIndex >= 0 && suggestions[selectedIndex]) {
+          selectSuggestion(suggestions[selectedIndex]);
+        }
+        break;
+      case 'Escape':
+        showAutocomplete = false;
+        selectedIndex = -1;
+        break;
+    }
+  }
+
+  function handleFocus() {
+    updateSuggestions();
+    showAutocomplete = true;
+  }
+
+  function handleClickOutside(event) {
+    if (containerRef && !containerRef.contains(event.target)) {
+      showAutocomplete = false;
+      showHelp = false;
+    }
+  }
+
+  function toggleHelp() {
+    showHelp = !showHelp;
+    showAutocomplete = false;
+  }
+
+  onMount(() => {
+    document.addEventListener('click', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+      if (debounceTimeout) clearTimeout(debounceTimeout);
+    };
+  });
+</script>
+
+<div class="search-container" bind:this={containerRef}>
+  <div class="search-input-wrapper">
+    <svg class="search-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+    </svg>
+    <input
+      type="text"
+      bind:this={inputRef}
+      value={value}
+      oninput={handleInput}
+      onkeydown={handleKeydown}
+      onfocus={handleFocus}
+      {placeholder}
+      class="search-input"
+    />
+    <button type="button" class="help-button" onclick={toggleHelp} title="Search syntax help">
+      ?
+    </button>
+  </div>
+
+  {#if showAutocomplete && suggestions.length > 0}
+    <div class="autocomplete-dropdown">
+      {#each suggestions as suggestion, index}
+        <button
+          type="button"
+          class="suggestion {index === selectedIndex ? 'selected' : ''}"
+          onclick={() => selectSuggestion(suggestion)}
+          onmouseenter={() => { selectedIndex = index; }}
+        >
+          {suggestion}
+        </button>
+      {/each}
+    </div>
+  {/if}
+
+  {#if showHelp}
+    <div class="help-tooltip">
+      <div class="help-header">Search Syntax</div>
+      <div class="help-content">
+        <div class="help-section">
+          <div class="help-row"><code>type:blog-post</code><span>Filter by contribution type</span></div>
+          <div class="help-row"><code>from:username</code><span>Search by user name/email/address</span></div>
+          <div class="help-row"><code>assigned:me</code><span>Filter by assignment (me, unassigned, name)</span></div>
+          <div class="help-row"><code>exclude:medium.com</code><span>Exclude submissions containing text</span></div>
+          <div class="help-row"><code>include:genlayer</code><span>Only show submissions containing text</span></div>
+          <div class="help-row"><code>has:url</code><span>Only submissions with URLs</span></div>
+          <div class="help-row"><code>no:url</code><span>Only submissions without URLs</span></div>
+          <div class="help-row"><code>min-contributions:3</code><span>Users with N+ accepted contributions</span></div>
+          <div class="help-row"><code>sort:-created</code><span>Sort order (created, -created, date, -date)</span></div>
+        </div>
+        <div class="help-section">
+          <div class="help-subtitle">Negation</div>
+          <div class="help-row"><code>-type:blog-post</code><span>Exclude contribution type</span></div>
+        </div>
+        <div class="help-section">
+          <div class="help-subtitle">Examples</div>
+          <div class="help-example">assigned:me exclude:medium.com has:url</div>
+          <div class="help-example">from:alice -type:referral min-contributions:2</div>
+        </div>
+        <div class="help-note">All terms must use tags. Unrecognized text is ignored.</div>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .search-container {
+    position: relative;
+    flex: 1;
+  }
+
+  .search-input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  .search-icon {
+    position: absolute;
+    left: 0.75rem;
+    width: 1.25rem;
+    height: 1.25rem;
+    color: #9ca3af;
+    pointer-events: none;
+  }
+
+  .search-input {
+    width: 100%;
+    padding: 0.625rem 2.5rem 0.625rem 2.5rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    background-color: #f9fafb;
+    transition: all 0.2s;
+  }
+
+  .search-input:focus {
+    outline: none;
+    border-color: #2563eb;
+    background-color: white;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+  }
+
+  .search-input::placeholder {
+    color: #9ca3af;
+    font-family: inherit;
+  }
+
+  .help-button {
+    position: absolute;
+    right: 0.5rem;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 50%;
+    border: 1px solid #d1d5db;
+    background: white;
+    color: #6b7280;
+    font-size: 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+  }
+
+  .help-button:hover {
+    background: #f3f4f6;
+    color: #374151;
+  }
+
+  .autocomplete-dropdown {
+    position: absolute;
+    top: calc(100% + 0.25rem);
+    left: 0;
+    right: 0;
+    z-index: 50;
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    max-height: 240px;
+    overflow-y: auto;
+  }
+
+  .suggestion {
+    display: block;
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.875rem;
+    color: #374151;
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+
+  .suggestion:hover,
+  .suggestion.selected {
+    background: #f3f4f6;
+  }
+
+  .help-tooltip {
+    position: absolute;
+    top: calc(100% + 0.25rem);
+    left: 0;
+    right: 0;
+    z-index: 50;
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    padding: 1rem;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+
+  .help-header {
+    font-weight: 600;
+    font-size: 0.875rem;
+    color: #111827;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  .help-content {
+    font-size: 0.8125rem;
+  }
+
+  .help-section {
+    margin-bottom: 0.75rem;
+  }
+
+  .help-subtitle {
+    font-weight: 500;
+    color: #374151;
+    margin-bottom: 0.25rem;
+  }
+
+  .help-row {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.25rem 0;
+  }
+
+  .help-row code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    background: #f3f4f6;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    color: #1f2937;
+    white-space: nowrap;
+    min-width: 140px;
+  }
+
+  .help-row span {
+    color: #6b7280;
+  }
+
+  .help-example {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.75rem;
+    background: #f9fafb;
+    padding: 0.375rem 0.5rem;
+    border-radius: 0.25rem;
+    margin-top: 0.25rem;
+    color: #4b5563;
+  }
+
+  .help-note {
+    margin-top: 0.75rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid #e5e7eb;
+    font-size: 0.75rem;
+    color: #9ca3af;
+    font-style: italic;
+  }
+</style>

--- a/frontend/src/lib/searchParser.js
+++ b/frontend/src/lib/searchParser.js
@@ -1,0 +1,192 @@
+/**
+ * Parse a GitHub-style search query into structured filters.
+ *
+ * Supported tags:
+ * - status:pending|accepted|rejected|more_info
+ * - type:contribution-type-name
+ * - from:username
+ * - assigned:me|unassigned|steward-name
+ * - exclude:text (multiple allowed)
+ * - include:text (multiple allowed)
+ * - has:url|evidence
+ * - no:url|evidence
+ * - min-contributions:number
+ * - sort:created|-created|date|-date
+ *
+ * Negation: -tag:value or NOT tag:value
+ * Quoted values: tag:"value with spaces"
+ */
+
+const SINGLE_VALUE_TAGS = ['status', 'type', 'from', 'assigned', 'sort'];
+const MULTI_VALUE_TAGS = ['exclude', 'include', 'has', 'no'];
+const NUMERIC_TAGS = ['min-contributions'];
+
+/**
+ * Tokenize the search query, respecting quoted strings.
+ * @param {string} query
+ * @returns {string[]}
+ */
+function tokenize(query) {
+  const tokens = [];
+  let current = '';
+  let inQuotes = false;
+  let quoteChar = '';
+
+  for (let i = 0; i < query.length; i++) {
+    const char = query[i];
+
+    if ((char === '"' || char === "'") && !inQuotes) {
+      inQuotes = true;
+      quoteChar = char;
+    } else if (char === quoteChar && inQuotes) {
+      inQuotes = false;
+      quoteChar = '';
+    } else if (char === ' ' && !inQuotes) {
+      if (current.trim()) {
+        tokens.push(current.trim());
+      }
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  if (current.trim()) {
+    tokens.push(current.trim());
+  }
+
+  return tokens;
+}
+
+/**
+ * Parse a single token into tag, value, and negation flag.
+ * @param {string} token
+ * @returns {{ tag: string, value: string, negated: boolean } | null}
+ */
+function parseToken(token) {
+  let negated = false;
+  let workingToken = token;
+
+  // Check for negation prefix
+  if (workingToken.startsWith('-')) {
+    negated = true;
+    workingToken = workingToken.slice(1);
+  } else if (workingToken.toUpperCase().startsWith('NOT ')) {
+    negated = true;
+    workingToken = workingToken.slice(4);
+  }
+
+  // Check for tag:value pattern
+  const colonIndex = workingToken.indexOf(':');
+  if (colonIndex === -1) {
+    return null; // Not a valid tag
+  }
+
+  const tag = workingToken.slice(0, colonIndex).toLowerCase();
+  let value = workingToken.slice(colonIndex + 1);
+
+  // Remove surrounding quotes from value
+  if ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))) {
+    value = value.slice(1, -1);
+  }
+
+  if (!value) {
+    return null; // Empty value
+  }
+
+  return { tag, value, negated };
+}
+
+/**
+ * Parse a search query string into structured filters.
+ * @param {string} query
+ * @returns {Object}
+ */
+export function parseSearch(query) {
+  const filters = {
+    status: null,
+    type: null,
+    from: null,
+    assigned: null,
+    exclude: [],
+    include: [],
+    has: [],
+    no: [],
+    minContributions: null,
+    sort: null
+  };
+
+  if (!query || !query.trim()) {
+    return { filters };
+  }
+
+  const tokens = tokenize(query);
+
+  for (const token of tokens) {
+    // Handle "NOT tag:value" as two tokens
+    if (token.toUpperCase() === 'NOT') {
+      continue; // Will be handled with next token
+    }
+
+    const parsed = parseToken(token);
+    if (!parsed) {
+      continue; // Ignore unrecognized tokens
+    }
+
+    const { tag, value, negated } = parsed;
+
+    // Handle single-value tags
+    if (SINGLE_VALUE_TAGS.includes(tag)) {
+      filters[tag] = { value, negated };
+    }
+    // Handle multi-value tags
+    else if (MULTI_VALUE_TAGS.includes(tag)) {
+      filters[tag].push(value);
+    }
+    // Handle numeric tags
+    else if (NUMERIC_TAGS.includes(tag)) {
+      const num = parseInt(value, 10);
+      if (!isNaN(num)) {
+        if (tag === 'min-contributions') {
+          filters.minContributions = num;
+        }
+      }
+    }
+  }
+
+  return { filters };
+}
+
+/**
+ * Convert parsed filters back to a query string.
+ * Useful for URL sync and display.
+ * @param {Object} filters
+ * @returns {string}
+ */
+export function filtersToQuery(filters) {
+  const parts = [];
+
+  for (const tag of SINGLE_VALUE_TAGS) {
+    const filter = filters[tag];
+    if (filter && filter.value) {
+      const prefix = filter.negated ? '-' : '';
+      const value = filter.value.includes(' ') ? `"${filter.value}"` : filter.value;
+      parts.push(`${prefix}${tag}:${value}`);
+    }
+  }
+
+  for (const tag of MULTI_VALUE_TAGS) {
+    const values = filters[tag] || [];
+    for (const value of values) {
+      const formattedValue = value.includes(' ') ? `"${value}"` : value;
+      parts.push(`${tag}:${formattedValue}`);
+    }
+  }
+
+  if (filters.minContributions !== null && filters.minContributions > 0) {
+    parts.push(`min-contributions:${filters.minContributions}`);
+  }
+
+  return parts.join(' ');
+}

--- a/frontend/src/lib/searchToParams.js
+++ b/frontend/src/lib/searchToParams.js
@@ -1,0 +1,119 @@
+/**
+ * Convert parsed search filters to API query parameters.
+ */
+
+/**
+ * Map parsed search filters to API parameters.
+ * @param {Object} parsed - Output from parseSearch()
+ * @param {Object} options - Additional context
+ * @param {Array} options.contributionTypes - List of contribution types for name/slug lookup
+ * @param {Array} options.stewardsList - List of stewards for name lookup
+ * @param {string} options.currentUserId - Current user's ID for "me" resolution
+ * @returns {Object} API query parameters
+ */
+export function searchToParams(parsed, options = {}) {
+  const { contributionTypes = [], stewardsList = [], currentUserId = null } = options;
+  const params = {};
+
+  const { filters } = parsed;
+
+  // status → state (handle negation as exclude_state)
+  if (filters.status) {
+    if (filters.status.negated) {
+      params.exclude_state = filters.status.value;
+    } else {
+      params.state = filters.status.value;
+    }
+  }
+
+  // type → contribution_type (by name, slug, or ID)
+  if (filters.type) {
+    const typeValue = filters.type.value.toLowerCase();
+    const type = contributionTypes.find(t =>
+      t.slug?.toLowerCase() === typeValue ||
+      t.name?.toLowerCase() === typeValue ||
+      String(t.id) === filters.type.value
+    );
+    if (type) {
+      if (filters.type.negated) {
+        params.exclude_contribution_type = type.id;
+      } else {
+        params.contribution_type = type.id;
+      }
+    }
+  }
+
+  // from → username_search (or exclude_username if negated)
+  if (filters.from) {
+    if (filters.from.negated) {
+      params.exclude_username = filters.from.value;
+    } else {
+      params.username_search = filters.from.value;
+    }
+  }
+
+  // assigned → assigned_to
+  if (filters.assigned) {
+    const val = filters.assigned.value.toLowerCase();
+    let assignedValue = null;
+
+    if (val === 'me' && currentUserId) {
+      assignedValue = currentUserId;
+    } else if (val === 'unassigned' || val === 'none') {
+      assignedValue = 'unassigned';
+    } else {
+      // Find steward by name
+      const steward = stewardsList.find(s =>
+        s.name?.toLowerCase().includes(val) ||
+        s.user_name?.toLowerCase().includes(val)
+      );
+      if (steward) {
+        assignedValue = steward.user_id;
+      }
+    }
+
+    if (assignedValue) {
+      if (filters.assigned.negated) {
+        params.exclude_assigned_to = assignedValue;
+      } else {
+        params.assigned_to = assignedValue;
+      }
+    }
+  }
+
+  // exclude → exclude_content (comma-separated for multiple values)
+  if (filters.exclude && filters.exclude.length > 0) {
+    params.exclude_content = filters.exclude.join(',');
+  }
+
+  // include → include_content (comma-separated for multiple values)
+  if (filters.include && filters.include.length > 0) {
+    params.include_content = filters.include.join(',');
+  }
+
+  // has:url / no:url → evidence filters
+  if (filters.no && (filters.no.includes('url') || filters.no.includes('evidence'))) {
+    params.only_empty_evidence = true;
+  } else if (filters.has && (filters.has.includes('url') || filters.has.includes('evidence'))) {
+    params.exclude_empty_evidence = true;
+  }
+
+  // min-contributions
+  if (filters.minContributions !== null && filters.minContributions > 0) {
+    params.min_accepted_contributions = filters.minContributions;
+  }
+
+  // sort → ordering
+  if (filters.sort) {
+    const sortMap = {
+      'created': 'created_at',
+      '-created': '-created_at',
+      'date': 'contribution_date',
+      '-date': '-contribution_date'
+    };
+    const sortValue = filters.sort.value;
+    params.ordering = sortMap[sortValue] || sortValue;
+  }
+
+  return params;
+}

--- a/frontend/src/routes/StewardSubmissions.svelte
+++ b/frontend/src/routes/StewardSubmissions.svelte
@@ -1,13 +1,15 @@
 <script>
   import { onMount } from 'svelte';
-  import { push } from 'svelte-spa-router';
+  import { push, querystring } from 'svelte-spa-router';
   import { authState } from '../lib/auth.js';
   import { stewardAPI, contributionsAPI, leaderboardAPI } from '../lib/api.js';
-  import { format } from 'date-fns';
   import PaginationEnhanced from '../components/PaginationEnhanced.svelte';
   import SubmissionCard from '../components/SubmissionCard.svelte';
+  import StewardSearchBar from '../components/StewardSearchBar.svelte';
   import { showSuccess, showError } from '../lib/toastStore';
-  
+  import { parseSearch } from '../lib/searchParser.js';
+  import { searchToParams } from '../lib/searchToParams.js';
+
   let submissions = $state([]);
   let contributionTypes = $state([]);
   let users = $state([]);
@@ -16,25 +18,12 @@
   let currentPage = $state(1);
   let totalCount = $state(0);
   let pageSize = $state(10);
-  
-  // Filters
+
+  // Filters - Status dropdown + search bar
   let stateFilter = $state('pending');
-  let typeFilter = $state('');
-  let assignedToFilter = $state('');  // '' = all, 'me' = assigned to me, steward_id = specific steward
-  let usernameSearch = $state('');
-  let searchTimeout = null;
+  let searchQuery = $state('');
   let stewardsList = $state([]);
   let assigningSubmissions = $state(new Set());  // Track which submissions are being assigned
-
-  // Exclusion filter states (checkbox values)
-  let excludeMediumBlogpost = $state(false);
-  let excludeEmptyEvidence = $state(false);
-  let minAcceptedContributions = $state(0);
-
-  // Applied exclusion filter states (what's actually sent to API)
-  let appliedExcludeMediumBlogpost = $state(false);
-  let appliedExcludeEmptyEvidence = $state(false);
-  let appliedMinAcceptedContributions = $state(0);
 
   // Review states
   let processingSubmissions = $state(new Set());
@@ -52,6 +41,11 @@
       push('/');
       return;
     }
+
+    // Sync filters from URL
+    const params = new URLSearchParams($querystring);
+    if (params.has('status')) stateFilter = params.get('status');
+    if (params.has('q')) searchQuery = params.get('q');
 
     await loadContributionTypes();
     await loadUsers();
@@ -125,46 +119,39 @@
     }
   }
   
+  function updateURL() {
+    const urlParams = new URLSearchParams();
+    if (stateFilter) urlParams.set('status', stateFilter);
+    if (searchQuery) urlParams.set('q', searchQuery);
+    const newUrl = urlParams.toString() ? `?${urlParams.toString()}` : '';
+    window.history.replaceState({}, '', `#/steward/submissions${newUrl}`);
+  }
+
   async function loadSubmissions() {
     loading = true;
     error = null;
     clearSelection();
 
     try {
-      const params = {
-        page: currentPage,
-        page_size: pageSize
-      };
+      // Update URL with current filters
+      updateURL();
 
+      // Build API params from search query
+      const parsed = parseSearch(searchQuery);
+      const currentUserId = $authState.user?.id;
+      const params = searchToParams(parsed, {
+        contributionTypes,
+        stewardsList,
+        currentUserId
+      });
+
+      // Add status from dropdown (overrides search query if present)
       if (stateFilter) {
         params.state = stateFilter;
       }
 
-      if (typeFilter) {
-        params.contribution_type = typeFilter;
-      }
-
-      if (usernameSearch) {
-        params.username_search = usernameSearch;
-      }
-
-      // Handle assigned_to filter
-      if (assignedToFilter === 'unassigned') {
-        params.assigned_to = 'unassigned';
-      } else if (assignedToFilter) {
-        params.assigned_to = assignedToFilter;
-      }
-
-      // Handle exclusion filters
-      if (appliedExcludeMediumBlogpost) {
-        params.exclude_medium_blogpost = true;
-      }
-      if (appliedExcludeEmptyEvidence) {
-        params.exclude_empty_evidence = true;
-      }
-      if (appliedMinAcceptedContributions > 0) {
-        params.min_accepted_contributions = appliedMinAcceptedContributions;
-      }
+      params.page = currentPage;
+      params.page_size = pageSize;
 
       const response = await stewardAPI.getSubmissions(params);
       submissions = response.data.results || [];
@@ -273,18 +260,8 @@
     loadSubmissions();
   }
 
-  function handleSearchChange() {
-    clearTimeout(searchTimeout);
-    searchTimeout = setTimeout(() => {
-      currentPage = 1;
-      loadSubmissions();
-    }, 500);
-  }
-
-  function applyExclusionFilters() {
-    appliedExcludeMediumBlogpost = excludeMediumBlogpost;
-    appliedExcludeEmptyEvidence = excludeEmptyEvidence;
-    appliedMinAcceptedContributions = minAcceptedContributions;
+  function handleSearchChange(query) {
+    searchQuery = query;
     currentPage = 1;
     loadSubmissions();
   }
@@ -355,9 +332,9 @@
   
   <!-- Filters -->
   <div class="bg-white shadow rounded-lg p-4 mb-6">
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+    <div class="flex flex-col md:flex-row gap-4">
       <!-- Status Filter -->
-      <div>
+      <div class="w-full md:w-48 flex-shrink-0">
         <label for="state-filter" class="block text-sm font-medium text-gray-700 mb-1">
           Status
         </label>
@@ -375,91 +352,18 @@
         </select>
       </div>
 
-      <!-- Contribution Type Filter -->
-      <div>
-        <label for="type-filter" class="block text-sm font-medium text-gray-700 mb-1">
-          Contribution Type
+      <!-- Search Bar -->
+      <div class="flex-1">
+        <label for="search-bar" class="block text-sm font-medium text-gray-700 mb-1">
+          Search
         </label>
-        <select
-          id="type-filter"
-          bind:value={typeFilter}
-          onchange={handleFilterChange}
-          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
-        >
-          <option value="">All Types</option>
-          {#each contributionTypes as type}
-            <option value={type.id}>{type.name}</option>
-          {/each}
-        </select>
-      </div>
-
-      <!-- Assigned To Filter -->
-      <div>
-        <label for="assigned-filter" class="block text-sm font-medium text-gray-700 mb-1">
-          Assigned To
-        </label>
-        <select
-          id="assigned-filter"
-          bind:value={assignedToFilter}
-          onchange={handleFilterChange}
-          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
-        >
-          <option value="">All</option>
-          <option value="unassigned">Unassigned</option>
-          {#each stewardsList as steward}
-            <option value={steward.user_id}>
-              {steward.name || steward.address?.slice(0, 10) + '...'}
-            </option>
-          {/each}
-        </select>
-      </div>
-
-      <!-- Username Search -->
-      <div>
-        <label for="username-search" class="block text-sm font-medium text-gray-700 mb-1">
-          Search User
-        </label>
-        <input
-          id="username-search"
-          type="text"
-          bind:value={usernameSearch}
-          oninput={handleSearchChange}
-          placeholder="Name or address..."
-          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+        <StewardSearchBar
+          bind:value={searchQuery}
+          {contributionTypes}
+          {stewardsList}
+          onSearch={handleSearchChange}
+          placeholder="type:blog-post assigned:me exclude:medium.com..."
         />
-      </div>
-    </div>
-
-    <!-- Exclusion Filters -->
-    <div class="border-t pt-4 mt-4">
-      <div class="flex flex-wrap items-center gap-4">
-        <span class="text-sm font-medium text-gray-700">Exclude:</span>
-        <label class="flex items-center gap-2 text-sm">
-          <input type="checkbox" bind:checked={excludeMediumBlogpost} class="rounded border-gray-300" />
-          Medium Blog Posts
-        </label>
-        <label class="flex items-center gap-2 text-sm">
-          <input type="checkbox" bind:checked={excludeEmptyEvidence} class="rounded border-gray-300" />
-          Submissions without URLs
-        </label>
-        <label class="flex items-center gap-2 text-sm">
-          Users with less than
-          <select bind:value={minAcceptedContributions} class="rounded border-gray-300 text-sm py-1 px-2">
-            <option value={0}>0</option>
-            <option value={1}>1</option>
-            <option value={2}>2</option>
-            <option value={3}>3</option>
-            <option value={4}>4</option>
-            <option value={5}>5</option>
-          </select>
-          accepted contributions
-        </label>
-        <button
-          onclick={applyExclusionFilters}
-          class="px-3 py-1 bg-primary-600 text-white text-sm rounded-md hover:bg-primary-700"
-        >
-          Apply
-        </button>
       </div>
     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "rabat",
+  "name": "conakry",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary
Replaces manual filter dropdowns with a unified GitHub-style search bar for steward submission filtering. Users can now use tag-based syntax like `status:pending assigned:me exclude:medium.com` for more flexible filtering.

## Changes
- New search libraries: parser, params mapper, and searchable UI component with autocomplete
- Backend: Generic content filters (`exclude_content`, `include_content`) replace hardcoded `exclude_medium_blogpost`
- Frontend: Consolidated UI from 4 dropdowns + 3 checkboxes into single search bar with Status dropdown
- Search queries sync to URL for shareable/bookmarkable links

## Test Plan
- Test individual tags (status:, type:, from:, assigned:, etc.)
- Test negation with `-` prefix and `NOT` keyword
- Test autocomplete suggestions for steward names and contribution types
- Verify URL sync works correctly with browser back/forward
- Test complex multi-tag queries with proper filtering