### PR TITLE
Migrate RPC and explorer from Caldera to ZKSync OS testnet

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -42,7 +42,7 @@ ALLOWED_HOSTS=your-apprunner-url.amazonaws.com,your-custom-domain.com
 FRONTEND_URL=https://main.d1234567890.amplifyapp.com
 SIWE_DOMAIN=main.d1234567890.amplifyapp.com
 VALIDATOR_CONTRACT_ADDRESS=0x7CceE43964F70CEAEfDED4b8b07410D30d64eC37
-VALIDATOR_RPC_URL=https://genlayer-testnet.rpc.caldera.xyz/http
+VALIDATOR_RPC_URL=https://zksync-os-testnet-genlayer.zksync.dev
 ```
 
 ### 3. Deploy Frontend (Amplify)
@@ -60,7 +60,7 @@ VALIDATOR_RPC_URL=https://genlayer-testnet.rpc.caldera.xyz/http
 ```
 VITE_API_URL=https://your-apprunner-url.amazonaws.com
 VITE_APP_NAME=Tally
-VITE_VALIDATOR_RPC_URL=https://genlayer-testnet.rpc.caldera.xyz/http
+VITE_VALIDATOR_RPC_URL=https://zksync-os-testnet-genlayer.zksync.dev
 VITE_VALIDATOR_CONTRACT_ADDRESS=0x143d20974FA35f72B8103f54D8A47F2991940d99
 ```
 

--- a/amplify.yml
+++ b/amplify.yml
@@ -22,7 +22,7 @@ applications:
             # Add your API endpoint here after App Runner deployment
             VITE_API_URL: https://tally-backend.33qpgck0g28d0.us-east-1.cs.amazonlightsail.com
             VITE_APP_NAME: Tally
-            VITE_VALIDATOR_RPC_URL: https://genlayer-testnet.rpc.caldera.xyz/http
+            VITE_VALIDATOR_RPC_URL: https://zksync-os-testnet-genlayer.zksync.dev
             VITE_VALIDATOR_CONTRACT_ADDRESS: 0x143d20974FA35f72B8103f54D8A47F2991940d99
     # Backend is handled by App Runner, not Amplify
     # This configuration is for frontend-only deployment

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,12 +35,12 @@ SIWE_DOMAIN=localhost
 # Blockchain Settings
 FACTORY_CONTRACT_ADDRESS=0x19f030293B97281fb742D9f3699DC9bA439706dD # ValidatorWalletFactory.sol
 VALIDATOR_CONTRACT_ADDRESS=0x19f030293B97281fb742D9f3699DC9bA439706dD # Staking.sol
-VALIDATOR_RPC_URL=https://genlayer-testnet.rpc.caldera.xyz/http
+VALIDATOR_RPC_URL=https://zksync-os-testnet-genlayer.zksync.dev
 
 # GenLayer Integration
 # The VALIDATOR_RPC_URL is also used for GenLayer Studio deployment checking
 # If you need a different RPC URL for GenLayer operations, you can optionally add:
-# GENLAYER_RPC_URL=https://genlayer-testnet.rpc.caldera.xyz/http
+# GENLAYER_RPC_URL=https://zksync-os-testnet-genlayer.zksync.dev
 
 # Cloudinary configuration (optional)
 # Sign up at https://cloudinary.com for free account

--- a/backend/aws-deployment-guide.md
+++ b/backend/aws-deployment-guide.md
@@ -91,7 +91,7 @@ aws ssm put-parameter --name "/tally/prod/allowed_hosts" --value "your-domain.co
 aws ssm put-parameter --name "/tally/prod/csrf_trusted_origins" --value "https://your-domain.com" --type "String"
 aws ssm put-parameter --name "/tally/prod/siwe_domain" --value "your-domain.com" --type "String"
 aws ssm put-parameter --name "/tally/prod/validator_contract_address" --value "0x7CceE43964F70CEAEfDED4b8b07410D30d64eC37" --type "String"
-aws ssm put-parameter --name "/tally/prod/validator_rpc_url" --value "https://genlayer-testnet.rpc.caldera.xyz/http" --type "String"
+aws ssm put-parameter --name "/tally/prod/validator_rpc_url" --value "https://zksync-os-testnet-genlayer.zksync.dev" --type "String"
 
 # reCAPTCHA configuration (required for spam protection)
 # Get keys from https://www.google.com/recaptcha/admin

--- a/backend/plan.md
+++ b/backend/plan.md
@@ -20,9 +20,9 @@
    - SSM parameters copied from /tally/* to /points/*
 
 ### The Problem
-Both App Runner services (`tally-backend` and `points-backend`) cannot reach external APIs (specifically `genlayer-testnet.rpc.caldera.xyz`) when using VPC connector. The error:
+Both App Runner services (`tally-backend` and `points-backend`) cannot reach external APIs (specifically `zksync-os-testnet-genlayer.zksync.dev`) when using VPC connector. The error:
 ```
-Network is unreachable - HTTPSConnectionPool(host='genlayer-testnet.rpc.caldera.xyz', port=443)
+Network is unreachable - HTTPSConnectionPool(host='zksync-os-testnet-genlayer.zksync.dev', port=443)
 ```
 
 **Root Cause Identified**: The NAT Gateway was created in subnet-080dc8ee51a2732f0, which is associated with the private route table. This creates a circular dependency - the private subnets route to the NAT Gateway, but the NAT Gateway itself is in a subnet that only has a route back to itself, not to the Internet Gateway.

--- a/backend/test_deployment_endpoint.py
+++ b/backend/test_deployment_endpoint.py
@@ -18,7 +18,7 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tally.settings')
 os.environ['SECRET_KEY'] = 'test-secret-key'
 os.environ['DEBUG'] = 'True'
 os.environ['VALIDATOR_CONTRACT_ADDRESS'] = '0x19f030293B97281fb742D9f3699DC9bA439706dD'
-os.environ['VALIDATOR_RPC_URL'] = 'https://genlayer-testnet.rpc.caldera.xyz/http'
+os.environ['VALIDATOR_RPC_URL'] = 'https://zksync-os-testnet-genlayer.zksync.dev'
 os.environ['SIWE_DOMAIN'] = 'localhost'
 
 try:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,7 +6,7 @@ VITE_APP_NAME=Tally
 VITE_APP_DESCRIPTION=GenLayer Testnet Program Tracking System
 
 # Validator contract configuration
-VITE_VALIDATOR_RPC_URL=https://genlayer-testnet.rpc.caldera.xyz/http
+VITE_VALIDATOR_RPC_URL=https://zksync-os-testnet-genlayer.zksync.dev
 VITE_VALIDATOR_CONTRACT_ADDRESS=0x10eCB157734c8152f1d84D00040c8AA46052CB27
 
 # Blockchain Explorer

--- a/frontend/src/components/BuilderProgress.svelte
+++ b/frontend/src/components/BuilderProgress.svelte
@@ -70,8 +70,8 @@
       symbol: 'GEN',
       decimals: 18
     },
-    rpcUrls: ['https://genlayer-testnet.rpc.caldera.xyz/http'],
-    blockExplorerUrls: ['https://genlayer-testnet.explorer.caldera.xyz']
+    rpcUrls: ['https://zksync-os-testnet-genlayer.zksync.dev'],
+    blockExplorerUrls: ['https://zksync-os-testnet-genlayer.explorer.zksync.dev']
   };
   
   const STUDIO_NETWORK = {

--- a/frontend/src/lib/blockchain.js
+++ b/frontend/src/lib/blockchain.js
@@ -4,7 +4,7 @@ import { ethers } from 'ethers';
 // Contract configuration - frontend-only
 const CONTRACT_INFO = {
   contract_address: import.meta.env.VITE_VALIDATOR_CONTRACT_ADDRESS || '0x10eCB157734c8152f1d84D00040c8AA46052CB27',
-  rpc_url: import.meta.env.VITE_VALIDATOR_RPC_URL || 'https://genlayer-testnet.rpc.caldera.xyz/http',
+  rpc_url: import.meta.env.VITE_VALIDATOR_RPC_URL || 'https://zksync-os-testnet-genlayer.zksync.dev',
   abi: [
     // Essential functions for validator management
     {
@@ -47,8 +47,8 @@ const ASIMOV_NETWORK = {
     symbol: 'GEN',
     decimals: 18
   },
-  rpcUrls: ['https://genlayer-testnet.rpc.caldera.xyz/http'],
-  blockExplorerUrls: ['https://genlayer-testnet.explorer.caldera.xyz']
+  rpcUrls: ['https://zksync-os-testnet-genlayer.zksync.dev'],
+  blockExplorerUrls: ['https://zksync-os-testnet-genlayer.explorer.zksync.dev']
 };
 
 /**


### PR DESCRIPTION
## Summary
- Replace all Caldera RPC URLs with new ZKSync OS testnet endpoint (`zksync-os-testnet-genlayer.zksync.dev`)
- Update MetaMask wallet block explorer URLs to new ZKSync explorer
- Update all env examples, deployment docs, and Amplify build config

## Test plan
- [ ] Verify MetaMask can add the Asimov network with the new RPC
- [ ] Verify builder journey network steps work correctly
- [ ] Update AWS SSM parameters for dev and prod (see PR description commands below)

## AWS SSM Parameter Updates

### Dev
```bash
aws ssm put-parameter --name "/tally/dev/validator_rpc_url" --value "https://zksync-os-testnet-genlayer.zksync.dev" --type "String" --overwrite
aws ssm put-parameter --name "/points/dev/validator_rpc_url" --value "https://zksync-os-testnet-genlayer.zksync.dev" --type "String" --overwrite
```

### Prod
```bash
aws ssm put-parameter --name "/tally/prod/validator_rpc_url" --value "https://zksync-os-testnet-genlayer.zksync.dev" --type "String" --overwrite
aws ssm put-parameter --name "/points/prod/validator_rpc_url" --value "https://zksync-os-testnet-genlayer.zksync.dev" --type "String" --overwrite
```