### PR TITLE
Fix steward search filters

### DIFF
--- a/backend/contributions/serializers.py
+++ b/backend/contributions/serializers.py
@@ -85,7 +85,7 @@ class ContributionTypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = ContributionType
         fields = [
-            'id', 'name', 'description', 'category', 'min_points', 'max_points',
+            'id', 'name', 'slug', 'description', 'category', 'min_points', 'max_points',
             'current_multiplier', 'is_submittable', 'examples',
             'created_at', 'updated_at'
         ]

--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -776,6 +776,8 @@ class StewardSubmissionFilterSet(FilterSet):
     username_search = CharFilter(method='filter_username')
     exclude_username = CharFilter(method='filter_exclude_username')
     assigned_to = CharFilter(method='filter_assigned_to')
+    exclude_assigned_to = CharFilter(method='filter_exclude_assigned_to')
+    exclude_contribution_type = NumberFilter(method='filter_exclude_contribution_type')
     exclude_content = CharFilter(method='filter_exclude_content')
     include_content = CharFilter(method='filter_include_content')
     exclude_empty_evidence = BooleanFilter(method='filter_exclude_empty_evidence')
@@ -811,6 +813,20 @@ class StewardSubmissionFilterSet(FilterSet):
             return queryset.filter(assigned_to_id=value)
         return queryset
 
+    def filter_exclude_assigned_to(self, queryset, name, value):
+        """Exclude submissions assigned to a specific steward."""
+        if value == 'null' or value == 'unassigned':
+            return queryset.exclude(assigned_to__isnull=True)
+        elif value:
+            return queryset.exclude(assigned_to_id=value)
+        return queryset
+
+    def filter_exclude_contribution_type(self, queryset, name, value):
+        """Exclude submissions of a specific contribution type."""
+        if value:
+            return queryset.exclude(contribution_type_id=value)
+        return queryset
+
     def filter_exclude_state(self, queryset, name, value):
         """Exclude submissions with specific state."""
         if value:
@@ -826,7 +842,7 @@ class StewardSubmissionFilterSet(FilterSet):
                     has_matching_evidence = Evidence.objects.filter(
                         submitted_contribution=OuterRef('pk')
                     ).filter(
-                        Q(url__icontains=term) | Q(notes__icontains=term)
+                        Q(url__icontains=term) | Q(description__icontains=term)
                     )
                     queryset = queryset.exclude(
                         Exists(has_matching_evidence) |
@@ -843,7 +859,7 @@ class StewardSubmissionFilterSet(FilterSet):
                     has_matching_evidence = Evidence.objects.filter(
                         submitted_contribution=OuterRef('pk')
                     ).filter(
-                        Q(url__icontains=term) | Q(notes__icontains=term)
+                        Q(url__icontains=term) | Q(description__icontains=term)
                     )
                     queryset = queryset.filter(
                         Exists(has_matching_evidence) |

--- a/frontend/src/lib/searchToParams.js
+++ b/frontend/src/lib/searchToParams.js
@@ -32,6 +32,7 @@ export function searchToParams(parsed, options = {}) {
     const type = contributionTypes.find(t =>
       t.slug?.toLowerCase() === typeValue ||
       t.name?.toLowerCase() === typeValue ||
+      t.name?.toLowerCase().replace(/\s+/g, '-') === typeValue ||
       String(t.id) === filters.type.value
     );
     if (type) {

--- a/frontend/src/routes/StewardSubmissions.svelte
+++ b/frontend/src/routes/StewardSubmissions.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { push, querystring } from 'svelte-spa-router';
   import { authState } from '../lib/auth.js';
+  import { userStore } from '../lib/userStore.js';
   import { stewardAPI, contributionsAPI, leaderboardAPI } from '../lib/api.js';
   import PaginationEnhanced from '../components/PaginationEnhanced.svelte';
   import SubmissionCard from '../components/SubmissionCard.svelte';
@@ -138,7 +139,7 @@
 
       // Build API params from search query
       const parsed = parseSearch(searchQuery);
-      const currentUserId = $authState.user?.id;
+      const currentUserId = $userStore.user?.id;
       const params = searchToParams(parsed, {
         contributionTypes,
         stewardsList,


### PR DESCRIPTION
Fix multiple issues in steward submission search filters:

- **type: filter**: Add slug field to API response and implement slugified name fallback (spaces to dashes)
- **include:/exclude: filters**: Fix Evidence field reference from notes to description
- **assigned:me filter**: Use userStore instead of non-existent authState.user property
- **Negated filters**: Add backend support for -type: and -assigned: negation operators

All search filters now work correctly: type, include, exclude, assigned, from, status, has/no, min-contributions, sort.