### PR TITLE
Fix validator count per network on Testnets page

### DIFF
--- a/backend/leaderboard/views.py
+++ b/backend/leaderboard/views.py
@@ -103,9 +103,14 @@ class LeaderboardViewSet(viewsets.ReadOnlyModelViewSet):
                 queryset = queryset.filter(type='validator')
 
             # Handle network filtering for validators
+            # Include validators with wallets on the specified network.
+            # For asimov (default network), also include validators with no wallets.
             network = self.request.query_params.get('network')
             if network and leaderboard_type == 'validator':
-                queryset = queryset.filter(user__validator__validator_wallets__network=network).distinct()
+                network_q = Q(user__validator__validator_wallets__network=network)
+                if network == 'asimov':
+                    network_q = network_q | ~Q(user__validator__validator_wallets__isnull=False)
+                queryset = queryset.filter(network_q).distinct()
 
         # Handle rank ordering
         order = self.request.query_params.get('order', 'asc')

--- a/frontend/src/components/GlobalDashboard.svelte
+++ b/frontend/src/components/GlobalDashboard.svelte
@@ -240,7 +240,7 @@
                 style="letter-spacing: -0.96px;"
                 >{networkStats.asimov.total}</span
               >
-              <span class="text-[13px] text-gray-500">Validators</span>
+              <span class="text-[13px] text-gray-500">Active Validators</span>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Filter leaderboard by network using wallet relationship for per-network validator counts
- Include wallet-less validators in asimov (default network) so count matches Validators page (35)
- Use leaderboard API instead of wallets API for consistent counts across pages
- Update label to "Active Validators"

## Test plan
- [ ] Navigate to /testnets — Asimov shows 35 validators, Bradbury shows 0
- [ ] Navigate to /validators — confirms same 35 count
- [ ] Asimov and Bradbury leaderboard tables show distinct (non-duplicated) data
- [ ] `npm run build` succeeds