### PR TITLE
Move landing page to /how-it-works, restore Overview portal

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -284,7 +284,7 @@ frontend/src/
   - Contains route definitions
   - Handles tooltip positioning
   - Manages route changes
-  - Landing page (`/`) renders full-bleed (no `px-3 py-3` padding on `<main>`)
+  - How it works page (`/how-it-works`) renders full-bleed (no `px-3 py-3` padding on `<main>`)
 - **Navigation**: `src/components/Navbar.svelte`
   - Top navigation bar
   - Auth button integration
@@ -297,6 +297,7 @@ frontend/src/
     - **Builders** - Category-specific dashboard and pages
     - **Validators** - Category-specific dashboard and pages
     - **Stewards** - Steward management pages (only visible to stewards)
+    - **How it works** (bottom pinned area, above Submit Contribution) - Links to `/how-it-works`
     - **Profile** - User profile and submissions
 
 ### Routes/Pages
@@ -307,7 +308,8 @@ const routes = {
   '/auth/github/callback': GitHubCallback,
 
   // Overview & Global
-  '/': Overview,                    // Landing page with hero, journey, role cards, CTA
+  '/': Overview,                    // Portal overview with HeroBanner, LiveStats, TrendingContributors, etc.
+  '/how-it-works': HowItWorks,      // How it works page (WelcomeHero, JourneySection, RoleCards, CTABanner)
   '/asimov': GlobalDashboard,       // Testnet Asimov dashboard
   '/contributions': Contributions,
   '/all-contributions': AllContributions,
@@ -438,7 +440,9 @@ Reusable, data-driven display components that accept data via props. Used on Das
   - Light variant: landing page — transparent bg, adapts between logged-in and anonymous states
   - Includes real rank computation logic (fetches leaderboard, computes points to next rank)
 
-#### Landing Page Components (`src/components/portal/landing-page/`)
+#### How It Works / Landing Page Components (`src/components/portal/landing-page/`)
+- Used by the `/how-it-works` route (`HowItWorks.svelte`)
+- First-time users are redirected here after completing their profile via `ProfileCompletionGuard`
 - **`WelcomeHero.svelte`** - Hero section with headline and stats
 - **`JourneySection.svelte`** - How-it-works journey steps
 - **`SubmitSection.svelte`** - Submit contribution CTA section

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -49,6 +49,7 @@
   import Community from './routes/Community.svelte';
   import Hackathon from './routes/Hackathon.svelte';
   import ReferralProgram from './routes/ReferralProgram.svelte';
+  import HowItWorks from './routes/HowItWorks.svelte';
   import GlobalDashboard from './components/GlobalDashboard.svelte';
   import StartupRequestDetail from './routes/StartupRequestDetail.svelte';
   import SystemAlerts from './components/portal/SystemAlerts.svelte';
@@ -62,6 +63,7 @@
     // Global/Testnet Asimov routes
     // Overview and Testnet Asimov routes
     '/': Overview,
+    '/how-it-works': HowItWorks,
     '/asimov': GlobalDashboard,
     '/contributions': Contributions,
     '/all-contributions': AllContributions,
@@ -125,8 +127,8 @@
     currentCategory.set(category);
   });
 
-  // Landing page needs full-bleed (no padding)
-  let isLandingPage = $derived($location === '/');
+  // How it works page needs full-bleed (no padding)
+  let isFullBleedPage = $derived($location === '/how-it-works');
   
   // Function to hide tooltips - used for route changes
   function hideTooltips() {
@@ -295,7 +297,7 @@
   <Navbar {toggleSidebar} {sidebarOpen} />
   <div class="flex-1 flex overflow-hidden">
     <Sidebar bind:isOpen={sidebarOpen} bind:collapsed={sidebarCollapsed} />
-    <main class="flex-1 overflow-y-auto {isLandingPage ? '' : 'px-3 py-3'}">
+    <main class="flex-1 overflow-y-auto {isFullBleedPage ? '' : 'px-3 py-3'}">
       <SystemAlerts />
       <Router
         {routes}

--- a/frontend/src/components/ProfileCompletionGuard.svelte
+++ b/frontend/src/components/ProfileCompletionGuard.svelte
@@ -2,6 +2,7 @@
   import { authState } from '../lib/auth.js';
   import { userStore } from '../lib/userStore.js';
   import { updateUserProfile } from '../lib/api.js';
+  import { push } from 'svelte-spa-router';
 
   // Form state
   let email = $state('');
@@ -88,7 +89,8 @@
       // Reload user data to ensure we have the latest
       await userStore.loadUser();
 
-      // Modal will close automatically when user data updates
+      // Redirect first-time users to How it works page
+      push('/how-it-works');
     } catch (err) {
       // Handle field-specific errors from Django REST Framework
       if (err.response?.data) {

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -344,6 +344,29 @@
 
   <!-- Bottom pinned area -->
   <div class="space-y-2">
+    <!-- How it works link -->
+    {#if !collapsed}
+      <button
+        onclick={() => navigate('/how-it-works')}
+        class="w-full flex items-center gap-2 px-3 py-2 rounded-[8px] transition-colors text-left {isActive('/how-it-works') ? 'bg-[#eeedfb]' : 'hover:bg-[#f5f5f5]'}"
+      >
+        <svg class="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke={isActive('/how-it-works') ? '#6D5DD3' : '#656567'} stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" /><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+        </svg>
+        <span class="text-[14px] font-medium tracking-[0.28px] {isActive('/how-it-works') ? 'text-[#6D5DD3]' : 'text-[#656567]'}">How it works</span>
+      </button>
+    {:else}
+      <button
+        onclick={() => navigate('/how-it-works')}
+        class="w-full flex px-3 py-2 rounded-[8px] transition-colors {isActive('/how-it-works') ? 'bg-[#eeedfb]' : 'hover:bg-[#f5f5f5]'}"
+        title="How it works"
+      >
+        <svg class="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke={isActive('/how-it-works') ? '#6D5DD3' : '#656567'} stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" /><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+        </svg>
+      </button>
+    {/if}
+
     <!-- Submit Contribution link -->
     {#if !collapsed}
       <button
@@ -598,6 +621,15 @@
 
   <!-- Bottom pinned area (mobile) -->
   <div class="p-3 space-y-2">
+    <button
+      onclick={() => navigate('/how-it-works')}
+      class="w-full flex items-center gap-2 px-3 py-2 rounded-[8px] transition-colors text-left {isActive('/how-it-works') ? 'bg-[#eeedfb]' : 'hover:bg-[#f5f5f5]'}"
+    >
+      <svg class="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke={isActive('/how-it-works') ? '#6D5DD3' : '#656567'} stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" /><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+      </svg>
+      <span class="text-[14px] font-medium tracking-[0.28px] {isActive('/how-it-works') ? 'text-[#6D5DD3]' : 'text-[#656567]'}">How it works</span>
+    </button>
     <button
       onclick={handleSubmitContribution}
       class="w-full flex items-center gap-2 px-3 py-2 rounded-[8px] hover:bg-[#f5f5f5] transition-colors text-left"

--- a/frontend/src/components/portal/landing-page/WelcomeHero.svelte
+++ b/frontend/src/components/portal/landing-page/WelcomeHero.svelte
@@ -16,7 +16,7 @@
   <div class="px-[20px] py-[128px] flex items-center justify-center">
     <div class="flex flex-col gap-[24px] items-center text-center">
       <h1 class="text-[64px] font-medium text-black font-display leading-[64px] w-[542px]" style="letter-spacing: -1.28px;">
-        {isLoggedIn ? `Welcome back, ${userName}` : 'Welcome to GenLayer Points'}
+        {isLoggedIn ? `Welcome, ${userName}` : 'Welcome to GenLayer Points'}
       </h1>
       <p class="text-[17px] text-black leading-[28px]" style="letter-spacing: 0.34px;">
         {isLoggedIn

--- a/frontend/src/routes/HowItWorks.svelte
+++ b/frontend/src/routes/HowItWorks.svelte
@@ -1,0 +1,33 @@
+<script>
+  import WelcomeHero from '../components/portal/landing-page/WelcomeHero.svelte';
+  import JourneySection from '../components/portal/landing-page/JourneySection.svelte';
+  import SubmitSection from '../components/portal/landing-page/SubmitSection.svelte';
+  import ClimbRanksSection from '../components/portal/landing-page/ClimbRanksSection.svelte';
+  import RoleCards from '../components/portal/landing-page/RoleCards.svelte';
+  import CTABanner from '../components/shared/CTABanner.svelte';
+</script>
+
+<div class="relative w-full overflow-clip isolate">
+  <!-- Top glow -->
+  <div class="absolute inset-x-0 top-[-477px] aspect-square min-h-[1218px] flex items-center justify-center -rotate-90 -scale-y-100 pointer-events-none" style="z-index: -1;">
+    <div class="relative w-full h-full" style="-webkit-mask-image: url('/assets/illustrations/welcome-gradient-mask.svg'); mask-image: url('/assets/illustrations/welcome-gradient-mask.svg'); -webkit-mask-size: 1818px 1489.395px; mask-size: 1818px 1489.395px; -webkit-mask-position: center -250px; mask-position: center -250px; -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;">
+      <img src="/assets/illustrations/welcome-gradient.png" alt="" class="absolute inset-0 w-full h-full object-cover mix-blend-screen" />
+    </div>
+  </div>
+
+  <!-- Bottom glow -->
+  <div class="absolute inset-x-0 bottom-[-319px] aspect-square min-h-[1218px] flex items-center justify-center rotate-90 pointer-events-none" style="z-index: -1;">
+    <div class="relative w-full h-full" style="-webkit-mask-image: url('/assets/illustrations/welcome-gradient-mask.svg'); mask-image: url('/assets/illustrations/welcome-gradient-mask.svg'); -webkit-mask-size: 1818px 1489.395px; mask-size: 1818px 1489.395px; -webkit-mask-position: center -21.395px; mask-position: center -21.395px; -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;">
+      <img src="/assets/illustrations/welcome-gradient.png" alt="" class="absolute inset-0 w-full h-full object-cover mix-blend-screen" />
+    </div>
+  </div>
+
+  <div class="space-y-[24px] z-10 relative">
+    <WelcomeHero />
+    <JourneySection />
+    <SubmitSection />
+    <ClimbRanksSection />
+    <RoleCards />
+    <CTABanner variant="light" />
+  </div>
+</div>

--- a/frontend/src/routes/Overview.svelte
+++ b/frontend/src/routes/Overview.svelte
@@ -1,33 +1,51 @@
 <script>
-  import WelcomeHero from '../components/portal/landing-page/WelcomeHero.svelte';
-  import JourneySection from '../components/portal/landing-page/JourneySection.svelte';
-  import SubmitSection from '../components/portal/landing-page/SubmitSection.svelte';
-  import ClimbRanksSection from '../components/portal/landing-page/ClimbRanksSection.svelte';
-  import RoleCards from '../components/portal/landing-page/RoleCards.svelte';
-  import CTABanner from '../components/shared/CTABanner.svelte';
+  import { push } from 'svelte-spa-router';
+  import HeroBanner from '../components/portal/HeroBanner.svelte';
+  import LiveStats from '../components/portal/LiveStats.svelte';
+  import TrendingContributors from '../components/portal/TrendingContributors.svelte';
+  import FeaturedBuilds from '../components/portal/FeaturedBuilds.svelte';
+  import PortalHighlights from '../components/portal/PortalHighlights.svelte';
+  import NewestMembers from '../components/portal/NewestMembers.svelte';
+  import MiniLeaderboard from '../components/portal/MiniLeaderboard.svelte';
 </script>
 
-<div class="relative w-full overflow-clip isolate">
-  <!-- Top glow -->
-  <div class="absolute inset-x-0 top-[-477px] aspect-square min-h-[1218px] flex items-center justify-center -rotate-90 -scale-y-100 pointer-events-none" style="z-index: -1;">
-    <div class="relative w-full h-full" style="-webkit-mask-image: url('/assets/illustrations/welcome-gradient-mask.svg'); mask-image: url('/assets/illustrations/welcome-gradient-mask.svg'); -webkit-mask-size: 1818px 1489.395px; mask-size: 1818px 1489.395px; -webkit-mask-position: center -250px; mask-position: center -250px; -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;">
-      <img src="/assets/illustrations/welcome-gradient.png" alt="" class="absolute inset-0 w-full h-full object-cover mix-blend-screen" />
-    </div>
-  </div>
+<div class="space-y-8">
+  <HeroBanner />
+  <LiveStats />
+  <TrendingContributors />
+  <FeaturedBuilds />
+  <PortalHighlights />
+  <NewestMembers />
+  <MiniLeaderboard />
 
-  <!-- Bottom glow -->
-  <div class="absolute inset-x-0 bottom-[-319px] aspect-square min-h-[1218px] flex items-center justify-center rotate-90 pointer-events-none" style="z-index: -1;">
-    <div class="relative w-full h-full" style="-webkit-mask-image: url('/assets/illustrations/welcome-gradient-mask.svg'); mask-image: url('/assets/illustrations/welcome-gradient-mask.svg'); -webkit-mask-size: 1818px 1489.395px; mask-size: 1818px 1489.395px; -webkit-mask-position: center -21.395px; mask-position: center -21.395px; -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;">
-      <img src="/assets/illustrations/welcome-gradient.png" alt="" class="absolute inset-0 w-full h-full object-cover mix-blend-screen" />
+  <!-- CTA Footer -->
+  <div class="relative overflow-hidden rounded-[24px] border border-[#f0f0f0] isolate">
+    <!-- Rainbow glow -->
+    <div class="absolute inset-0 flex items-center justify-center pointer-events-none" style="z-index: -1;">
+      <div class="relative w-full h-full" style="-webkit-mask-image: url('/assets/illustrations/welcome-gradient-mask.svg'); mask-image: url('/assets/illustrations/welcome-gradient-mask.svg'); -webkit-mask-size: 1818px 1489.395px; mask-size: 1818px 1489.395px; -webkit-mask-position: center; mask-position: center; -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;">
+        <img src="/assets/illustrations/welcome-gradient.png" alt="" class="absolute inset-0 w-full h-full object-cover mix-blend-screen" />
+      </div>
     </div>
-  </div>
 
-  <div class="space-y-[24px] z-10 relative">
-    <WelcomeHero />
-    <JourneySection />
-    <SubmitSection />
-    <ClimbRanksSection />
-    <RoleCards />
-    <CTABanner variant="light" />
+    <div class="px-8 md:px-20 py-24 md:py-32 text-center">
+      <h2 class="text-3xl md:text-[64px] font-medium text-gray-900 font-display leading-tight mb-4" style="letter-spacing: -1.28px;">
+        Start contributing today
+      </h2>
+      <p class="text-[#6b6b6b] text-base max-w-xl mx-auto mb-8">
+        Join professional validators and builders in creating the trust infrastructure for the AI age.
+      </p>
+      <div>
+        <button
+          onclick={() => push('/builders/contributions')}
+          class="bg-[#101010] text-white py-2 px-8 rounded-[24px] text-[14px] font-medium hover:bg-black transition-colors"
+        >
+          Start building <img
+            src="/assets/icons/arrow-right-line.svg"
+            class="inline w-4 h-4 ml-1 brightness-0 invert"
+            alt=""
+          />
+        </button>
+      </div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Reverts Overview (`/`) to the original portal layout (HeroBanner, LiveStats, TrendingContributors, etc.) with a rainbow gradient CTA footer
- Creates new `/how-it-works` route with the landing page content (WelcomeHero, JourneySection, RoleCards, etc.)
- Adds "How it works" sidebar item (open book icon) above "Submit Contribution" in both desktop and mobile
- Redirects first-time users to `/how-it-works` after profile completion
- Removes "back" from welcome greeting ("Welcome, {name}" instead of "Welcome back, {name}")

## Test plan
- [ ] Overview (`/`) renders portal components: HeroBanner, LiveStats, TrendingContributors, FeaturedBuilds, PortalHighlights, NewestMembers, MiniLeaderboard, rainbow CTA footer
- [ ] `/how-it-works` renders landing page content with full-bleed layout
- [ ] Sidebar shows "How it works" with open book icon above "Submit Contribution" (desktop + mobile)
- [ ] After first login + profile completion, user is redirected to `/how-it-works`
- [ ] `npm run build` succeeds