### PR TITLE
Fix community referral visibility and add leaderboard pagination

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -74,7 +74,8 @@
     '/leaderboard': Leaderboard,
     '/participants': Validators,
     '/referrals': Referrals,
-    '/community': Community,
+    '/community/leaderboard': Community,
+    '/community': ReferralProgram,
     '/hackathon': Hackathon,
     '/referral-program': ReferralProgram,
 

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -275,24 +275,48 @@
       </div>
 
       <!-- Community -->
-      <a
-        href="/community"
-        onclick={(e) => { e.preventDefault(); navigate('/community'); }}
-        class="flex items-center gap-2 px-3 py-2 rounded-[8px] transition-colors text-[14px] font-medium text-black tracking-[0.28px]"
-        style={getActiveSection() === 'community' ? 'background: #f0eafb;' : ''}
-        onmouseenter={(e) => { if (getActiveSection() !== 'community') { e.currentTarget.style.background = '#f0eafb'; e.currentTarget.querySelector('img').src = '/assets/icons/group-3-line-purple.svg'; }}}
-        onmouseleave={(e) => { if (getActiveSection() !== 'community') { e.currentTarget.style.background = ''; e.currentTarget.querySelector('img').src = '/assets/icons/group-3-line.svg'; }}}
-        title={collapsed ? 'Community' : ''}
-      >
-        {#if getActiveSection() === 'community'}
-          <img src="/assets/icons/group-3-line-purple.svg" alt="" class="w-4 h-4 flex-shrink-0">
-        {:else}
-          <img src="/assets/icons/group-3-line.svg" alt="" class="w-4 h-4 flex-shrink-0">
+      <div>
+        <button
+          onclick={() => changeCategory('community', '/community')}
+          class="w-full flex items-center gap-2 px-3 py-2 rounded-[8px] transition-colors text-[14px] font-medium text-black tracking-[0.28px]"
+          style={getActiveSection() === 'community' ? 'background: #f0eafb;' : ''}
+          onmouseenter={(e) => { if (getActiveSection() !== 'community') { e.currentTarget.style.background = '#f0eafb'; e.currentTarget.querySelector('img').src = '/assets/icons/group-3-line-purple.svg'; }}}
+          onmouseleave={(e) => { if (getActiveSection() !== 'community') { e.currentTarget.style.background = ''; e.currentTarget.querySelector('img').src = '/assets/icons/group-3-line.svg'; }}}
+          title={collapsed ? 'Community' : ''}
+        >
+          {#if getActiveSection() === 'community'}
+            <img src="/assets/icons/group-3-line-purple.svg" alt="" class="w-4 h-4 flex-shrink-0">
+          {:else}
+            <img src="/assets/icons/group-3-line.svg" alt="" class="w-4 h-4 flex-shrink-0">
+          {/if}
+          {#if !collapsed}
+            <span>Community</span>
+          {/if}
+        </button>
+
+        {#if !collapsed && getActiveSection() === 'community'}
+          <div class="pl-5">
+            <a
+              href="/community"
+              onclick={(e) => { e.preventDefault(); navigate('/community'); }}
+              class="flex items-center border-l-[1.5px] px-3 py-2 text-[14px] font-medium text-black tracking-[0.28px] {
+                $location === '/community' ? 'border-[#8D81E1]' : 'border-[#f5f5f5]'
+              }"
+            >
+              Referral Program
+            </a>
+            <a
+              href="/community/leaderboard"
+              onclick={(e) => { e.preventDefault(); navigate('/community/leaderboard'); }}
+              class="flex items-center border-l-[1.5px] px-3 py-2 text-[14px] font-medium text-black tracking-[0.28px] {
+                isActive('/community/leaderboard') ? 'border-[#8D81E1]' : 'border-[#f5f5f5]'
+              }"
+            >
+              Leaderboard
+            </a>
+          </div>
         {/if}
-        {#if !collapsed}
-          <span>Community</span>
-        {/if}
-      </a>
+      </div>
 
       <!-- Stewards -->
       <div>
@@ -592,7 +616,7 @@
 
       <!-- Community -->
       <button
-        onclick={() => navigate('/community')}
+        onclick={() => changeCategory('community', '/community')}
         class="w-full flex items-center gap-2 px-3 py-2 rounded-[8px] transition-colors text-[14px] font-medium text-black tracking-[0.28px]"
         style={getActiveSection() === 'community' ? 'background: #f0eafb;' : ''}
       >
@@ -603,6 +627,29 @@
         {/if}
         <span>Community</span>
       </button>
+
+      {#if getActiveSection() === 'community'}
+        <div class="pl-5">
+          <a
+            href="/community"
+            onclick={(e) => { e.preventDefault(); navigate('/community'); }}
+            class="flex items-center border-l-[1.5px] px-3 py-2 text-[14px] font-medium text-black tracking-[0.28px] {
+              $location === '/community' ? 'border-[#8D81E1]' : 'border-[#f5f5f5]'
+            }"
+          >
+            Referral Program
+          </a>
+          <a
+            href="/community/leaderboard"
+            onclick={(e) => { e.preventDefault(); navigate('/community/leaderboard'); }}
+            class="flex items-center border-l-[1.5px] px-3 py-2 text-[14px] font-medium text-black tracking-[0.28px] {
+              isActive('/community/leaderboard') ? 'border-[#8D81E1]' : 'border-[#f5f5f5]'
+            }"
+          >
+            Leaderboard
+          </a>
+        </div>
+      {/if}
 
       <!-- Stewards -->
       <button

--- a/frontend/src/routes/Community.svelte
+++ b/frontend/src/routes/Community.svelte
@@ -3,67 +3,60 @@
   import { push } from 'svelte-spa-router';
   import Avatar from '../components/Avatar.svelte';
   import Icon from '../components/Icons.svelte';
-  import { leaderboardAPI, creatorAPI } from '../lib/api';
-  import { authState } from '../lib/auth.js';
-  import { userStore } from '../lib/userStore.js';
+  import { leaderboardAPI } from '../lib/api';
 
-  // Get current user from store
-  let user = $derived($userStore.user);
-
-  // Check if user is already a community member (has creator profile)
-  let isCommunityMember = $derived(!!user?.creator);
+  const PAGE_SIZE = 50;
 
   // State management
   let communityMembers = $state([]);
   let loading = $state(true);
+  let loadingMore = $state(false);
   let error = $state(null);
-  let joiningCommunity = $state(false);
+  let offset = $state(0);
+  let hasMore = $state(true);
+  let totalCount = $state(0);
 
   // Fetch community data
   async function fetchCommunity() {
     try {
       loading = true;
       error = null;
+      offset = 0;
 
-      const response = await leaderboardAPI.getCommunity();
+      const response = await leaderboardAPI.getCommunity({ limit: PAGE_SIZE, offset: 0 });
       const data = response.data;
 
-      communityMembers = data.top_community || [];
-      loading = false;
+      communityMembers = data.results || [];
+      totalCount = data.count || 0;
+      hasMore = communityMembers.length >= PAGE_SIZE;
+      offset = communityMembers.length;
     } catch (err) {
       error = err.message || 'Failed to load community members';
+    } finally {
       loading = false;
+    }
+  }
+
+  async function loadMore() {
+    try {
+      loadingMore = true;
+      const response = await leaderboardAPI.getCommunity({ limit: PAGE_SIZE, offset });
+      const data = response.data;
+      const newResults = data.results || [];
+
+      communityMembers = [...communityMembers, ...newResults];
+      offset += newResults.length;
+      hasMore = newResults.length >= PAGE_SIZE;
+    } catch (err) {
+      console.error('Failed to load more members:', err);
+    } finally {
+      loadingMore = false;
     }
   }
 
   onMount(() => {
     fetchCommunity();
   });
-
-  async function joinAsCommunity() {
-    if (!$authState.isAuthenticated || !user?.address) {
-      return;
-    }
-
-    try {
-      joiningCommunity = true;
-      error = null;
-
-      const response = await creatorAPI.joinAsCreator();
-
-      if (response.status === 201 || response.status === 200) {
-        // Reload user data
-        await userStore.loadUser();
-
-        // Redirect to user's profile
-        push(`/participant/${user.address}`);
-      }
-    } catch (err) {
-      error = err.response?.data?.message || 'Failed to join the community';
-    } finally {
-      joiningCommunity = false;
-    }
-  }
 
   function getRankClass(rank) {
     if (rank === 1) return 'bg-amber-100 text-amber-800';
@@ -75,7 +68,7 @@
 
 <div class="space-y-6 sm:space-y-8">
       <!-- Main Title -->
-      <h1 class="text-2xl font-bold text-gray-900">Community</h1>
+      <h1 class="text-2xl font-bold text-gray-900">Community Leaderboard</h1>
 
       <!-- Top Community Members Section -->
       <div class="space-y-4">
@@ -154,11 +147,11 @@
                         <div class="flex items-center gap-2">
                           <div class="flex items-center text-xs text-orange-600" title="Builder Referral Points">
                             <Icon name="builder" size="xs" className="mr-0.5" />
-                            {member.builder_points}
+                            {member.referral_builder_points}
                           </div>
                           <div class="flex items-center text-xs text-sky-600" title="Validator Referral Points">
                             <Icon name="validator" size="xs" className="mr-0.5" />
-                            {member.validator_points}
+                            {member.referral_validator_points}
                           </div>
                         </div>
                       </div>
@@ -172,92 +165,19 @@
       {/if}
       </div>
 
-  <!-- Become a Community Member Card (only show if NOT a community member) -->
-  {#if $authState.isAuthenticated && user && !isCommunityMember}
-    <div class="bg-purple-50 border-2 border-purple-200 rounded-xl overflow-hidden hover:shadow-lg transition-all">
-      <div class="p-6">
-        <div class="flex items-center mb-4">
-          <div class="flex items-center justify-center w-12 h-12 bg-purple-500 rounded-full mr-4 flex-shrink-0">
-            <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
-            </svg>
-          </div>
-          <div>
-            <h3 class="text-xl font-bold text-purple-900 mb-1">Become a Top Community Member</h3>
-            <p class="text-purple-700 text-sm">Grow the GenLayer community and earn rewards</p>
-          </div>
-        </div>
-
-        <div class="space-y-4">
-          <div>
-            <p class="text-sm text-purple-700 mb-3">Community members help grow the GenLayer ecosystem by inviting others to join as Builders or Validators. The more your referrals contribute, the more points you earn!</p>
-            <ul class="space-y-2">
-              <li class="flex items-center text-sm text-purple-600">
-                <svg class="w-4 h-4 mr-2 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                  <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-                </svg>
-                Earn points when your referrals complete contributions
-              </li>
-              <li class="flex items-center text-sm text-purple-600">
-                <svg class="w-4 h-4 mr-2 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                  <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-                </svg>
-                Track Builder and Validator referral points separately
-              </li>
-              <li class="flex items-center text-sm text-purple-600">
-                <svg class="w-4 h-4 mr-2 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                  <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-                </svg>
-                Climb the leaderboard by supporting the ecosystem
-              </li>
-            </ul>
-          </div>
-
-          {#if error}
-            <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded text-sm">
-              {error}
-            </div>
-          {/if}
-
-          <button
-            onclick={joinAsCommunity}
-            disabled={joiningCommunity}
-            class="w-full flex items-center justify-center px-4 py-3 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors font-semibold group-hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {#if joiningCommunity}
-              <div class="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>
-              Joining...
-            {:else}
-              <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
-              </svg>
-              Join the Community
-            {/if}
-          </button>
-        </div>
-      </div>
-    </div>
-  {:else if !$authState.isAuthenticated}
-    <!-- Information Card (only shown when not authenticated) -->
-    <div class="bg-purple-50 border border-purple-200 rounded-lg p-6">
-      <div class="flex">
-        <div class="flex-shrink-0">
-          <svg class="h-5 w-5 text-purple-400" fill="currentColor" viewBox="0 0 20 20">
-            <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
-          </svg>
-        </div>
-        <div class="ml-3">
-          <h3 class="text-sm font-medium text-purple-900">About the Community</h3>
-          <div class="mt-2 text-sm text-purple-700">
-            <p>Community members help grow the GenLayer ecosystem by inviting others to join as Builders or Validators.</p>
-            <ul class="list-disc list-inside mt-2 space-y-1">
-              <li>Earn points when your referrals complete contributions</li>
-              <li>Track Builder and Validator referral points separately</li>
-              <li>Climb the leaderboard by supporting the ecosystem</li>
-            </ul>
-          </div>
-        </div>
-      </div>
+  {#if hasMore && !loading}
+    <div class="flex justify-center py-4">
+      <button
+        onclick={loadMore}
+        disabled={loadingMore}
+        class="px-6 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
+      >
+        {#if loadingMore}
+          Loading...
+        {:else}
+          Load more
+        {/if}
+      </button>
     </div>
   {/if}
 </div>

--- a/frontend/src/routes/Leaderboard.svelte
+++ b/frontend/src/routes/Leaderboard.svelte
@@ -4,12 +4,17 @@
   import { leaderboardAPI } from '../lib/api';
   import { currentCategory, categoryTheme } from '../stores/category.js';
   
+  const PAGE_SIZE = 50;
+
   // State management
   let leaderboard = $state([]);
   let loading = $state(true);
+  let loadingMore = $state(false);
   let error = $state(null);
   let searchQuery = $state('');
-  
+  let offset = $state(0);
+  let hasMore = $state(true);
+
   // Filter leaderboard based on search
   let filteredLeaderboard = $derived(
     !searchQuery ? leaderboard : leaderboard.filter(entry => {
@@ -19,36 +24,59 @@
       return name.includes(query) || address.includes(query);
     })
   );
-  
+
   // Fetch data based on category
   async function fetchLeaderboard() {
     try {
       loading = true;
       error = null;
-      
+      offset = 0;
+
       let response;
       if ($currentCategory === 'global') {
-        response = await leaderboardAPI.getLeaderboard();
-        leaderboard = response.data || [];
+        response = await leaderboardAPI.getLeaderboard({ limit: PAGE_SIZE, offset: 0 });
       } else {
-        // Fetch type-specific leaderboard
-        response = await leaderboardAPI.getLeaderboardByType($currentCategory);
-        // API now returns array directly, not wrapped in entries
-        leaderboard = response.data || [];
+        response = await leaderboardAPI.getLeaderboardByType($currentCategory, 'asc', { limit: PAGE_SIZE, offset: 0 });
       }
-      
-      loading = false;
+
+      const data = response.data || [];
+      leaderboard = data;
+      offset = data.length;
+      hasMore = data.length >= PAGE_SIZE;
     } catch (err) {
       error = err.message || 'Failed to load leaderboard';
+    } finally {
       loading = false;
     }
   }
-  
+
+  async function loadMore() {
+    try {
+      loadingMore = true;
+
+      let response;
+      if ($currentCategory === 'global') {
+        response = await leaderboardAPI.getLeaderboard({ limit: PAGE_SIZE, offset });
+      } else {
+        response = await leaderboardAPI.getLeaderboardByType($currentCategory, 'asc', { limit: PAGE_SIZE, offset });
+      }
+
+      const data = response.data || [];
+      leaderboard = [...leaderboard, ...data];
+      offset += data.length;
+      hasMore = data.length >= PAGE_SIZE;
+    } catch (err) {
+      console.error('Failed to load more entries:', err);
+    } finally {
+      loadingMore = false;
+    }
+  }
+
   // Fetch on mount and when category changes
   onMount(() => {
     fetchLeaderboard();
   });
-  
+
   // Re-fetch when category changes
   $effect(() => {
     if ($currentCategory) {
@@ -133,6 +161,22 @@
         />
       {/if}
     </div>
+
+    {#if hasMore && !searchQuery}
+      <div class="flex justify-center py-4">
+        <button
+          onclick={loadMore}
+          disabled={loadingMore}
+          class="px-6 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
+        >
+          {#if loadingMore}
+            Loading...
+          {:else}
+            Load more
+          {/if}
+        </button>
+      </div>
+    {/if}
   {/if}
 </div>
 

--- a/frontend/src/routes/ReferralProgram.svelte
+++ b/frontend/src/routes/ReferralProgram.svelte
@@ -5,10 +5,10 @@
   import checkIcon from '../assets/referral/check-icon.png';
   import cardBg1 from '../assets/referral/card-bg-1.png';
   import cardBg2 from '../assets/referral/card-bg-2.png';
-  import iconPortal from '../assets/referral/icon-portal.png';
-  import iconReferral from '../assets/referral/icon-referral.png';
-  import iconShare1 from '../assets/referral/icon-share-1.png';
-  import iconShare2 from '../assets/referral/icon-share-2.png';
+  const iconPortal = '/assets/icons/hexagon-genlayer.svg';
+  const iconBuilder = '/assets/illustrations/builder-badge.svg';
+  const iconValidator = '/assets/illustrations/validator-badge.svg';
+  const iconCommunity = '/assets/illustrations/community-badge.svg';
   import arrowRightWhite from '../assets/referral/arrow-right-white.png';
   import roleBgValidators from '../assets/referral/role-bg-validators.png';
   import roleBgCommunity from '../assets/referral/role-bg-community.png';
@@ -130,7 +130,7 @@
       title: 'Referral Program',
       description: 'Invite Builders, Validators, and Community members to GenLayer. Earn 10% of all points from their successful contributions — forever, with no cap.',
       image: 'https://portal.genlayer.foundation/assets/referral_og_image.png',
-      url: 'https://portal.genlayer.foundation/#/referral-program',
+      url: 'https://portal.genlayer.foundation/#/community',
     });
     return () => resetPageMeta();
   });
@@ -307,7 +307,7 @@
           <div class="flex-1 w-full">
             <div class="relative bg-white border border-[#f5f5f5] rounded-[12px] overflow-hidden flex items-center justify-center" style="min-height: 280px;">
               <img src={cardBg1} alt="" class="absolute inset-0 w-full h-full object-contain opacity-40 pointer-events-none" />
-              <img src={iconReferral} alt="Referral" class="relative z-10 w-20 h-20" />
+              <img src={iconBuilder} alt="Referral" class="relative z-10 w-20 h-20" />
             </div>
           </div>
         </div>
@@ -346,9 +346,9 @@
             <div class="relative bg-white border border-[#f5f5f5] rounded-[12px] overflow-hidden flex items-center justify-center" style="min-height: 280px;">
               <img src={cardBg1} alt="" class="absolute inset-0 w-full h-full object-contain opacity-40 pointer-events-none" />
               <div class="relative z-10 flex items-center gap-6">
-                <img src={iconReferral} alt="Builders" class="w-14 h-14" />
-                <img src={iconShare1} alt="Validators" class="w-14 h-14 -mt-8" />
-                <img src={iconShare2} alt="Community" class="w-14 h-14" />
+                <img src={iconBuilder} alt="Builders" class="w-14 h-14" />
+                <img src={iconValidator} alt="Validators" class="w-14 h-14 -mt-8" />
+                <img src={iconCommunity} alt="Community" class="w-14 h-14" />
               </div>
             </div>
           </div>
@@ -370,7 +370,7 @@
         <div class="bg-white border border-[#e5e5e5] rounded-[12px] overflow-hidden flex flex-col">
           <div class="relative flex items-center justify-center" style="min-height: 240px;">
             <img src={cardBg1} alt="" class="absolute inset-0 w-full h-full object-contain opacity-30 pointer-events-none" />
-            <img src={iconReferral} alt="Builders" class="relative z-10 w-20 h-20" />
+            <img src={iconBuilder} alt="Builders" class="relative z-10 w-20 h-20" />
           </div>
           <div class="p-5 md:p-6 flex flex-col flex-1 gap-3">
             <h3 class="text-[22px] md:text-[24px] font-semibold font-display" style="letter-spacing: -0.48px;">Builders</h3>
@@ -394,7 +394,7 @@
         <div class="bg-white border border-[#e5e5e5] rounded-[12px] overflow-hidden flex flex-col">
           <div class="relative flex items-center justify-center" style="min-height: 240px;">
             <img src={roleBgValidators} alt="" class="absolute inset-0 w-full h-full object-contain opacity-30 pointer-events-none" />
-            <img src={iconShare1} alt="Validators" class="relative z-10 w-20 h-20" />
+            <img src={iconValidator} alt="Validators" class="relative z-10 w-20 h-20" />
           </div>
           <div class="p-5 md:p-6 flex flex-col flex-1 gap-3">
             <h3 class="text-[22px] md:text-[24px] font-semibold font-display" style="letter-spacing: -0.48px;">Validators</h3>
@@ -418,7 +418,7 @@
         <div class="bg-white border border-[#e5e5e5] rounded-[12px] overflow-hidden flex flex-col">
           <div class="relative flex items-center justify-center" style="min-height: 240px;">
             <img src={roleBgCommunity} alt="" class="absolute inset-0 w-full h-full object-contain opacity-30 pointer-events-none" />
-            <img src={iconShare2} alt="Community" class="relative z-10 w-20 h-20" />
+            <img src={iconCommunity} alt="Community" class="relative z-10 w-20 h-20" />
           </div>
           <div class="p-5 md:p-6 flex flex-col flex-1 gap-3">
             <h3 class="text-[22px] md:text-[24px] font-semibold font-display" style="letter-spacing: -0.48px;">Community</h3>

--- a/frontend/src/routes/WaitlistParticipants.svelte
+++ b/frontend/src/routes/WaitlistParticipants.svelte
@@ -6,10 +6,19 @@
   import Avatar from '../components/Avatar.svelte';
   import Icon from '../components/Icons.svelte';
 
+  const PAGE_SIZE = 50;
+
   // State variables
   let waitlistUsers = $state([]);
   let loading = $state(true);
+  let loadingMore = $state(false);
   let error = $state(null);
+  let offset = $state(0);
+  let hasMore = $state(true);
+
+  // Cached enrichment data (fetched once)
+  let allUsers = [];
+  let waitlistContributions = null;
 
   onMount(async () => {
     await fetchWaitlistData();
@@ -24,69 +33,79 @@
     }
   };
 
+  function enrichEntries(rawEntries) {
+    return rawEntries.map(entry => {
+      const userDetails = entry.user_details || {};
+
+      const fullUser = allUsers.find(u =>
+        u.address && userDetails.address &&
+        u.address.toLowerCase() === userDetails.address.toLowerCase()
+      );
+
+      const waitlistContribution = waitlistContributions?.data?.results?.find(c =>
+        c.user_details?.address?.toLowerCase() === userDetails.address?.toLowerCase()
+      );
+
+      return {
+        address: userDetails.address || '',
+        isWaitlisted: true,
+        user: fullUser || userDetails,
+        score: entry.total_points,
+        waitlistRank: entry.rank,
+        nodeVersion: fullUser?.validator?.node_version || null,
+        matchesTarget: fullUser?.validator?.matches_target || false,
+        targetVersion: fullUser?.validator?.target_version || null,
+        joinedWaitlist: waitlistContribution?.contribution_date || fullUser?.created_at,
+        referral_points: entry.referral_points || null
+      };
+    });
+  }
+
   async function fetchWaitlistData() {
     try {
       loading = true;
       error = null;
+      offset = 0;
 
-      // Fetch waitlist-only users
-      const [waitlistResponse, usersRes] = await Promise.all([
-        leaderboardAPI.getLeaderboardByType('validator-waitlist'),
-        usersAPI.getUsers()
-      ]);
-
-      if (waitlistResponse.data) {
-        const rawEntries = Array.isArray(waitlistResponse.data) ? waitlistResponse.data : [];
-        const allUsers = usersRes.data.results || [];
-
-        // Get contributions for waitlist users to find their join dates
-        const waitlistContributions = await contributionsAPI.getContributions({
+      // Fetch enrichment data and first page of waitlist entries
+      const [waitlistResponse, usersRes, contribRes] = await Promise.all([
+        leaderboardAPI.getLeaderboardByType('validator-waitlist', 'asc', { limit: PAGE_SIZE, offset: 0 }),
+        usersAPI.getUsers(),
+        contributionsAPI.getContributions({
           contribution_type_slug: 'validator-waitlist',
           limit: 100
-        });
+        })
+      ]);
 
-        // Process and enrich waitlist user data
-        waitlistUsers = rawEntries.map(entry => {
-          const userDetails = entry.user_details || {};
+      allUsers = usersRes.data.results || [];
+      waitlistContributions = contribRes;
 
-          // Find full user data
-          const fullUser = allUsers.find(u =>
-            u.address && userDetails.address &&
-            u.address.toLowerCase() === userDetails.address.toLowerCase()
-          );
-
-          // Find when they joined the waitlist
-          const waitlistContribution = waitlistContributions.data?.results?.find(c =>
-            c.user_details?.address?.toLowerCase() === userDetails.address?.toLowerCase()
-          );
-
-          return {
-            address: userDetails.address || '',
-            isWaitlisted: true,
-            user: fullUser || userDetails,
-            score: entry.total_points,
-            waitlistRank: entry.rank,
-            nodeVersion: fullUser?.validator?.node_version || null,
-            matchesTarget: fullUser?.validator?.matches_target || false,
-            targetVersion: fullUser?.validator?.target_version || null,
-            joinedWaitlist: waitlistContribution?.contribution_date || fullUser?.created_at,
-            referral_points: entry.referral_points || null
-          };
-        });
-
-        // Sort by waitlist rank
-        waitlistUsers.sort((a, b) => {
-          if (a.waitlistRank && b.waitlistRank) {
-            return a.waitlistRank - b.waitlistRank;
-          }
-          return 0;
-        });
-      }
-
-      loading = false;
+      const rawEntries = Array.isArray(waitlistResponse.data) ? waitlistResponse.data : [];
+      waitlistUsers = enrichEntries(rawEntries);
+      offset = rawEntries.length;
+      hasMore = rawEntries.length >= PAGE_SIZE;
     } catch (err) {
       error = err.message || 'Failed to load waitlist data';
+    } finally {
       loading = false;
+    }
+  }
+
+  async function loadMore() {
+    try {
+      loadingMore = true;
+
+      const response = await leaderboardAPI.getLeaderboardByType('validator-waitlist', 'asc', { limit: PAGE_SIZE, offset });
+      const rawEntries = Array.isArray(response.data) ? response.data : [];
+      const enriched = enrichEntries(rawEntries);
+
+      waitlistUsers = [...waitlistUsers, ...enriched];
+      offset += rawEntries.length;
+      hasMore = rawEntries.length >= PAGE_SIZE;
+    } catch (err) {
+      error = err.message || 'Failed to load more participants';
+    } finally {
+      loadingMore = false;
     }
   }
 
@@ -271,5 +290,21 @@
         </table>
       </div>
     </div>
+
+    {#if hasMore}
+      <div class="flex justify-center py-4">
+        <button
+          onclick={loadMore}
+          disabled={loadingMore}
+          class="px-6 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
+        >
+          {#if loadingMore}
+            Loading...
+          {:else}
+            Load more
+          {/if}
+        </button>
+      </div>
+    {/if}
   {/if}
 </div>


### PR DESCRIPTION
## Summary
- **Fix community leaderboard data**: Corrected field name mismatches (`top_community`→`results`, `builder_points`→`referral_builder_points`, `validator_points`→`referral_validator_points`) that caused the community leaderboard to show no data
- **Add Community sidebar section**: New collapsible Community nav section (matching Builders/Validators pattern) with Referral Program (`/community`) and Leaderboard (`/community/leaderboard`) sub-items
- **Server-side pagination**: All leaderboards (builders, validators, community, waitlist participants) now fetch 50 entries per API call with a "Load more" button, instead of loading everything at once
- **Replace blurry icons**: Swapped tiny PNG icons in the referral program page with crisp SVG assets already used elsewhere in the app

## Test plan
- [ ] Navigate to Community section in sidebar — verify Referral Program and Leaderboard sub-items appear
- [ ] Open `/community` — verify referral program page renders with crisp SVG icons
- [ ] Open `/community/leaderboard` — verify community leaderboard displays data correctly
- [ ] Open any leaderboard (builders, validators, global) — verify only 50 entries load initially and "Load more" button appends more
- [ ] Open waitlist participants — verify same pagination behavior
- [ ] Test "Load more" with network throttling — verify a failure doesn't wipe already-loaded data