### PR TITLE
Fix Discord invite links to genlayerlabs

### DIFF
--- a/frontend/src/components/WorkingGroupsSection.svelte
+++ b/frontend/src/components/WorkingGroupsSection.svelte
@@ -236,7 +236,7 @@
     <!-- Contact @ras message -->
     <div class="bg-white rounded-lg border {$categoryTheme.border} p-3">
       <p class="text-sm text-gray-600">
-        <span class="mr-1">💡</span> <strong>Interested in joining?</strong> Contact <span class="font-mono {$categoryTheme.bgSecondary} px-1.5 py-0.5 rounded {$categoryTheme.text} font-semibold">@ras</span> on <a href="https://discord.com/invite/qjCU4AWnKE" target="_blank" rel="noopener noreferrer" class="{$categoryTheme.text} hover:text-green-700 underline font-semibold">Discord</a> to learn more.
+        <span class="mr-1">💡</span> <strong>Interested in joining?</strong> Contact <span class="font-mono {$categoryTheme.bgSecondary} px-1.5 py-0.5 rounded {$categoryTheme.text} font-semibold">@ras</span> on <a href="https://discord.gg/genlayerlabs" target="_blank" rel="noopener noreferrer" class="{$categoryTheme.text} hover:text-green-700 underline font-semibold">Discord</a> to learn more.
       </p>
     </div>
 

--- a/frontend/src/routes/Hackathon.svelte
+++ b/frontend/src/routes/Hackathon.svelte
@@ -437,7 +437,7 @@
           Register on DoraHacks
           <img src={arrowRight} alt="" class="w-4 h-4 brightness-0 invert" />
         </a>
-        <a href="https://discord.gg/genlayer" target="_blank" rel="noopener noreferrer"
+        <a href="https://discord.gg/genlayerlabs" target="_blank" rel="noopener noreferrer"
            class="inline-flex items-center gap-2 bg-[#f5f5f5] text-black h-10 rounded-[20px] px-4 text-[14px] font-medium tracking-[0.28px]">
           Join Discord
           <img src={arrowRightDark} alt="" class="w-4 h-4" />


### PR DESCRIPTION
## Summary
- Update Discord link on Hackathon page from `discord.gg/genlayer` to `discord.gg/genlayerlabs`
- Update Discord link in Working Groups section from `discord.com/invite/qjCU4AWnKE` to `discord.gg/genlayerlabs`

## Test plan
- [ ] Verify Hackathon page "Join Discord" button links to https://discord.gg/genlayerlabs
- [ ] Verify Working Groups "Discord" link points to https://discord.gg/genlayerlabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)