### PR TITLE
Fix background overlap in steward dashboard

### DIFF
--- a/frontend/src/routes/ContributionTypeDetail.svelte
+++ b/frontend/src/routes/ContributionTypeDetail.svelte
@@ -238,7 +238,7 @@
   }
 </style>
 
-<div class="min-h-screen {categoryColors.pageBg} -m-8 p-8">
+<div class="{categoryColors.pageBg} rounded-lg p-6 sm:p-8">
   <div class="space-y-6 sm:space-y-8">
     {#if loading}
     <div class="flex justify-center items-center p-8">

--- a/frontend/src/routes/StewardDashboard.svelte
+++ b/frontend/src/routes/StewardDashboard.svelte
@@ -77,7 +77,7 @@
   }
 </script>
 
-<div class="container mx-auto px-4 py-8 min-h-screen {$categoryTheme.bg}" style="margin: -2rem -1rem; padding: 2rem 3rem;">
+<div class="container mx-auto px-4 py-8">
   <!-- Header -->
   <h1 class="text-2xl font-bold text-gray-900 mb-6">Steward Dashboard</h1>
 


### PR DESCRIPTION
Remove negative margin hacks from steward dashboard and contribution detail pages that were causing visual overlap issues. Simplify to standard spacing patterns for better layout consistency.