### PR TITLE
Move review delay notice to global layout

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -287,6 +287,15 @@
   <div class="flex-1 flex overflow-hidden">
     <Sidebar bind:isOpen={sidebarOpen} />
     <main class="flex-1 overflow-y-auto container mx-auto px-4 py-4 md:py-6 lg:py-8">
+      <!-- Temporary review delay notice -->
+      <div class="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-4 flex items-start gap-3">
+        <svg class="w-5 h-5 text-amber-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+        </svg>
+        <p class="text-sm text-amber-800">
+          Contribution reviews are currently delayed. All submissions are being recorded and will be reviewed shortly. Thank you for your patience and continued participation.
+        </p>
+      </div>
       <Router
         {routes}
         on:conditionsFailed={hideTooltips}

--- a/frontend/src/routes/StewardDashboard.svelte
+++ b/frontend/src/routes/StewardDashboard.svelte
@@ -81,16 +81,6 @@
   <!-- Header -->
   <h1 class="text-2xl font-bold text-gray-900 mb-6">Steward Dashboard</h1>
 
-  <!-- Temporary review delay notice -->
-  <div class="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6 flex items-start gap-3">
-    <svg class="w-5 h-5 text-amber-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-    </svg>
-    <p class="text-sm text-amber-800">
-      Contribution reviews will experience a brief delay this week. All submissions are being recorded and will be reviewed shortly. Thank you for your patience and continued participation.
-    </p>
-  </div>
-
   {#if loading}
     <div class="flex justify-center items-center p-8">
       <div class="animate-spin rounded-full h-10 w-10 border-b-2 border-primary-600"></div>


### PR DESCRIPTION
Moves the temporary review delay banner from StewardDashboard into App.svelte so it appears on every page. Updates the notice text to the finalized version.