### PR TITLE
Update faucet URL to new testnet faucet

### DIFF
--- a/frontend/src/lib/config.js
+++ b/frontend/src/lib/config.js
@@ -2,7 +2,7 @@
 export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 
 // External Links Configuration
-export const FAUCET_URL = 'https://genlayer-testnet.hub.caldera.xyz/';
+export const FAUCET_URL = 'https://testnet-faucet.genlayer.foundation/';
 
 // Application Configuration
 export const APP_NAME = 'Tally';


### PR DESCRIPTION
## Summary
- Update faucet URL from `https://genlayer-testnet.hub.caldera.xyz/` to `https://testnet-faucet.genlayer.foundation/`

## Test plan
- [ ] Verify faucet link on builder progress page opens the new URL
- [ ] Confirm the new faucet page loads correctly