### PR TITLE
fix(community): optimize leaderboard/community endpoint to prevent 30s timeout (#383)

### DIFF
--- a/backend/leaderboard/views.py
+++ b/backend/leaderboard/views.py
@@ -428,34 +428,53 @@ class LeaderboardViewSet(viewsets.ReadOnlyModelViewSet):
         Returns users with referrals sorted by total referral points.
         """
         from .models import ReferralPoints
-        from users.serializers import UserSerializer
-        from django.db.models import F
+        from django.db.models import F, Sum
 
-        # Get all referral points ordered by total points (builder + validator)
+        # Optional limit to keep response size controlled on large datasets
+        try:
+            limit = int(request.query_params.get('limit', 200))
+        except (ValueError, TypeError):
+            limit = 200
+        limit = min(max(limit, 1), 1000)
+
+        # Single optimized queryset with only fields needed by the UI
         referral_points = ReferralPoints.objects.select_related('user').annotate(
             total_points=F('builder_points') + F('validator_points')
-        ).filter(user__visible=True, total_points__gt=0).order_by('-total_points')
+        ).filter(
+            user__visible=True,
+            total_points__gt=0
+        ).order_by('-total_points')
 
-        # Calculate aggregate stats
+        # Aggregate from DB (avoid python loops over queryset)
+        aggregates = referral_points.aggregate(
+            total_builder_points=Sum('builder_points'),
+            total_validator_points=Sum('validator_points')
+        )
         total_community = referral_points.count()
-        total_builder_points = sum(rp.builder_points for rp in referral_points)
-        total_validator_points = sum(rp.validator_points for rp in referral_points)
 
-        # Get all community members
-        top_community = []
-        for rp in referral_points:
-            user_data = UserSerializer(rp.user).data
-            top_community.append({
-                **user_data,
-                'builder_points': rp.builder_points,
-                'validator_points': rp.validator_points,
-                'total_points': rp.builder_points + rp.validator_points
-            })
+        # Return lightweight rows only; avoids heavy nested serializers/N+1 queries
+        top_community = list(
+            referral_points.values(
+                'user__id',
+                'user__name',
+                'user__address',
+                'user__profile_image_url',
+                'builder_points',
+                'validator_points',
+                'total_points'
+            )[:limit]
+        )
+
+        for row in top_community:
+            row['id'] = row.pop('user__id')
+            row['name'] = row.pop('user__name')
+            row['address'] = row.pop('user__address')
+            row['profile_image_url'] = row.pop('user__profile_image_url')
 
         return Response({
             'total_community': total_community,
-            'total_builder_points': total_builder_points,
-            'total_validator_points': total_validator_points,
+            'total_builder_points': aggregates['total_builder_points'] or 0,
+            'total_validator_points': aggregates['total_validator_points'] or 0,
             'top_community': top_community
         })
 


### PR DESCRIPTION
## Summary
This PR fixes issue #383 where the Community page (`Top Community Members`) could fail with `timeout of 30000ms exceeded`.

## Root Cause
The `/api/v1/leaderboard/community/` endpoint serialized each user with full `UserSerializer`, which is expensive and can trigger slow/N+1 query behavior as data grows.

## Changes
- Optimized `community` action in `backend/leaderboard/views.py`:
  - Replaced full `UserSerializer` usage with a lightweight `values(...)` projection for only required fields:
    - `id`, `name`, `address`, `profile_image_url`, `builder_points`, `validator_points`, `total_points`
  - Moved totals computation to DB aggregation (`Sum`) instead of Python loops
  - Added optional `limit` query param (default `200`, clamped to `1..1000`) to control payload size

## Why this fixes it
The endpoint now performs less work per row and returns a smaller payload, significantly reducing response time and lowering timeout risk on the Community page.

## Issue
Closes #383

## Testing
- Static check: `python -m py_compile backend/leaderboard/views.py` passed
- Manual verification recommended:
  1. Open `/community`
  2. Confirm `Top Community Members` loads without timeout
  3. (Optional) Verify `?limit=50` returns bounded results
