### PR TITLE
Add review delay notice to steward dashboard

### DIFF
--- a/frontend/src/routes/StewardDashboard.svelte
+++ b/frontend/src/routes/StewardDashboard.svelte
@@ -80,7 +80,17 @@
 <div class="container mx-auto px-4 py-8 min-h-screen {$categoryTheme.bg}" style="margin: -2rem -1rem; padding: 2rem 3rem;">
   <!-- Header -->
   <h1 class="text-2xl font-bold text-gray-900 mb-6">Steward Dashboard</h1>
-  
+
+  <!-- Temporary review delay notice -->
+  <div class="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6 flex items-start gap-3">
+    <svg class="w-5 h-5 text-amber-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+    </svg>
+    <p class="text-sm text-amber-800">
+      Contribution reviews will experience a brief delay this week. All submissions are being recorded and will be reviewed shortly. Thank you for your patience and continued participation.
+    </p>
+  </div>
+
   {#if loading}
     <div class="flex justify-center items-center p-8">
       <div class="animate-spin rounded-full h-10 w-10 border-b-2 border-primary-600"></div>


### PR DESCRIPTION
Adds a temporary amber notice banner to the Steward Dashboard informing the community that contribution reviews will experience a brief delay this week. All submissions continue to be recorded and will be reviewed shortly. The notice is easy to remove once reviews catch up.