### PR TITLE
Add steward permission system, CRM notes, proposals & review templates

### DIFF
--- a/backend/contributions/admin.py
+++ b/backend/contributions/admin.py
@@ -11,7 +11,7 @@ from django.db.models import Count
 from django.core.exceptions import ValidationError
 from django.contrib.auth import get_user_model
 from datetime import datetime
-from .models import Category, ContributionType, Contribution, SubmittedContribution, Evidence, ContributionHighlight, Mission, StartupRequest
+from .models import Category, ContributionType, Contribution, SubmittedContribution, Evidence, ContributionHighlight, Mission, StartupRequest, SubmissionNote
 from .validator_forms import CreateValidatorForm
 from leaderboard.models import GlobalLeaderboardMultiplier
 
@@ -361,20 +361,31 @@ class ContributionAdmin(admin.ModelAdmin):
         js = ('admin/js/contribution_type_dynamic.js',)
 
 
+class SubmissionNoteInline(admin.TabularInline):
+    model = SubmissionNote
+    extra = 0
+    readonly_fields = ('user', 'message', 'is_proposal', 'created_at')
+    fields = ('user', 'message', 'is_proposal', 'created_at')
+    can_delete = False
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
 @admin.register(SubmittedContribution)
 class SubmittedContributionAdmin(admin.ModelAdmin):
-    list_display = ('user', 'contribution_type', 'suggested_points', 'evidence_count', 'state',
+    list_display = ('user', 'contribution_type', 'proposed_points', 'evidence_count', 'state',
                    'contribution_date', 'created_at', 'reviewed_by')
     list_filter = ('state', 'contribution_type__category', 'contribution_type', 'created_at', 'reviewed_at')
     search_fields = ('user__email', 'user__name', 'notes', 'staff_reply', 'mission__name')
     date_hierarchy = 'created_at'
     readonly_fields = ('id', 'created_at', 'updated_at', 'last_edited_at',
-                      'converted_contribution_link', 'contribution_type_info', 'suggested_points')
-    inlines = [EvidenceInline]
+                      'converted_contribution_link', 'contribution_type_info', 'proposed_points')
+    inlines = [EvidenceInline, SubmissionNoteInline]
     
     fieldsets = (
         ('Submission Info', {
-            'fields': ('id', 'user', 'contribution_type', 'contribution_type_info', 'suggested_points', 'contribution_date', 'notes')
+            'fields': ('id', 'user', 'contribution_type', 'contribution_type_info', 'proposed_points', 'contribution_date', 'notes')
         }),
         ('Review Status', {
             'fields': ('state', 'staff_reply', 'reviewed_by', 'reviewed_at')

--- a/backend/contributions/forms.py
+++ b/backend/contributions/forms.py
@@ -31,10 +31,10 @@ class SubmissionReviewForm(forms.ModelForm):
         # Add help text for state field
         self.fields['state'].help_text = "Select action to take on this submission"
         
-        # Pre-populate points if suggested_points exists
-        if self.instance and self.instance.suggested_points:
-            self.initial['points'] = self.instance.suggested_points
-            self.fields['points'].help_text = f"Suggested: {self.instance.suggested_points} points (auto-calculated)"
+        # Pre-populate points if proposed_points exists
+        if self.instance and self.instance.proposed_points:
+            self.initial['points'] = self.instance.proposed_points
+            self.fields['points'].help_text = f"Suggested: {self.instance.proposed_points} points (auto-calculated)"
         
     def clean(self):
         cleaned_data = super().clean()

--- a/backend/contributions/migrations/0031_rename_suggested_points_to_proposed_points.py
+++ b/backend/contributions/migrations/0031_rename_suggested_points_to_proposed_points.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contributions', '0030_startuprequest'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='submittedcontribution',
+            old_name='suggested_points',
+            new_name='proposed_points',
+        ),
+    ]

--- a/backend/contributions/migrations/0032_submittedcontribution_proposal_fields_submissionnote.py
+++ b/backend/contributions/migrations/0032_submittedcontribution_proposal_fields_submissionnote.py
@@ -1,0 +1,77 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('contributions', '0031_rename_suggested_points_to_proposed_points'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='submittedcontribution',
+            name='proposed_action',
+            field=models.CharField(blank=True, choices=[('accept', 'Accept'), ('reject', 'Reject'), ('more_info', 'More Info')], help_text='Proposed review action', max_length=20, null=True),
+        ),
+        migrations.AddField(
+            model_name='submittedcontribution',
+            name='proposed_contribution_type',
+            field=models.ForeignKey(blank=True, help_text='Proposed contribution type for acceptance', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='proposed_submissions', to='contributions.contributiontype'),
+        ),
+        migrations.AddField(
+            model_name='submittedcontribution',
+            name='proposed_user',
+            field=models.ForeignKey(blank=True, help_text='Proposed user to assign the contribution to', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='proposed_contributions', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AddField(
+            model_name='submittedcontribution',
+            name='proposed_staff_reply',
+            field=models.TextField(blank=True, default='', help_text='Proposed staff reply message'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='submittedcontribution',
+            name='proposed_create_highlight',
+            field=models.BooleanField(default=False, help_text='Whether to create a highlight for the contribution'),
+        ),
+        migrations.AddField(
+            model_name='submittedcontribution',
+            name='proposed_highlight_title',
+            field=models.CharField(blank=True, default='', help_text='Proposed highlight title', max_length=200),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='submittedcontribution',
+            name='proposed_highlight_description',
+            field=models.TextField(blank=True, default='', help_text='Proposed highlight description'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='submittedcontribution',
+            name='proposed_by',
+            field=models.ForeignKey(blank=True, help_text='Steward who made the proposal', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='submission_proposals', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AddField(
+            model_name='submittedcontribution',
+            name='proposed_at',
+            field=models.DateTimeField(blank=True, help_text='When the proposal was made', null=True),
+        ),
+        migrations.CreateModel(
+            name='SubmissionNote',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('message', models.TextField()),
+                ('is_proposal', models.BooleanField(default=False, help_text='True for auto-generated proposal notes')),
+                ('submitted_contribution', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='internal_notes', to='contributions.submittedcontribution')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='submission_notes', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'ordering': ['created_at'],
+            },
+        ),
+    ]

--- a/backend/contributions/permissions.py
+++ b/backend/contributions/permissions.py
@@ -5,13 +5,43 @@ class IsSteward(permissions.BasePermission):
     """
     Custom permission to only allow stewards to access certain views.
     """
-    
+
     def has_permission(self, request, view):
         """
         Check if the user is authenticated and has a steward profile.
         """
         if not request.user or not request.user.is_authenticated:
             return False
-        
+
         # Check if user has a steward profile
         return hasattr(request.user, 'steward')
+
+
+def steward_has_permission(user, contribution_type_id, action):
+    """
+    Check if a steward has a specific action permission on a contribution type.
+    Returns False if user is not a steward or doesn't have the permission.
+    """
+    if not hasattr(user, 'steward'):
+        return False
+    from stewards.models import StewardPermission
+    return StewardPermission.objects.filter(
+        steward=user.steward,
+        contribution_type_id=contribution_type_id,
+        action=action,
+    ).exists()
+
+
+def steward_permitted_type_ids(user, actions=None):
+    """
+    Get list of contribution type IDs the steward has permissions on.
+    If actions is provided, only return types where the steward has at least one of those actions.
+    If actions is None, return types where the steward has any permission.
+    """
+    if not hasattr(user, 'steward'):
+        return []
+    from stewards.models import StewardPermission
+    qs = StewardPermission.objects.filter(steward=user.steward)
+    if actions:
+        qs = qs.filter(action__in=actions)
+    return list(qs.values_list('contribution_type_id', flat=True).distinct())

--- a/backend/contributions/tests/test_steward_permissions.py
+++ b/backend/contributions/tests/test_steward_permissions.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient
 from rest_framework import status
 from contributions.models import SubmittedContribution, ContributionType, Category
-from stewards.models import Steward
+from stewards.models import Steward, StewardPermission
 from datetime import datetime
 from django.utils import timezone
 
@@ -45,8 +45,16 @@ class StewardPermissionTest(TestCase):
             address='0x0987654321098765432109876543210987654321',
             password='testpass123'
         )
-        Steward.objects.create(user=self.steward_user)
-        
+        self.steward = Steward.objects.create(user=self.steward_user)
+
+        # Grant all permissions to steward for the test contribution type
+        for action in ['propose', 'accept', 'reject', 'request_more_info']:
+            StewardPermission.objects.create(
+                steward=self.steward,
+                contribution_type=self.contribution_type,
+                action=action
+            )
+
         # Create admin user
         self.admin_user = User.objects.create_superuser(
             email='admin@test.com',

--- a/backend/stewards/admin.py
+++ b/backend/stewards/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Steward, WorkingGroup, WorkingGroupParticipant
+from .models import Steward, StewardPermission, ReviewTemplate, WorkingGroup, WorkingGroupParticipant
 
 
 class StewardInline(admin.StackedInline):
@@ -13,13 +13,22 @@ class StewardInline(admin.StackedInline):
     can_delete = True  # Allow deletion through inline
 
 
+class StewardPermissionInline(admin.TabularInline):
+    """Inline for managing steward permissions from the steward detail page."""
+    model = StewardPermission
+    extra = 1
+    autocomplete_fields = ['contribution_type']
+    fields = ('contribution_type', 'action')
+
+
 @admin.register(Steward)
 class StewardAdmin(admin.ModelAdmin):
-    list_display = ('user', 'created_at', 'updated_at')
+    list_display = ('user', 'permission_count', 'created_at', 'updated_at')
     search_fields = ('user__email', 'user__name')
     list_filter = ('created_at', 'updated_at')
     ordering = ('-created_at',)
-    
+    inlines = [StewardPermissionInline]
+
     fieldsets = (
         (None, {
             'fields': ('user',)
@@ -30,6 +39,31 @@ class StewardAdmin(admin.ModelAdmin):
         }),
     )
     readonly_fields = ('created_at', 'updated_at')
+
+    def permission_count(self, obj):
+        return obj.permissions.count()
+    permission_count.short_description = 'Permissions'
+
+
+@admin.register(StewardPermission)
+class StewardPermissionAdmin(admin.ModelAdmin):
+    list_display = ('steward', 'contribution_type', 'action', 'created_at')
+    list_filter = ('action', 'contribution_type__category', 'contribution_type')
+    search_fields = ('steward__user__name', 'steward__user__email', 'contribution_type__name')
+    autocomplete_fields = ['steward', 'contribution_type']
+    ordering = ('steward', 'contribution_type', 'action')
+
+
+@admin.register(ReviewTemplate)
+class ReviewTemplateAdmin(admin.ModelAdmin):
+    list_display = ('label', 'text_preview', 'created_at', 'updated_at')
+    search_fields = ('label', 'text')
+    readonly_fields = ('created_at', 'updated_at')
+    ordering = ('label',)
+
+    def text_preview(self, obj):
+        return obj.text[:80] + '...' if len(obj.text) > 80 else obj.text
+    text_preview.short_description = 'Text Preview'
 
 
 # Note: StewardInline is imported and added to UserAdmin in users/admin.py

--- a/backend/stewards/migrations/0004_stewardpermission_reviewtemplate.py
+++ b/backend/stewards/migrations/0004_stewardpermission_reviewtemplate.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('stewards', '0003_workinggroup_icon_workinggroup_description'),
+        ('contributions', '0031_rename_suggested_points_to_proposed_points'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='StewardPermission',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('action', models.CharField(choices=[('propose', 'Propose'), ('accept', 'Accept'), ('reject', 'Reject'), ('request_more_info', 'Request More Info')], max_length=20)),
+                ('contribution_type', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='steward_permissions', to='contributions.contributiontype')),
+                ('steward', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='permissions', to='stewards.steward')),
+            ],
+            options={
+                'ordering': ['steward', 'contribution_type', 'action'],
+                'unique_together': {('steward', 'contribution_type', 'action')},
+            },
+        ),
+        migrations.CreateModel(
+            name='ReviewTemplate',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('label', models.CharField(help_text="Short label, e.g. 'Insufficient evidence'", max_length=100)),
+                ('text', models.TextField(help_text='Full template text to insert into reply fields')),
+            ],
+            options={
+                'ordering': ['label'],
+            },
+        ),
+    ]

--- a/backend/stewards/migrations/0005_grant_all_permissions_to_existing_stewards.py
+++ b/backend/stewards/migrations/0005_grant_all_permissions_to_existing_stewards.py
@@ -1,0 +1,51 @@
+from django.db import migrations
+
+
+def grant_all_permissions(apps, schema_editor):
+    """
+    Grant all 4 actions on all contribution types to every existing Steward,
+    preserving current behavior where all stewards have full permissions.
+    """
+    Steward = apps.get_model('stewards', 'Steward')
+    ContributionType = apps.get_model('contributions', 'ContributionType')
+    StewardPermission = apps.get_model('stewards', 'StewardPermission')
+
+    actions = ['propose', 'accept', 'reject', 'request_more_info']
+    stewards = Steward.objects.all()
+    contribution_types = ContributionType.objects.all()
+
+    permissions_to_create = []
+    for steward in stewards:
+        for ct in contribution_types:
+            for action in actions:
+                permissions_to_create.append(
+                    StewardPermission(
+                        steward=steward,
+                        contribution_type=ct,
+                        action=action,
+                    )
+                )
+
+    if permissions_to_create:
+        StewardPermission.objects.bulk_create(
+            permissions_to_create,
+            ignore_conflicts=True
+        )
+
+
+def reverse_grant(apps, schema_editor):
+    """Remove all auto-granted permissions."""
+    StewardPermission = apps.get_model('stewards', 'StewardPermission')
+    StewardPermission.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('stewards', '0004_stewardpermission_reviewtemplate'),
+        ('contributions', '0032_submittedcontribution_proposal_fields_submissionnote'),
+    ]
+
+    operations = [
+        migrations.RunPython(grant_all_permissions, reverse_grant),
+    ]

--- a/backend/stewards/models.py
+++ b/backend/stewards/models.py
@@ -18,6 +18,51 @@ class Steward(BaseModel):
         return f"{self.user.email} - Steward"
 
 
+class StewardPermission(BaseModel):
+    """
+    Per-action, per-contribution-type permission for stewards.
+    Controls what actions a steward can perform on submissions of each type.
+    """
+    ACTION_CHOICES = [
+        ('propose', 'Propose'),
+        ('accept', 'Accept'),
+        ('reject', 'Reject'),
+        ('request_more_info', 'Request More Info'),
+    ]
+    steward = models.ForeignKey(
+        Steward,
+        on_delete=models.CASCADE,
+        related_name='permissions'
+    )
+    contribution_type = models.ForeignKey(
+        'contributions.ContributionType',
+        on_delete=models.CASCADE,
+        related_name='steward_permissions'
+    )
+    action = models.CharField(max_length=20, choices=ACTION_CHOICES)
+
+    class Meta:
+        unique_together = ['steward', 'contribution_type', 'action']
+        ordering = ['steward', 'contribution_type', 'action']
+
+    def __str__(self):
+        return f"{self.steward.user} - {self.contribution_type} - {self.action}"
+
+
+class ReviewTemplate(BaseModel):
+    """
+    Admin-managed template messages for steward review workflows.
+    """
+    label = models.CharField(max_length=100, help_text="Short label, e.g. 'Insufficient evidence'")
+    text = models.TextField(help_text="Full template text to insert into reply fields")
+
+    class Meta:
+        ordering = ['label']
+
+    def __str__(self):
+        return self.label
+
+
 class WorkingGroup(BaseModel):
     """
     A working group that participants can be members of.

--- a/frontend/src/components/CRMNotesPanel.svelte
+++ b/frontend/src/components/CRMNotesPanel.svelte
@@ -1,0 +1,107 @@
+<script>
+  import { formatDistanceToNow } from 'date-fns';
+
+  let {
+    submissionId,
+    notes = [],
+    onAddNote = null,
+    loading = false
+  } = $props();
+
+  let newNote = $state('');
+  let submitting = $state(false);
+
+  function formatDate(dateString) {
+    if (!dateString) return '';
+    try {
+      return formatDistanceToNow(new Date(dateString), { addSuffix: true });
+    } catch {
+      return dateString;
+    }
+  }
+
+  async function handleAddNote() {
+    if (!newNote.trim() || !onAddNote) return;
+    submitting = true;
+    try {
+      await onAddNote(submissionId, newNote.trim());
+      newNote = '';
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<div class="border border-gray-200 rounded-lg flex flex-col flex-1 min-h-0">
+  <div class="px-4 py-2.5 bg-gray-50 border-b border-gray-200 flex items-center justify-between flex-shrink-0">
+    <h4 class="text-sm font-medium text-gray-700">Internal Notes</h4>
+    <span class="text-xs text-gray-500">{notes.length} note{notes.length !== 1 ? 's' : ''}</span>
+  </div>
+
+  <div class="flex-1 min-h-0 overflow-y-auto notes-scroll">
+    {#if loading}
+      <div class="p-4 text-center text-sm text-gray-500">Loading notes...</div>
+    {:else if notes.length === 0}
+      <div class="p-4 text-center text-sm text-gray-400">No notes yet</div>
+    {:else}
+      <div class="divide-y divide-gray-100">
+        {#each notes as note}
+          <div class="px-4 py-2.5">
+            <div class="flex items-center gap-2 mb-1">
+              <span class="text-xs font-medium text-gray-700">{note.user_name}</span>
+              {#if note.is_proposal}
+                <span class="text-[10px] px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 font-medium">Proposal</span>
+              {/if}
+              <span class="text-[10px] text-gray-400 ml-auto">{formatDate(note.created_at)}</span>
+            </div>
+            <p class="text-sm text-gray-600 whitespace-pre-wrap">{note.message}</p>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+
+  <!-- Add Note Form -->
+  <div class="px-4 py-3 border-t border-gray-200 bg-gray-50 flex-shrink-0">
+    <div class="flex gap-2">
+      <input
+        type="text"
+        bind:value={newNote}
+        placeholder="Add a note..."
+        class="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-primary-500"
+        onkeydown={(e) => { if (e.key === 'Enter' && newNote.trim()) handleAddNote(); }}
+      />
+      <button
+        onclick={handleAddNote}
+        disabled={!newNote.trim() || submitting}
+        class="px-3 py-1.5 text-sm bg-gray-600 text-white rounded-md hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {submitting ? '...' : 'Add'}
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .notes-scroll {
+    scrollbar-width: thin;
+    scrollbar-color: #d1d5db transparent;
+  }
+
+  .notes-scroll::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .notes-scroll::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .notes-scroll::-webkit-scrollbar-thumb {
+    background-color: #d1d5db;
+    border-radius: 3px;
+  }
+
+  .notes-scroll::-webkit-scrollbar-thumb:hover {
+    background-color: #9ca3af;
+  }
+</style>

--- a/frontend/src/components/StewardSearchBar.svelte
+++ b/frontend/src/components/StewardSearchBar.svelte
@@ -23,8 +23,8 @@
     { name: 'assigned', description: 'Filter by assignment', values: () => ['me', 'unassigned', ...stewardsList.map(s => s.name || s.address?.slice(0, 10))] },
     { name: 'exclude', description: 'Exclude submissions containing text', values: () => ['medium.com'] },
     { name: 'include', description: 'Only show submissions containing text', values: () => [] },
-    { name: 'has', description: 'Filter by presence', values: () => ['url', 'evidence'] },
-    { name: 'no', description: 'Filter by absence', values: () => ['url', 'evidence'] },
+    { name: 'has', description: 'Filter by presence', values: () => ['url', 'evidence', 'proposal'] },
+    { name: 'no', description: 'Filter by absence', values: () => ['url', 'evidence', 'proposal'] },
     { name: 'min-contributions', description: 'Min accepted contributions', values: () => ['1', '2', '3', '4', '5'] },
     { name: 'sort', description: 'Sort order', values: () => ['created', '-created', 'date', '-date'] }
   ];
@@ -218,6 +218,7 @@
           <div class="help-row"><code>exclude:medium.com</code><span>Exclude submissions containing text</span></div>
           <div class="help-row"><code>include:genlayer</code><span>Only show submissions containing text</span></div>
           <div class="help-row"><code>has:url</code><span>Only submissions with URLs</span></div>
+          <div class="help-row"><code>has:proposal</code><span>Only submissions with a proposal</span></div>
           <div class="help-row"><code>no:url</code><span>Only submissions without URLs</span></div>
           <div class="help-row"><code>min-contributions:3</code><span>Users with N+ accepted contributions</span></div>
           <div class="help-row"><code>sort:-created</code><span>Sort order (created, -created, date, -date)</span></div>

--- a/frontend/src/components/SubmissionCard.svelte
+++ b/frontend/src/components/SubmissionCard.svelte
@@ -3,15 +3,17 @@
   import { format } from 'date-fns';
   import ContributionCard from './ContributionCard.svelte';
   import ContributionSelection from '../lib/components/ContributionSelection.svelte';
+  import CRMNotesPanel from './CRMNotesPanel.svelte';
   import Link from '../lib/components/Link.svelte';
   import Avatar from './Avatar.svelte';
   import Badge from './Badge.svelte';
   import { parseMarkdown } from '../lib/markdownLoader.js';
-  
+
   let {
     submission,
     showReviewForm = false,
     onReview = null,
+    onPropose = null,
     onCancel = null,
     reviewData = null,
     isProcessing = false,
@@ -19,42 +21,89 @@
     contributionTypes = [],
     users = [],
     multipliers = {},
-    isOwnSubmission = false
+    isOwnSubmission = false,
+    permissions = {},
+    templates = [],
+    notes = [],
+    notesLoading = false,
+    onAddNote = null
   } = $props();
-  
+
+  // Determine which actions this steward can take on this submission
+  let canAccept = $derived(
+    showReviewForm && permissions[submission.contribution_type]?.includes('accept')
+  );
+  let canReject = $derived(
+    showReviewForm && permissions[submission.contribution_type]?.includes('reject')
+  );
+  let canRequestInfo = $derived(
+    showReviewForm && permissions[submission.contribution_type]?.includes('request_more_info')
+  );
+  let canPropose = $derived(
+    showReviewForm && permissions[submission.contribution_type]?.includes('propose')
+  );
+  let hasAnyAction = $derived(canAccept || canReject || canRequestInfo || canPropose);
+
   // State for review form
   let reviewAction = $state(reviewData?.action || 'accept');
+  let proposedAction = $state('accept');
   let selectedUser = $state(reviewData?.user || submission.user);
   let selectedType = $state(reviewData?.contribution_type || submission.contribution_type);
-  let points = $state(reviewData?.points || submission.suggested_points || submission.contribution_type_details?.min_points || 0);
+  let points = $state(reviewData?.points || submission.proposed_points || submission.contribution_type_details?.min_points || 0);
   let staffReply = $state(reviewData?.staff_reply || '');
   let createHighlight = $state(reviewData?.create_highlight || false);
   let highlightTitle = $state(reviewData?.highlight_title || '');
   let highlightDescription = $state(reviewData?.highlight_description || '');
-  
+
   // For ContributionSelection component
   let selectedCategory = $state(submission.contribution_type_details?.category || 'validator');
   let selectedContributionTypeObj = $state(null);
   let selectedMission = $state(submission.mission || null);
-  
-  // Reset form when submission changes
+
+  // Track which submission's proposal we've auto-filled to avoid overwriting user edits
+  let lastProposalFilled = $state(null);
+
+  // Auto-fill form from proposal data when available
   $effect(() => {
-    if (submission) {
-      // Only reset if no existing review data
-      if (!reviewData) {
-        reviewAction = 'accept';
-        selectedUser = submission.user;
-        selectedType = submission.contribution_type;
-        points = submission.contribution_type_details?.min_points || 0;
-        staffReply = '';
-        createHighlight = false;
-        highlightTitle = '';
-        highlightDescription = '';
-        selectedCategory = submission.contribution_type_details?.category || 'validator';
+    if (submission?.has_proposal && lastProposalFilled !== submission.id) {
+      lastProposalFilled = submission.id;
+
+      const action = submission.proposed_action || 'accept';
+
+      if ((action === 'accept' && canAccept) ||
+          (action === 'reject' && canReject) ||
+          (action === 'more_info' && canRequestInfo)) {
+        reviewAction = action;
+      } else if (canPropose) {
+        reviewAction = 'propose';
+        proposedAction = action;
+      } else {
+        reviewAction = getDefaultAction();
+        proposedAction = 'accept';
       }
+
+      selectedUser = submission.proposed_user || submission.user;
+      selectedType = submission.proposed_contribution_type || submission.contribution_type;
+      points = submission.proposed_points ?? submission.contribution_type_details?.min_points ?? 0;
+      staffReply = submission.proposed_staff_reply || '';
+      createHighlight = submission.proposed_create_highlight || false;
+      highlightTitle = submission.proposed_highlight_title || '';
+      highlightDescription = submission.proposed_highlight_description || '';
+
+      const type = contributionTypes.find(t => t.id === selectedType);
+      selectedCategory = type?.category || submission.contribution_type_details?.category || 'validator';
     }
   });
-  
+
+  function getDefaultAction() {
+    // Pick the first available action as default
+    if (canAccept) return 'accept';
+    if (canReject) return 'reject';
+    if (canRequestInfo) return 'more_info';
+    if (canPropose) return 'propose';
+    return 'accept';
+  }
+
   // Sync selected contribution type with the ContributionSelection component
   $effect(() => {
     if (selectedContributionTypeObj && selectedContributionTypeObj.id !== selectedType) {
@@ -67,11 +116,11 @@
       }
     }
   });
-  
+
   function handleContributionSelectionChange(category, contributionType) {
     // Handle contribution selection change
   }
-  
+
   function getStateClass(state) {
     switch (state) {
       case 'pending':
@@ -86,7 +135,7 @@
         return 'bg-gray-100 text-gray-800';
     }
   }
-  
+
   function getStateBorderClass(state) {
     switch (state) {
       case 'pending':
@@ -101,7 +150,7 @@
         return 'border-l-gray-400';
     }
   }
-  
+
   function getStateBackgroundClass(state) {
     switch (state) {
       case 'pending':
@@ -116,30 +165,41 @@
         return 'bg-gray-50';
     }
   }
-  
+
   function formatDate(dateString) {
     if (!dateString) return 'N/A';
     return format(new Date(dateString), 'MMM d, yyyy HH:mm');
   }
-  
+
   function adjustPoints(delta) {
     const type = contributionTypes.find(t => t.id === selectedType);
     if (!type) return;
-    
+
     const newPoints = points + delta;
     points = Math.max(type.min_points, Math.min(type.max_points, newPoints));
   }
-  
+
   function getFinalPoints() {
     const multiplier = multipliers[selectedType] || 1;
     return Math.round(points * multiplier);
   }
-  
+
   function getTypeName(typeId) {
     const type = contributionTypes.find(t => t.id === typeId);
     return type?.name || 'Contribution';
   }
-  
+
+  function handleTemplateSelect(event) {
+    const templateId = event.target.value;
+    if (!templateId) return;
+    const template = templates.find(t => String(t.id) === templateId);
+    if (template) {
+      staffReply = template.text;
+    }
+    // Reset the select
+    event.target.value = '';
+  }
+
   function handleReview() {
     if (onReview) {
       const data = {
@@ -153,6 +213,27 @@
         highlight_description: highlightDescription
       };
       onReview(submission.id, data);
+    }
+  }
+
+  function handlePropose() {
+    if (onPropose) {
+      const data = {
+        proposed_action: proposedAction,
+        proposed_staff_reply: staffReply,
+      };
+
+      // Only include accept-specific fields when proposing accept
+      if (proposedAction === 'accept') {
+        data.proposed_points = points;
+        data.proposed_contribution_type = selectedType;
+        data.proposed_user = selectedUser;
+        data.proposed_create_highlight = createHighlight;
+        data.proposed_highlight_title = highlightTitle;
+        data.proposed_highlight_description = highlightDescription;
+      }
+
+      onPropose(submission.id, data);
     }
   }
 </script>
@@ -198,17 +279,29 @@
           Submitted {formatDate(submission.created_at)}
         </p>
       </div>
-      <span class="px-3 py-1 rounded-full text-sm font-medium {getStateClass(submission.state)}">
-        {submission.state_display}
-      </span>
+      <div class="flex items-center gap-2">
+        {#if submission.has_proposal}
+          <span class="px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+            Proposal
+          </span>
+        {/if}
+        {#if submission.notes_count > 0}
+          <span class="px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+            {submission.notes_count} note{submission.notes_count !== 1 ? 's' : ''}
+          </span>
+        {/if}
+        <span class="px-3 py-1 rounded-full text-sm font-medium {getStateClass(submission.state)}">
+          {submission.state_display}
+        </span>
+      </div>
     </div>
   </div>
-  
+
   <!-- Content -->
   <div class="px-6 py-4">
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:items-start">
-      <!-- Left Column - Submission Details -->
-      <div class="space-y-4">
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:items-stretch">
+      <!-- Left Column - Submission Details + CRM Notes -->
+      <div class="flex flex-col gap-4">
         {#if !isOwnSubmission}
           <div>
             <h4 class="text-sm font-medium text-gray-700">User</h4>
@@ -229,7 +322,7 @@
               </Link>
             </div>
           </div>
-          
+
           <div>
             <h4 class="text-sm font-medium text-gray-700">Contribution Type</h4>
             <div class="mt-1 flex items-center gap-2 flex-wrap">
@@ -274,7 +367,7 @@
             <div class="markdown-content mt-1 text-sm text-gray-900">{@html parseMarkdown(submission.notes)}</div>
           </div>
         {/if}
-        
+
         {#if submission.evidence_items?.length > 0}
           <div>
             <h4 class="text-sm font-medium text-gray-700">Evidence</h4>
@@ -294,15 +387,25 @@
             </ul>
           </div>
         {/if}
-        
+
         {#if submission.staff_reply && submission.state !== 'rejected'}
           <div class="bg-gray-50 p-3 rounded">
             <h4 class="text-sm font-medium text-gray-700 mb-1">Staff Response</h4>
             <div class="markdown-content text-sm text-gray-600">{@html parseMarkdown(submission.staff_reply)}</div>
           </div>
         {/if}
+
+        <!-- CRM Notes Panel (steward view only) -->
+        {#if showReviewForm && !isOwnSubmission}
+          <CRMNotesPanel
+            submissionId={submission.id}
+            {notes}
+            loading={notesLoading}
+            {onAddNote}
+          />
+        {/if}
       </div>
-      
+
       <!-- Right Column - Action Forms or Status or Contribution Card -->
       <div class="flex flex-col gap-4">
         {#if submission.state === 'accepted' && submission.contribution && isOwnSubmission}
@@ -313,250 +416,351 @@
             variant="compact"
           />
         {:else if showReviewForm && (submission.state === 'pending' || submission.state === 'more_info_needed')}
-          <div class="border {reviewAction === 'accept' ? 'border-green-200' : reviewAction === 'reject' ? 'border-red-200' : 'border-blue-200'} rounded-lg">
-            <!-- Action Toggle Buttons -->
-            <div class="flex">
-              <button
-                type="button"
-                onclick={() => reviewAction = 'accept'}
-                class="flex-1 px-3 py-2.5 text-sm font-medium transition-colors {reviewAction === 'accept' ? 'bg-green-600 text-white' : 'bg-green-50 text-green-700 hover:bg-green-100'} border-r border-gray-200"
-              >
-                Accept
-              </button>
-              <button
-                type="button"
-                onclick={() => reviewAction = 'reject'}
-                class="flex-1 px-3 py-2.5 text-sm font-medium transition-colors {reviewAction === 'reject' ? 'bg-red-600 text-white' : 'bg-red-50 text-red-700 hover:bg-red-100'} border-r border-gray-200"
-              >
-                Reject
-              </button>
-              <button
-                type="button"
-                onclick={() => reviewAction = 'more_info'}
-                class="flex-1 px-3 py-2.5 text-sm font-medium transition-colors {reviewAction === 'more_info' ? 'bg-blue-600 text-white' : 'bg-blue-50 text-blue-700 hover:bg-blue-100'}"
-              >
-                Request Info
-              </button>
-            </div>
-            
-            <!-- Dynamic Form Content -->
-            {#if reviewAction === 'accept'}
-              <div class="p-4 bg-green-50">
-                <div class="space-y-3">
-                  {#if users.length > 0}
-                    <div>
-                      <label class="block text-sm font-medium text-gray-700">
-                        Assign Contribution To
-                      </label>
-                      <div class="mt-1 flex items-center gap-2">
-                        <Avatar
-                          user={users.find(u => u.id === selectedUser)}
-                          size="sm"
-                        />
-                        <select
-                          bind:value={selectedUser}
-                          class="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm bg-white"
-                        >
-                          {#each users as user}
-                            <option value={user.id}>
-                              {user.display_name}
-                            </option>
-                          {/each}
-                        </select>
-                      </div>
-                      <p class="text-xs text-gray-500 mt-1">
-                        The contribution will be assigned to this user
-                      </p>
-                    </div>
+          <!-- Proposal Notice -->
+          {#if submission.has_proposal}
+            <div class="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2">
+              <div class="flex items-center gap-2">
+                <svg class="w-4 h-4 text-amber-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <span class="text-sm text-amber-800">
+                  Proposed by <span class="font-medium">{submission.proposed_by_details?.name || 'a steward'}</span>
+                  {#if submission.proposed_at}
+                    on {formatDate(submission.proposed_at)}
                   {/if}
-                  
-                  <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-2">
-                      Contribution Type
-                    </label>
-                    <ContributionSelection
-                      bind:selectedCategory
-                      bind:selectedContributionType={selectedContributionTypeObj}
-                      bind:selectedMission
-                      defaultContributionType={submission.contribution_type}
-                      defaultMission={submission.mission?.id}
-                      onlySubmittable={false}
-                      stewardMode={true}
-                      providedContributionTypes={contributionTypes}
-                      onSelectionChange={handleContributionSelectionChange}
-                    />
-                  </div>
-                  
-                  <div class="grid grid-cols-2 gap-4">
-                    <div>
-                      <label class="block text-sm font-medium text-gray-700 mb-2">
-                        Points
-                      </label>
-                      <div class="inline-flex items-center">
-                        <button
-                          onclick={() => adjustPoints(points > 10 ? -5 : -1)}
-                          class="w-7 h-8 flex items-center justify-center bg-white hover:bg-gray-50 rounded-l-lg text-gray-600 hover:text-gray-800 font-bold transition-colors border border-r-0 border-gray-300"
-                          type="button"
-                        >
-                          −
-                        </button>
-                        <input
-                          type="number"
-                          bind:value={points}
-                          class="w-12 h-8 px-1 border-y border-gray-300 text-sm text-center font-semibold bg-white focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent focus:z-10"
-                        />
-                        <button
-                          onclick={() => adjustPoints(points > 10 ? 5 : 1)}
-                          class="w-7 h-8 flex items-center justify-center bg-white hover:bg-gray-50 rounded-r-lg text-gray-600 hover:text-gray-800 font-bold transition-colors border border-l-0 border-gray-300"
-                          type="button"
-                        >
-                          +
-                        </button>
-                      </div>
-                      <p class="text-xs text-gray-500 mt-1">
-                        Range: {contributionTypes.find(t => t.id === selectedType)?.min_points || 0}-{contributionTypes.find(t => t.id === selectedType)?.max_points || 100}
-                      </p>
-                    </div>
-                    
-                    <div>
-                      <label class="block text-sm font-medium text-gray-700 mb-2">
-                        Final Points
-                      </label>
-                      <div class="text-2xl font-bold text-green-700">
-                        {getFinalPoints()}
-                      </div>
-                      <p class="text-xs text-gray-500 mt-1">
-                        ×{multipliers[selectedType] || 1} multiplier
-                      </p>
-                    </div>
-                  </div>
-                  
-                  <div class="border border-yellow-300 rounded-lg overflow-hidden">
-                    <button
-                      type="button"
-                      onclick={() => createHighlight = !createHighlight}
-                      class="w-full px-3 py-2 bg-yellow-50 hover:bg-yellow-100 transition-colors flex items-center justify-between text-left"
-                    >
-                      <span class="flex items-center gap-2">
-                        <svg class="w-4 h-4 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-                        </svg>
-                        <span class="text-sm font-medium text-yellow-900">Feature this contribution</span>
-                      </span>
-                      <svg 
-                        class="w-4 h-4 text-yellow-600 transition-transform {createHighlight ? 'rotate-180' : ''}" 
-                        fill="none" 
-                        stroke="currentColor" 
-                        viewBox="0 0 24 24"
-                      >
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                      </svg>
-                    </button>
-                    
-                    {#if createHighlight}
-                      <div class="px-4 py-3 bg-white border-t border-yellow-300 space-y-3">
-                        <p class="text-xs text-yellow-700 mb-2">
-                          Highlighted contributions are displayed on the dashboard and earn special recognition
-                        </p>
-                        
-                        <div>
-                          <label class="block text-sm font-medium text-gray-700 mb-1">
-                            Feature Title <span class="text-red-500">*</span>
-                          </label>
-                          <input
-                            type="text"
-                            bind:value={highlightTitle}
-                            placeholder="e.g., Outstanding Bug Discovery"
-                            class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-yellow-500"
-                          />
-                        </div>
-                        
-                        <div>
-                          <label class="block text-sm font-medium text-gray-700 mb-1">
-                            Feature Description <span class="text-red-500">*</span>
-                          </label>
-                          <textarea
-                            bind:value={highlightDescription}
-                            placeholder="Describe why this contribution is being highlighted..."
-                            rows="3"
-                            class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-yellow-500"
-                          ></textarea>
+                </span>
+              </div>
+            </div>
+          {/if}
+
+          {#if hasAnyAction}
+            <div class="border {reviewAction === 'accept' ? 'border-green-200' : reviewAction === 'reject' ? 'border-red-200' : reviewAction === 'propose' ? 'border-amber-200' : 'border-blue-200'} rounded-lg">
+              <!-- Action Toggle Buttons - Only show actions the steward has permission for -->
+              <div class="flex flex-wrap">
+                {#if canAccept}
+                  <button
+                    type="button"
+                    onclick={() => reviewAction = 'accept'}
+                    class="flex-1 px-3 py-2.5 text-sm font-medium transition-colors {reviewAction === 'accept' ? 'bg-green-600 text-white' : 'bg-green-50 text-green-700 hover:bg-green-100'} border-r border-gray-200"
+                  >
+                    Accept
+                  </button>
+                {/if}
+                {#if canReject}
+                  <button
+                    type="button"
+                    onclick={() => reviewAction = 'reject'}
+                    class="flex-1 px-3 py-2.5 text-sm font-medium transition-colors {reviewAction === 'reject' ? 'bg-red-600 text-white' : 'bg-red-50 text-red-700 hover:bg-red-100'} border-r border-gray-200"
+                  >
+                    Reject
+                  </button>
+                {/if}
+                {#if canRequestInfo}
+                  <button
+                    type="button"
+                    onclick={() => reviewAction = 'more_info'}
+                    class="flex-1 px-3 py-2.5 text-sm font-medium transition-colors {reviewAction === 'more_info' ? 'bg-blue-600 text-white' : 'bg-blue-50 text-blue-700 hover:bg-blue-100'} border-r border-gray-200"
+                  >
+                    Request Info
+                  </button>
+                {/if}
+                {#if canPropose}
+                  <button
+                    type="button"
+                    onclick={() => reviewAction = 'propose'}
+                    class="flex-1 px-3 py-2.5 text-sm font-medium transition-colors {reviewAction === 'propose' ? 'bg-amber-600 text-white' : 'bg-amber-50 text-amber-700 hover:bg-amber-100'}"
+                  >
+                    Propose
+                  </button>
+                {/if}
+              </div>
+
+              <!-- Dynamic Form Content -->
+              {#if reviewAction === 'accept' || reviewAction === 'propose'}
+                <div class="p-4 {reviewAction === 'accept' ? 'bg-green-50' : 'bg-amber-50'}">
+                  <div class="space-y-3">
+                    {#if reviewAction === 'propose'}
+                      <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-2">Proposed Action</label>
+                        <div class="flex gap-2">
+                          <button type="button" onclick={() => proposedAction = 'accept'}
+                            class="flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors {proposedAction === 'accept' ? 'bg-green-600 text-white' : 'bg-white border border-gray-300 text-gray-600 hover:bg-gray-50'}">
+                            Accept
+                          </button>
+                          <button type="button" onclick={() => proposedAction = 'reject'}
+                            class="flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors {proposedAction === 'reject' ? 'bg-red-600 text-white' : 'bg-white border border-gray-300 text-gray-600 hover:bg-gray-50'}">
+                            Reject
+                          </button>
+                          <button type="button" onclick={() => proposedAction = 'more_info'}
+                            class="flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors {proposedAction === 'more_info' ? 'bg-blue-600 text-white' : 'bg-white border border-gray-300 text-gray-600 hover:bg-gray-50'}">
+                            Request Info
+                          </button>
                         </div>
                       </div>
                     {/if}
-                  </div>
+                    {#if reviewAction === 'accept' || proposedAction === 'accept'}
+                    <div class="space-y-3">
+                    {#if users.length > 0}
+                      <div>
+                        <label class="block text-sm font-medium text-gray-700">
+                          Assign Contribution To
+                        </label>
+                        <div class="mt-1 flex items-center gap-2">
+                          <Avatar
+                            user={users.find(u => u.id === selectedUser)}
+                            size="sm"
+                          />
+                          <select
+                            bind:value={selectedUser}
+                            class="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm bg-white"
+                          >
+                            {#each users as user}
+                              <option value={user.id}>
+                                {user.display_name}
+                              </option>
+                            {/each}
+                          </select>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-1">
+                          The contribution will be assigned to this user
+                        </p>
+                      </div>
+                    {/if}
 
-                  <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">
-                      Note (optional)
-                    </label>
-                    <textarea
-                      bind:value={staffReply}
-                      placeholder="Add an optional note for this contribution..."
-                      rows="3"
-                      class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-green-500"
-                    ></textarea>
-                  </div>
+                    <div>
+                      <label class="block text-sm font-medium text-gray-700 mb-2">
+                        Contribution Type
+                      </label>
+                      <ContributionSelection
+                        bind:selectedCategory
+                        bind:selectedContributionType={selectedContributionTypeObj}
+                        bind:selectedMission
+                        defaultContributionType={submission.contribution_type}
+                        defaultMission={submission.mission?.id}
+                        onlySubmittable={false}
+                        stewardMode={true}
+                        providedContributionTypes={contributionTypes}
+                        onSelectionChange={handleContributionSelectionChange}
+                      />
+                    </div>
 
-                  <button
-                    onclick={handleReview}
-                    disabled={isProcessing}
-                    class="w-full px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-colors"
-                  >
-                    {isProcessing ? 'Processing...' : 'Accept & Create Contribution'}
-                  </button>
-                </div>
-              </div>
-            {:else if reviewAction === 'reject'}
-              <div class="p-4 bg-red-50">
-                <div class="space-y-3">
-                  <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">
-                      Rejection Reason
-                    </label>
-                    <textarea
-                      bind:value={staffReply}
-                      placeholder="Please provide a reason for rejection..."
-                      rows="4"
-                      class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-white"
-                    ></textarea>
+                    <div class="grid grid-cols-2 gap-4">
+                      <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-2">
+                          Points
+                        </label>
+                        <div class="inline-flex items-center">
+                          <button
+                            onclick={() => adjustPoints(points > 10 ? -5 : -1)}
+                            class="w-7 h-8 flex items-center justify-center bg-white hover:bg-gray-50 rounded-l-lg text-gray-600 hover:text-gray-800 font-bold transition-colors border border-r-0 border-gray-300"
+                            type="button"
+                          >
+                            −
+                          </button>
+                          <input
+                            type="number"
+                            bind:value={points}
+                            class="w-12 h-8 px-1 border-y border-gray-300 text-sm text-center font-semibold bg-white focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent focus:z-10"
+                          />
+                          <button
+                            onclick={() => adjustPoints(points > 10 ? 5 : 1)}
+                            class="w-7 h-8 flex items-center justify-center bg-white hover:bg-gray-50 rounded-r-lg text-gray-600 hover:text-gray-800 font-bold transition-colors border border-l-0 border-gray-300"
+                            type="button"
+                          >
+                            +
+                          </button>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-1">
+                          Range: {contributionTypes.find(t => t.id === selectedType)?.min_points || 0}-{contributionTypes.find(t => t.id === selectedType)?.max_points || 100}
+                        </p>
+                      </div>
+
+                      <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-2">
+                          Final Points
+                        </label>
+                        <div class="text-2xl font-bold {reviewAction === 'accept' ? 'text-green-700' : 'text-amber-700'}">
+                          {getFinalPoints()}
+                        </div>
+                        <p class="text-xs text-gray-500 mt-1">
+                          ×{multipliers[selectedType] || 1} multiplier
+                        </p>
+                      </div>
+                    </div>
+
+                    <div class="border border-yellow-300 rounded-lg overflow-hidden">
+                      <button
+                        type="button"
+                        onclick={() => createHighlight = !createHighlight}
+                        class="w-full px-3 py-2 bg-yellow-50 hover:bg-yellow-100 transition-colors flex items-center justify-between text-left"
+                      >
+                        <span class="flex items-center gap-2">
+                          <svg class="w-4 h-4 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+                          </svg>
+                          <span class="text-sm font-medium text-yellow-900">Feature this contribution</span>
+                        </span>
+                        <svg
+                          class="w-4 h-4 text-yellow-600 transition-transform {createHighlight ? 'rotate-180' : ''}"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                      </button>
+
+                      {#if createHighlight}
+                        <div class="px-4 py-3 bg-white border-t border-yellow-300 space-y-3">
+                          <p class="text-xs text-yellow-700 mb-2">
+                            Highlighted contributions are displayed on the dashboard and earn special recognition
+                          </p>
+
+                          <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1">
+                              Feature Title <span class="text-red-500">*</span>
+                            </label>
+                            <input
+                              type="text"
+                              bind:value={highlightTitle}
+                              placeholder="e.g., Outstanding Bug Discovery"
+                              class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-yellow-500"
+                            />
+                          </div>
+
+                          <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1">
+                              Feature Description <span class="text-red-500">*</span>
+                            </label>
+                            <textarea
+                              bind:value={highlightDescription}
+                              placeholder="Describe why this contribution is being highlighted..."
+                              rows="3"
+                              class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-yellow-500"
+                            ></textarea>
+                          </div>
+                        </div>
+                      {/if}
+                    </div>
+                    </div>
+                    {/if}
+
+                    <div>
+                      <label class="block text-sm font-medium text-gray-700 mb-1">
+                        {reviewAction === 'propose' && proposedAction === 'reject' ? 'Rejection Reason' : reviewAction === 'propose' && proposedAction === 'more_info' ? 'Information Needed' : 'Note (optional)'}
+                      </label>
+                      {#if templates.length > 0}
+                        <select
+                          onchange={handleTemplateSelect}
+                          class="w-full px-3 py-1.5 mb-2 border border-gray-300 rounded-md text-sm bg-white text-gray-600"
+                        >
+                          <option value="">-- Select template --</option>
+                          {#each templates as template}
+                            <option value={template.id}>{template.label}</option>
+                          {/each}
+                        </select>
+                      {/if}
+                      <textarea
+                        bind:value={staffReply}
+                        placeholder={reviewAction === 'propose' && proposedAction === 'reject' ? 'Please provide a reason for rejection...' : reviewAction === 'propose' && proposedAction === 'more_info' ? 'What additional information do you need?' : 'Add an optional note for this contribution...'}
+                        rows="3"
+                        class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 {reviewAction === 'accept' ? 'focus:ring-green-500' : 'focus:ring-amber-500'}"
+                      ></textarea>
+                    </div>
+
+                    {#if reviewAction === 'accept'}
+                      <button
+                        onclick={handleReview}
+                        disabled={isProcessing}
+                        class="w-full px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-colors"
+                      >
+                        {isProcessing ? 'Processing...' : 'Accept & Create Contribution'}
+                      </button>
+                    {:else}
+                      <!-- Propose action -->
+                      <button
+                        onclick={handlePropose}
+                        disabled={isProcessing}
+                        class="w-full px-4 py-2 bg-amber-600 text-white rounded-md hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-colors"
+                      >
+                        {isProcessing ? 'Processing...' : 'Submit Proposal'}
+                      </button>
+                    {/if}
                   </div>
-                  
-                  <button
-                    onclick={handleReview}
-                    disabled={isProcessing}
-                    class="w-full px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-colors"
-                  >
-                    {isProcessing ? 'Processing...' : 'Reject Submission'}
-                  </button>
                 </div>
-              </div>
-            {:else if reviewAction === 'more_info'}
-              <div class="p-4 bg-blue-50">
-                <div class="space-y-3">
-                  <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-1">
-                      Information Needed
-                    </label>
-                    <textarea
-                      bind:value={staffReply}
-                      placeholder="What additional information do you need from the submitter?"
-                      rows="4"
-                      class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-white"
-                    ></textarea>
+              {:else if reviewAction === 'reject'}
+                <div class="p-4 bg-red-50">
+                  <div class="space-y-3">
+                    <div>
+                      <label class="block text-sm font-medium text-gray-700 mb-1">
+                        Rejection Reason
+                      </label>
+                      {#if templates.length > 0}
+                        <select
+                          onchange={handleTemplateSelect}
+                          class="w-full px-3 py-1.5 mb-2 border border-gray-300 rounded-md text-sm bg-white text-gray-600"
+                        >
+                          <option value="">-- Select template --</option>
+                          {#each templates as template}
+                            <option value={template.id}>{template.label}</option>
+                          {/each}
+                        </select>
+                      {/if}
+                      <textarea
+                        bind:value={staffReply}
+                        placeholder="Please provide a reason for rejection..."
+                        rows="4"
+                        class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-white"
+                      ></textarea>
+                    </div>
+
+                    <button
+                      onclick={handleReview}
+                      disabled={isProcessing}
+                      class="w-full px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-colors"
+                    >
+                      {isProcessing ? 'Processing...' : 'Reject Submission'}
+                    </button>
                   </div>
-                  
-                  <button
-                    onclick={handleReview}
-                    disabled={isProcessing}
-                    class="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-colors"
-                  >
-                    {isProcessing ? 'Processing...' : 'Request Information'}
-                  </button>
                 </div>
-              </div>
-            {/if}
-          </div>
+              {:else if reviewAction === 'more_info'}
+                <div class="p-4 bg-blue-50">
+                  <div class="space-y-3">
+                    <div>
+                      <label class="block text-sm font-medium text-gray-700 mb-1">
+                        Information Needed
+                      </label>
+                      {#if templates.length > 0}
+                        <select
+                          onchange={handleTemplateSelect}
+                          class="w-full px-3 py-1.5 mb-2 border border-gray-300 rounded-md text-sm bg-white text-gray-600"
+                        >
+                          <option value="">-- Select template --</option>
+                          {#each templates as template}
+                            <option value={template.id}>{template.label}</option>
+                          {/each}
+                        </select>
+                      {/if}
+                      <textarea
+                        bind:value={staffReply}
+                        placeholder="What additional information do you need from the submitter?"
+                        rows="4"
+                        class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-white"
+                      ></textarea>
+                    </div>
+
+                    <button
+                      onclick={handleReview}
+                      disabled={isProcessing}
+                      class="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-colors"
+                    >
+                      {isProcessing ? 'Processing...' : 'Request Information'}
+                    </button>
+                  </div>
+                </div>
+              {/if}
+            </div>
+          {/if}
         {:else if submission.state === 'accepted' && submission.contribution}
           <!-- Show contribution details if accepted -->
           <ContributionCard

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -190,6 +190,17 @@ export const stewardAPI = {
   bulkRejectSubmissions: (submissionIds, staffReply) =>
     api.post('/steward-submissions/bulk-reject/', { submission_ids: submissionIds, staff_reply: staffReply }),
 
+  // Steward permissions and templates
+  getMyPermissions: () => api.get('/steward-submissions/my-permissions/'),
+  getTemplates: () => api.get('/steward-submissions/templates/'),
+
+  // Proposals
+  proposeSubmission: (id, data) => api.post(`/steward-submissions/${id}/propose/`, data),
+
+  // CRM Notes
+  getNotes: (id) => api.get(`/steward-submissions/${id}/notes/`),
+  addNote: (id, message) => api.post(`/steward-submissions/${id}/notes/`, { message }),
+
   // Working Groups
   getWorkingGroups: () => api.get('/stewards/working-groups/'),
   getWorkingGroup: (id) => api.get(`/stewards/working-groups/${id}/`),

--- a/frontend/src/lib/searchToParams.js
+++ b/frontend/src/lib/searchToParams.js
@@ -99,6 +99,13 @@ export function searchToParams(parsed, options = {}) {
     params.exclude_empty_evidence = true;
   }
 
+  // has:proposal / no:proposal → proposal filter
+  if (filters.has && filters.has.includes('proposal')) {
+    params.has_proposal = true;
+  } else if (filters.no && filters.no.includes('proposal')) {
+    params.has_proposal = false;
+  }
+
   // min-contributions
   if (filters.minContributions !== null && filters.minContributions > 0) {
     params.min_accepted_contributions = filters.minContributions;

--- a/frontend/src/lib/stewardPermissions.js
+++ b/frontend/src/lib/stewardPermissions.js
@@ -1,0 +1,39 @@
+import { writable, get } from 'svelte/store';
+import { stewardAPI } from './api.js';
+
+const permissions = writable({});
+
+let loaded = false;
+
+async function load() {
+  try {
+    const response = await stewardAPI.getMyPermissions();
+    permissions.set(response.data || {});
+    loaded = true;
+  } catch (err) {
+    permissions.set({});
+  }
+}
+
+function hasPermission(contributionTypeId, action) {
+  const perms = get(permissions);
+  const actions = perms[String(contributionTypeId)] || [];
+  return actions.includes(action);
+}
+
+function getActions(contributionTypeId) {
+  const perms = get(permissions);
+  return perms[String(contributionTypeId)] || [];
+}
+
+function isLoaded() {
+  return loaded;
+}
+
+export const stewardPermissions = {
+  subscribe: permissions.subscribe,
+  load,
+  hasPermission,
+  getActions,
+  isLoaded,
+};

--- a/frontend/src/routes/StewardDashboard.svelte
+++ b/frontend/src/routes/StewardDashboard.svelte
@@ -237,20 +237,31 @@
                 <div class="p-4 hover:bg-gray-50 transition-colors">
                   <div class="flex items-center justify-between">
                     <div class="flex items-center gap-3">
-                      <Avatar 
+                      <Avatar
                         user={steward}
                         size="sm"
                         clickable={true}
                       />
                       <div class="min-w-0">
-                        <button
-                          onclick={() => push(`/participant/${steward.address}`)}
-                          class="text-sm font-medium text-gray-900 hover:{$categoryTheme.text} transition-colors truncate"
-                        >
-                          {steward.name || `${steward.address.slice(0, 6)}...${steward.address.slice(-4)}`}
-                        </button>
-                        <div class="text-xs text-gray-500">
-                          Steward since {format(new Date(steward.created_at), 'MMM yyyy')}
+                        <div class="flex items-center gap-2">
+                          <button
+                            onclick={() => push(`/participant/${steward.address}`)}
+                            class="text-sm font-medium text-gray-900 hover:{$categoryTheme.text} transition-colors truncate"
+                          >
+                            {steward.name || `${steward.address.slice(0, 6)}...${steward.address.slice(-4)}`}
+                          </button>
+                          {#if steward.role === 'Steward'}
+                            <span class="px-1.5 py-0.5 text-[10px] font-medium rounded bg-green-100 text-green-700">Steward</span>
+                          {:else if steward.role === 'Reviewer'}
+                            <span class="px-1.5 py-0.5 text-[10px] font-medium rounded bg-blue-100 text-blue-700">Reviewer</span>
+                          {/if}
+                        </div>
+                        <div class="flex items-center gap-1.5 text-xs text-gray-500">
+                          <span>Since {format(new Date(steward.created_at), 'MMM yyyy')}</span>
+                          {#if steward.permitted_categories?.length > 0}
+                            <span class="text-gray-300">·</span>
+                            <span class="text-gray-400">{steward.permitted_categories.join(', ')}</span>
+                          {/if}
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- **Steward Permission System**: Per-action (`propose`, `accept`, `reject`, `request_more_info`), per-contribution-type permissions via `StewardPermission` model. Stewards only see submissions for their permitted contribution types.
- **Proposal System**: Stewards with `propose` permission can propose actions (accept/reject/request info) with all relevant fields. Proposals auto-fill the review form for stewards with final action permissions. Each proposal creates a CRM note preserving history.
- **CRM Notes**: Internal `SubmissionNote` model for steward-only notes on submissions, with a dedicated panel in the review UI. Proposal history is automatically tracked.
- **Review Templates**: Admin-managed `ReviewTemplate` model with template dropdown in all action forms (accept, reject, request info, propose).
- **In-place Updates**: All steward actions (review, propose, assign, bulk reject) now update the UI in-place without full page reloads.
- **Role Display**: Steward dashboard shows role badges ("Steward" vs "Reviewer") and permitted contribution categories.
- **Data Migration**: Existing stewards automatically granted all permissions on all contribution types to preserve current behavior.

## Backend Changes
- `StewardPermission` and `ReviewTemplate` models in `stewards/`
- `SubmissionNote` model and `proposed_*` fields on `SubmittedContribution`
- Permission enforcement in `get_queryset()`, `review()`, and `bulk_reject()`
- New endpoints: `my-permissions`, `templates`, `propose`, `notes`
- Renamed `suggested_points` → `proposed_points`

## Frontend Changes
- Permission-based conditional action buttons in `SubmissionCard`
- Propose form with action sub-selector (accept/reject/request info)
- Auto-fill from proposals with yellow notification banner
- `CRMNotesPanel` component with scrollable notes list
- `stewardPermissions.js` store
- `has:proposal` / `no:proposal` search filters
- Role badges on steward dashboard

## Test plan
- [ ] Verify migrations run cleanly
- [ ] Verify existing stewards get all permissions via data migration
- [ ] Test permission filtering: limited steward only sees permitted submission types
- [ ] Test action enforcement: 403 when attempting unpermitted actions
- [ ] Test propose flow: submit proposal, verify fields set and CRM note created
- [ ] Test proposal auto-fill: open submission with proposal, verify form pre-filled
- [ ] Test review clears proposal fields
- [ ] Test CRM notes: add note, verify visible to other stewards
- [ ] Test templates: create in admin, verify dropdown works
- [ ] Test in-place updates: review/propose/assign without page reload
- [ ] Test bulk reject with permission filtering
- [ ] Test `has:proposal` search filter
- [ ] Test role badges on steward dashboard