### PR TITLE
perf(leaderboard): reduce builder/community "view all" latency by skipping validator-only counts (#378)

### DIFF
--- a/backend/leaderboard/serializers.py
+++ b/backend/leaderboard/serializers.py
@@ -49,10 +49,12 @@ class LeaderboardEntrySerializer(serializers.ModelSerializer):
 
     def get_active_validators_count(self, obj):
         """
-        Get count of active validator wallets for this user's validator.
-        Returns null if user has no validator wallets linked, otherwise returns the active count.
-        Uses annotated values from queryset to avoid N+1 queries.
+        Get count of active validator wallets for validator-related leaderboards.
+        Returns null for other leaderboard types.
         """
+        if obj.type not in {'validator', 'validator-waitlist', 'validator-waitlist-graduation'}:
+            return None
+
         # Use annotated values if available (from optimized queryset)
         if hasattr(obj, '_total_validators_count') and hasattr(obj, '_active_validators_count'):
             # If no validator wallets at all, return null

--- a/backend/leaderboard/views.py
+++ b/backend/leaderboard/views.py
@@ -72,34 +72,41 @@ class LeaderboardViewSet(viewsets.ReadOnlyModelViewSet):
             'user__creator'
         )
 
-        # Annotate with validator wallet counts to avoid N+1 queries
-        queryset = queryset.annotate(
-            _active_validators_count=Count(
-                'user__validator__validator_wallets',
-                filter=Q(user__validator__validator_wallets__status='active')
-            ),
-            _total_validators_count=Count(
-                'user__validator__validator_wallets'
-            )
-        )
-
         # Filter by user address if provided
         user_address = self.request.query_params.get('user_address')
+        leaderboard_type = self.request.query_params.get('type')
+
         if user_address:
             queryset = queryset.filter(user__address__iexact=user_address)
             # When filtering by user, don't apply type filter unless explicitly provided
-            leaderboard_type = self.request.query_params.get('type')
             if leaderboard_type:
                 queryset = queryset.filter(type=leaderboard_type)
         else:
             # Get type from query params
-            leaderboard_type = self.request.query_params.get('type')
-
             if leaderboard_type:
                 queryset = queryset.filter(type=leaderboard_type)
             else:
                 # Default to validator leaderboard only when not filtering by user
+                leaderboard_type = 'validator'
                 queryset = queryset.filter(type='validator')
+
+        # Validator wallet count annotations are expensive and only needed
+        # for validator-oriented leaderboards.
+        needs_validator_counts = leaderboard_type in {
+            'validator',
+            'validator-waitlist',
+            'validator-waitlist-graduation',
+        }
+        if needs_validator_counts:
+            queryset = queryset.annotate(
+                _active_validators_count=Count(
+                    'user__validator__validator_wallets',
+                    filter=Q(user__validator__validator_wallets__status='active')
+                ),
+                _total_validators_count=Count(
+                    'user__validator__validator_wallets'
+                )
+            )
 
         # Handle rank ordering
         order = self.request.query_params.get('order', 'asc')
@@ -109,7 +116,6 @@ class LeaderboardViewSet(viewsets.ReadOnlyModelViewSet):
             queryset = queryset.order_by('rank')
 
         return queryset
-
     def list(self, request, *args, **kwargs):
         """
         Override to apply limit after filtering/ordering.
@@ -521,3 +527,4 @@ class LeaderboardViewSet(viewsets.ReadOnlyModelViewSet):
 
         return Response(results)
     
+


### PR DESCRIPTION
## Summary
This PR improves performance for "View All Builders" and other non-validator leaderboard views by removing unnecessary validator-wallet counting work from the request path.

## Problem
Issue #378 reports slow loading in builder-focused "view all" flows.
The leaderboard endpoint was always adding validator wallet count annotations, and serializer fallback logic could still query validator wallets even for non-validator leaderboard rows.

## Changes

### 1) Optimize queryset annotations by leaderboard type
In `LeaderboardViewSet.get_queryset`:
- Moved type resolution earlier
- Applied validator wallet annotations **only** when `type` is validator-related:
  - `validator`
  - `validator-waitlist`
  - `validator-waitlist-graduation`
- Non-validator leaderboards (e.g. builder/community) now skip these expensive joins/counts.

### 2) Prevent serializer fallback queries on non-validator rows
In `LeaderboardEntrySerializer.get_active_validators_count`:
- Early-return `None` when entry type is not validator-related
- Keeps validator count behavior unchanged for validator leaderboards
- Avoids extra DB queries during serialization for builder/community lists

## Why this helps
Builder/community "view all" requests no longer perform validator-specific counting logic, reducing query complexity and serialization overhead.

## Scope
- No API contract changes for existing leaderboard fields
- Validator leaderboards keep active validator count behavior
- Non-validator leaderboards now avoid unnecessary count work

## Issue
Closes #378

## Validation
- Static check passed:
  - `python -m py_compile backend/leaderboard/views.py backend/leaderboard/serializers.py`
