### PR TITLE
Fix referral program buttons and redirect referred users to hackathon

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -161,6 +161,11 @@
         // Clean URL without page reload to remove the ref parameter
         const cleanUrl = window.location.pathname + window.location.hash;
         window.history.replaceState({}, '', cleanUrl);
+
+        // TODO: Remove after April 1, 2026 — temporarily send referred users to hackathon
+        if (new Date() < new Date('2026-04-01')) {
+          window.location.hash = '#/hackathon';
+        }
       }
     } catch (error) {
       // Error capturing referral code silently handled

--- a/frontend/src/routes/ReferralProgram.svelte
+++ b/frontend/src/routes/ReferralProgram.svelte
@@ -1,5 +1,7 @@
 <script>
   import { setPageMeta, resetPageMeta } from '../lib/meta.js';
+  import { authState } from '../lib/auth.js';
+  import { push } from 'svelte-spa-router';
   import checkIcon from '../assets/referral/check-icon.png';
   import cardBg1 from '../assets/referral/card-bg-1.png';
   import cardBg2 from '../assets/referral/card-bg-2.png';
@@ -181,6 +183,16 @@
       cancelAnimationFrame(frameId);
     };
   });
+
+  function handleGetReferral() {
+    if ($authState.isAuthenticated) {
+      push('/referrals');
+    } else {
+      sessionStorage.setItem('redirectAfterLogin', '/referrals');
+      const authButton = document.querySelector('[data-auth-button]');
+      if (authButton) authButton.click();
+    }
+  }
 </script>
 
 <div class="flex flex-col">
@@ -204,6 +216,7 @@
         Earn 10% of the points of their successful contributions
       </p>
       <button
+        onclick={handleGetReferral}
         class="inline-flex items-center gap-2 h-12 px-8 text-white font-medium rounded-full text-base transition-opacity hover:opacity-90"
         style="background: linear-gradient(to bottom, #be8ff5, #ac6df3);"
       >
@@ -365,6 +378,7 @@
               Write Intelligent Contracts, build dApps, and contribute developer tools to the GenLayer ecosystem.
             </p>
             <button
+              onclick={handleGetReferral}
               class="flex items-center justify-center gap-2 w-full h-11 mt-auto text-white font-medium rounded-full text-sm transition-opacity hover:opacity-90"
               style="background-color: #131214;"
             >
@@ -388,6 +402,7 @@
               Run nodes, provide AI models, and help scale and secure the network through Optimistic Democracy.
             </p>
             <button
+              onclick={handleGetReferral}
               class="flex items-center justify-center gap-2 w-full h-11 mt-auto text-white font-medium rounded-full text-sm transition-opacity hover:opacity-90"
               style="background-color: #131214;"
             >
@@ -411,6 +426,7 @@
               Create content, spread the word, and bring new contributors through referrals and outreach.
             </p>
             <button
+              onclick={handleGetReferral}
               class="flex items-center justify-center gap-2 w-full h-11 mt-auto text-white font-medium rounded-full text-sm transition-opacity hover:opacity-90"
               style="background-color: #131214;"
             >
@@ -442,6 +458,7 @@
         Every person you bring into GenLayer earns you 10% of their contribution points — forever.
       </p>
       <button
+        onclick={handleGetReferral}
         class="inline-flex items-center gap-2 h-12 px-8 text-white font-medium rounded-full text-base transition-opacity hover:opacity-90"
         style="background: linear-gradient(to bottom, #be8ff5, #ac6df3);"
       >


### PR DESCRIPTION
## Summary
- Wire up all inactive buttons on the referral program page ("Get Your Referral Link", "Invite a Builder/Validator/Community") to trigger wallet login when not authenticated, then navigate to `/referrals`
- Temporarily redirect new users arriving via `?ref=` referral links to the hackathon page (until April 1, 2026)

## Test plan
- [ ] Visit `/referral-program` while logged out, click any CTA button — should open wallet login
- [ ] After logging in, verify redirect to `/referrals`
- [ ] Visit `/referral-program` while logged in, click any CTA button — should go directly to `/referrals`
- [ ] Visit the site with a `?ref=ABCD1234` parameter — should be redirected to `/hackathon`
- [ ] Verify referral code is still stored in localStorage after redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)