### PR TITLE
Exclude validator-waitlist from referral points & DRY up breakdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,6 @@ conductor-*
 .cursorrules
 run.sh
 setup.sh
+
+# gstack security reports
+.gstack/

--- a/backend/leaderboard/management/commands/recalculate_referral_points.py
+++ b/backend/leaderboard/management/commands/recalculate_referral_points.py
@@ -2,7 +2,7 @@ import logging
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from users.models import User
-from leaderboard.models import ReferralPoints, recalculate_referrer_points
+from leaderboard.models import ReferralPoints, recalculate_referrer_points, VALIDATOR_REFERRAL_EXCLUDED_SLUGS
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +91,8 @@ class Command(BaseCommand):
                         new_validator = int((Contribution.objects.filter(
                             user_id__in=referred_user_ids,
                             contribution_type__category__slug='validator'
+                        ).exclude(
+                            contribution_type__slug__in=VALIDATOR_REFERRAL_EXCLUDED_SLUGS
                         ).aggregate(Sum('frozen_global_points'))['frozen_global_points__sum'] or 0) * 0.1)
 
                         if new_builder != current_builder or new_validator != current_validator:

--- a/backend/leaderboard/models.py
+++ b/backend/leaderboard/models.py
@@ -11,6 +11,12 @@ from tally.middleware.logging_utils import get_app_logger
 
 logger = get_app_logger('leaderboard')
 
+# Onboarding badge slugs excluded from validator referral point calculations.
+# These are signup markers, not actual validator work.
+# Gate 1 (user eligibility) is handled by get_eligible_referred_user_ids().
+# Gate 2 (contribution exclusion) uses this constant.
+VALIDATOR_REFERRAL_EXCLUDED_SLUGS = ['validator-waitlist']
+
 
 # Helper functions for leaderboard configuration
 def has_contribution_badge(user, slug):
@@ -93,6 +99,8 @@ def calculate_waitlist_points(user):
                 user_id__in=eligible_ids,
                 contribution_type__category__slug='validator',
                 contribution_date__lte=grad_contrib.contribution_date
+            ).exclude(
+                contribution_type__slug__in=VALIDATOR_REFERRAL_EXCLUDED_SLUGS
             ).aggregate(Sum('frozen_global_points'))['frozen_global_points__sum'] or 0) * 0.1)
 
             referral_points = builder_referral + validator_referral
@@ -500,6 +508,87 @@ class ReferralPoints(BaseModel):
         return f"{self.user.email} - B:{self.builder_points} V:{self.validator_points}"
 
 
+def get_referral_breakdown(user):
+    """
+    Build full referral breakdown for a user: per-referred-user builder/validator
+    point split, sorted by total points. Used by both the /users/referrals/ endpoint
+    and the UserSerializer.referral_details field.
+
+    Returns dict with: total_referrals, builder_points, validator_points, referrals list.
+    """
+    from users.models import User
+    from contributions.models import Contribution
+    from django.db.models import Count, Sum
+
+    # Get stored totals from ReferralPoints
+    try:
+        rp = user.referral_points
+        builder_pts = rp.builder_points
+        validator_pts = rp.validator_points
+    except ReferralPoints.DoesNotExist:
+        builder_pts = 0
+        validator_pts = 0
+
+    # Get all referred users with annotated contribution count
+    referred_users = User.objects.filter(
+        referred_by=user
+    ).select_related('validator', 'builder').annotate(
+        total_contributions=Count('contributions', distinct=True)
+    )
+
+    # Materialize once to avoid double queryset evaluation
+    referred_users_list = list(referred_users)
+    referred_user_ids = [u.id for u in referred_users_list]
+
+    # Bulk-query per-user builder/validator points
+    builder_points_by_user = {
+        item['user_id']: item['total'] or 0
+        for item in Contribution.objects.filter(
+            user_id__in=referred_user_ids,
+            contribution_type__category__slug='builder'
+        ).values('user_id').annotate(total=Sum('frozen_global_points'))
+    }
+
+    validator_points_by_user = {
+        item['user_id']: item['total'] or 0
+        for item in Contribution.objects.filter(
+            user_id__in=referred_user_ids,
+            contribution_type__category__slug='validator'
+        ).exclude(
+            contribution_type__slug__in=VALIDATOR_REFERRAL_EXCLUDED_SLUGS
+        ).values('user_id').annotate(total=Sum('frozen_global_points'))
+    }
+
+    referral_list = []
+    for referred_user in referred_users_list:
+        builder_contribution_points = builder_points_by_user.get(referred_user.id, 0)
+        validator_contribution_points = validator_points_by_user.get(referred_user.id, 0)
+        total_points = builder_contribution_points + validator_contribution_points
+
+        referral_list.append({
+            'id': referred_user.id,
+            'name': referred_user.name or 'Anonymous',
+            'address': referred_user.address,
+            'profile_image_url': referred_user.profile_image_url,
+            'total_points': total_points,
+            'builder_contribution_points': builder_contribution_points,
+            'validator_contribution_points': validator_contribution_points,
+            'created_at': referred_user.created_at,
+            'total_contributions': referred_user.total_contributions,
+            'is_validator': hasattr(referred_user, 'validator'),
+            'is_builder': hasattr(referred_user, 'builder'),
+        })
+
+    referral_list.sort(key=lambda x: x['total_points'], reverse=True)
+
+    return {
+        'total_referrals': len(referral_list),
+        'builder_points': builder_pts,
+        'validator_points': validator_pts,
+        'referrals': referral_list
+    }
+
+
 def update_referrer_points(contribution):
     """Update referral points when a referred user makes a contribution."""
     referrer = contribution.user.referred_by
@@ -520,6 +609,8 @@ def update_referrer_points(contribution):
     rp.validator_points = int((Contribution.objects.filter(
         user_id__in=eligible_ids,
         contribution_type__category__slug='validator'
+    ).exclude(
+        contribution_type__slug__in=VALIDATOR_REFERRAL_EXCLUDED_SLUGS
     ).aggregate(Sum('frozen_global_points'))['frozen_global_points__sum'] or 0) * 0.1)
 
     rp.save(update_fields=['builder_points', 'validator_points'])
@@ -593,6 +684,8 @@ def recalculate_referrer_points(referrer):
         rp.validator_points = int((Contribution.objects.filter(
             user_id__in=eligible_ids,
             contribution_type__category__slug='validator'
+        ).exclude(
+            contribution_type__slug__in=VALIDATOR_REFERRAL_EXCLUDED_SLUGS
         ).aggregate(Sum('frozen_global_points'))['frozen_global_points__sum'] or 0) * 0.1)
     else:
         rp.builder_points = 0
@@ -748,12 +841,13 @@ def recalculate_all_leaderboards():
                             for referred_contrib in referrer_contributions[user_id]:
                                 referred_user_id = referred_contrib['user_id']
                                 category = referred_contrib['contribution_type__category__slug']
+                                slug = referred_contrib['contribution_type__slug']
                                 contrib_points = referred_contrib['frozen_global_points'] or 0
 
                                 if referred_user_id in users_eligible_for_referrals:
                                     if category == 'builder':
                                         builder_referral += int(contrib_points * 0.1)
-                                    elif category == 'validator':
+                                    elif category == 'validator' and slug not in VALIDATOR_REFERRAL_EXCLUDED_SLUGS:
                                         validator_referral += int(contrib_points * 0.1)
 
                             points += builder_referral + validator_referral
@@ -787,12 +881,13 @@ def recalculate_all_leaderboards():
                                         if referred_contrib['contribution_date'] <= grad_date:
                                             referred_user_id = referred_contrib['user_id']
                                             category = referred_contrib['contribution_type__category__slug']
+                                            slug = referred_contrib['contribution_type__slug']
                                             contrib_points = referred_contrib['frozen_global_points'] or 0
 
                                             if referred_user_id in users_eligible_for_referrals:
                                                 if category == 'builder':
                                                     builder_referral += int(contrib_points * 0.1)
-                                                elif category == 'validator':
+                                                elif category == 'validator' and slug not in VALIDATOR_REFERRAL_EXCLUDED_SLUGS:
                                                     validator_referral += int(contrib_points * 0.1)
 
                                     points += builder_referral + validator_referral
@@ -812,12 +907,13 @@ def recalculate_all_leaderboards():
                 for contrib in referred_contribs:
                     referred_user_id = contrib['user_id']
                     category = contrib['contribution_type__category__slug']
+                    slug = contrib['contribution_type__slug']
                     contrib_points = contrib['frozen_global_points'] or 0
 
                     if referred_user_id in users_eligible_for_referrals:
                         if category == 'builder':
                             builder_points += int(contrib_points * 0.1)
-                        elif category == 'validator':
+                        elif category == 'validator' and slug not in VALIDATOR_REFERRAL_EXCLUDED_SLUGS:
                             validator_points += int(contrib_points * 0.1)
 
                 referral_points_to_create.append(ReferralPoints(

--- a/backend/leaderboard/tests/test_referral_points.py
+++ b/backend/leaderboard/tests/test_referral_points.py
@@ -1,0 +1,339 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from decimal import Decimal
+from datetime import timedelta
+
+from leaderboard.models import (
+    ReferralPoints,
+    update_referrer_points,
+    recalculate_referrer_points,
+    get_eligible_referred_user_ids,
+    get_referral_breakdown,
+    GlobalLeaderboardMultiplier,
+    VALIDATOR_REFERRAL_EXCLUDED_SLUGS,
+)
+from contributions.models import Contribution, ContributionType, Category
+
+User = get_user_model()
+
+
+class ReferralPointsExclusionTest(TestCase):
+    """Test that validator-waitlist is excluded from validator referral points."""
+
+    def setUp(self):
+        # Create categories
+        self.validator_category = Category.objects.create(
+            name='Validator', slug='validator', description='Validator contributions'
+        )
+        self.builder_category = Category.objects.create(
+            name='Builder', slug='builder', description='Builder contributions'
+        )
+
+        # Create contribution types
+        self.waitlist_type = ContributionType.objects.create(
+            name='Validator Waitlist',
+            slug='validator-waitlist',
+            description='Joined the validator waitlist',
+            category=self.validator_category,
+            min_points=20,
+            max_points=20,
+        )
+        self.node_running_type = ContributionType.objects.create(
+            name='Node Running',
+            slug='node-running',
+            description='Running a validator node',
+            category=self.validator_category,
+            min_points=10,
+            max_points=100,
+        )
+        self.builder_welcome_type = ContributionType.objects.create(
+            name='Builder Welcome',
+            slug='builder-welcome',
+            description='Welcome to the builder community',
+            category=self.builder_category,
+            min_points=20,
+            max_points=20,
+        )
+        self.blog_type = ContributionType.objects.create(
+            name='Blog Post',
+            slug='blog-post',
+            description='Blog post contribution',
+            category=self.builder_category,
+            min_points=10,
+            max_points=100,
+        )
+
+        # Create multipliers (required for frozen_global_points)
+        now = timezone.now()
+        for ct in [self.waitlist_type, self.node_running_type, self.builder_welcome_type, self.blog_type]:
+            GlobalLeaderboardMultiplier.objects.create(
+                contribution_type=ct,
+                multiplier_value=Decimal('1.0'),
+                valid_from=now - timedelta(days=30),
+            )
+
+        # Create referrer and referred user
+        self.referrer = User.objects.create_user(
+            email='referrer@test.com',
+            password='testpass123',
+            name='Referrer',
+            address='0x1111111111111111111111111111111111111111',
+        )
+        self.referred_user = User.objects.create_user(
+            email='referred@test.com',
+            password='testpass123',
+            name='Referred',
+            address='0x2222222222222222222222222222222222222222',
+            referred_by=self.referrer,
+        )
+
+    def _create_contribution(self, user, contribution_type, points):
+        """Helper to create a contribution with frozen_global_points."""
+        return Contribution.objects.create(
+            user=user,
+            contribution_type=contribution_type,
+            points=points,
+            frozen_global_points=points,
+            multiplier_at_creation=Decimal('1.0'),
+            contribution_date=timezone.now(),
+        )
+
+    def test_validator_waitlist_excluded_from_referral_sum(self):
+        """Referred user with only validator-waitlist should give referrer 0 validator referral points."""
+        # Give referred user the waitlist badge + a builder contribution (so they pass eligibility gate)
+        self._create_contribution(self.referred_user, self.waitlist_type, 20)
+        self._create_contribution(self.referred_user, self.blog_type, 50)
+
+        # Trigger referral update
+        contribution = Contribution.objects.filter(
+            user=self.referred_user, contribution_type=self.blog_type
+        ).first()
+        update_referrer_points(contribution)
+
+        rp = ReferralPoints.objects.get(user=self.referrer)
+        # Validator referral should be 0 (waitlist excluded), not 2 (10% of 20)
+        self.assertEqual(rp.validator_points, 0)
+        # Builder referral should be 5 (10% of 50)
+        self.assertEqual(rp.builder_points, 5)
+
+    def test_real_validator_included_in_referral_sum(self):
+        """Referred user with real validator contribution should give referrer correct 10%."""
+        self._create_contribution(self.referred_user, self.node_running_type, 100)
+
+        contribution = Contribution.objects.filter(
+            user=self.referred_user, contribution_type=self.node_running_type
+        ).first()
+        update_referrer_points(contribution)
+
+        rp = ReferralPoints.objects.get(user=self.referrer)
+        self.assertEqual(rp.validator_points, 10)  # 10% of 100
+
+    def test_mixed_contributions_excludes_badge(self):
+        """Referred user with waitlist (20) + node-running (100) should give referrer 10, not 12."""
+        self._create_contribution(self.referred_user, self.waitlist_type, 20)
+        self._create_contribution(self.referred_user, self.node_running_type, 100)
+
+        contribution = Contribution.objects.filter(
+            user=self.referred_user, contribution_type=self.node_running_type
+        ).first()
+        update_referrer_points(contribution)
+
+        rp = ReferralPoints.objects.get(user=self.referrer)
+        # Should be 10% of 100 = 10, NOT 10% of 120 = 12
+        self.assertEqual(rp.validator_points, 10)
+
+    def test_eligible_user_filter_unchanged(self):
+        """Eligibility gate still works: user with ONLY onboarding badges is not eligible."""
+        self._create_contribution(self.referred_user, self.waitlist_type, 20)
+
+        eligible_ids = get_eligible_referred_user_ids(self.referrer)
+        self.assertEqual(len(eligible_ids), 0)
+
+    def test_eligible_user_with_real_contribution(self):
+        """User with real contribution passes eligibility gate."""
+        self._create_contribution(self.referred_user, self.waitlist_type, 20)
+        self._create_contribution(self.referred_user, self.node_running_type, 100)
+
+        eligible_ids = get_eligible_referred_user_ids(self.referrer)
+        self.assertIn(self.referred_user.id, eligible_ids)
+
+    def test_recalculate_matches_update(self):
+        """recalculate_referrer_points gives same result as update_referrer_points."""
+        self._create_contribution(self.referred_user, self.waitlist_type, 20)
+        self._create_contribution(self.referred_user, self.node_running_type, 100)
+        self._create_contribution(self.referred_user, self.blog_type, 50)
+
+        # Use update path
+        contribution = Contribution.objects.filter(
+            user=self.referred_user, contribution_type=self.node_running_type
+        ).first()
+        update_referrer_points(contribution)
+        rp_update = ReferralPoints.objects.get(user=self.referrer)
+        update_builder = rp_update.builder_points
+        update_validator = rp_update.validator_points
+
+        # Reset and use recalculate path
+        rp_update.builder_points = 0
+        rp_update.validator_points = 0
+        rp_update.save()
+
+        recalculate_referrer_points(self.referrer)
+        rp_recalc = ReferralPoints.objects.get(user=self.referrer)
+
+        self.assertEqual(rp_recalc.builder_points, update_builder)
+        self.assertEqual(rp_recalc.validator_points, update_validator)
+
+    def test_constant_contains_validator_waitlist(self):
+        """Verify the exclusion constant contains validator-waitlist."""
+        self.assertIn('validator-waitlist', VALIDATOR_REFERRAL_EXCLUDED_SLUGS)
+
+
+class ReferralBreakdownHelperTest(TestCase):
+    """Test the shared get_referral_breakdown() helper."""
+
+    def setUp(self):
+        # Create categories
+        self.validator_category = Category.objects.create(
+            name='Validator', slug='validator', description='Validator contributions'
+        )
+        self.builder_category = Category.objects.create(
+            name='Builder', slug='builder', description='Builder contributions'
+        )
+
+        # Create contribution types
+        self.waitlist_type = ContributionType.objects.create(
+            name='Validator Waitlist',
+            slug='validator-waitlist',
+            description='Joined the validator waitlist',
+            category=self.validator_category,
+            min_points=20,
+            max_points=20,
+        )
+        self.node_running_type = ContributionType.objects.create(
+            name='Node Running',
+            slug='node-running',
+            description='Running a validator node',
+            category=self.validator_category,
+            min_points=10,
+            max_points=100,
+        )
+        self.blog_type = ContributionType.objects.create(
+            name='Blog Post',
+            slug='blog-post',
+            description='Blog post contribution',
+            category=self.builder_category,
+            min_points=10,
+            max_points=100,
+        )
+
+        # Create multipliers
+        now = timezone.now()
+        for ct in [self.waitlist_type, self.node_running_type, self.blog_type]:
+            GlobalLeaderboardMultiplier.objects.create(
+                contribution_type=ct,
+                multiplier_value=Decimal('1.0'),
+                valid_from=now - timedelta(days=30),
+            )
+
+        # Create referrer and referred users
+        self.referrer = User.objects.create_user(
+            email='referrer@test.com',
+            password='testpass123',
+            name='Referrer',
+            address='0x1111111111111111111111111111111111111111',
+        )
+        self.referred_user_a = User.objects.create_user(
+            email='referred_a@test.com',
+            password='testpass123',
+            name='Referred A',
+            address='0x2222222222222222222222222222222222222222',
+            referred_by=self.referrer,
+        )
+        self.referred_user_b = User.objects.create_user(
+            email='referred_b@test.com',
+            password='testpass123',
+            name='Referred B',
+            address='0x3333333333333333333333333333333333333333',
+            referred_by=self.referrer,
+        )
+
+    def _create_contribution(self, user, contribution_type, points):
+        """Helper to create a contribution with frozen_global_points."""
+        return Contribution.objects.create(
+            user=user,
+            contribution_type=contribution_type,
+            points=points,
+            frozen_global_points=points,
+            multiplier_at_creation=Decimal('1.0'),
+            contribution_date=timezone.now(),
+        )
+
+    def test_returns_correct_structure(self):
+        """Helper returns dict with expected keys."""
+        result = get_referral_breakdown(self.referrer)
+        self.assertIn('total_referrals', result)
+        self.assertIn('builder_points', result)
+        self.assertIn('validator_points', result)
+        self.assertIn('referrals', result)
+
+    def test_no_referrals_returns_zeros(self):
+        """User with no referrals returns empty breakdown."""
+        loner = User.objects.create_user(
+            email='loner@test.com',
+            password='testpass123',
+            name='Loner',
+            address='0x4444444444444444444444444444444444444444',
+        )
+        result = get_referral_breakdown(loner)
+        self.assertEqual(result['total_referrals'], 0)
+        self.assertEqual(result['builder_points'], 0)
+        self.assertEqual(result['validator_points'], 0)
+        self.assertEqual(result['referrals'], [])
+
+    def test_lists_all_referred_users(self):
+        """Breakdown includes all referred users regardless of contributions."""
+        result = get_referral_breakdown(self.referrer)
+        self.assertEqual(result['total_referrals'], 2)
+        addresses = {r['address'] for r in result['referrals']}
+        self.assertIn(self.referred_user_a.address, addresses)
+        self.assertIn(self.referred_user_b.address, addresses)
+
+    def test_excludes_validator_waitlist_from_per_user_breakdown(self):
+        """Per-user validator points exclude validator-waitlist contributions."""
+        self._create_contribution(self.referred_user_a, self.waitlist_type, 20)
+        self._create_contribution(self.referred_user_a, self.node_running_type, 100)
+
+        # Trigger stored referral point calculation
+        contribution = Contribution.objects.filter(
+            user=self.referred_user_a, contribution_type=self.node_running_type
+        ).first()
+        update_referrer_points(contribution)
+
+        result = get_referral_breakdown(self.referrer)
+        user_a_entry = next(r for r in result['referrals'] if r['id'] == self.referred_user_a.id)
+        # Should be 100 (node-running only), not 120 (waitlist + node-running)
+        self.assertEqual(user_a_entry['validator_contribution_points'], 100)
+
+    def test_breakdown_sorted_by_total_points_descending(self):
+        """Referral list is sorted by total_points descending."""
+        self._create_contribution(self.referred_user_a, self.blog_type, 50)
+        self._create_contribution(self.referred_user_b, self.blog_type, 200)
+
+        result = get_referral_breakdown(self.referrer)
+        self.assertEqual(result['referrals'][0]['id'], self.referred_user_b.id)
+        self.assertEqual(result['referrals'][1]['id'], self.referred_user_a.id)
+
+    def test_referral_entry_has_expected_fields(self):
+        """Each referral entry has all expected fields."""
+        self._create_contribution(self.referred_user_a, self.blog_type, 50)
+
+        result = get_referral_breakdown(self.referrer)
+        entry = result['referrals'][0]
+        expected_fields = [
+            'id', 'name', 'address', 'profile_image_url', 'total_points',
+            'builder_contribution_points', 'validator_contribution_points',
+            'created_at', 'total_contributions', 'is_validator', 'is_builder',
+        ]
+        for field in expected_fields:
+            self.assertIn(field, entry, f"Missing field: {field}")

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -686,86 +686,11 @@ class UserSerializer(serializers.ModelSerializer):
         return User.objects.filter(referred_by=obj).count()
 
     def get_referral_details(self, obj):
-        """
-        Get comprehensive referral information including list of referred users.
-        Queries contribution points directly from Contribution table for accuracy.
-
-        IMPORTANT: This is an expensive operation and should only be included
-        when explicitly requested via include_referral_details=true in context.
-        """
-        # Skip this expensive operation unless explicitly requested
+        """Referral breakdown. Only included when include_referral_details=True."""
         if not self.context.get('include_referral_details', False):
             return None
-
-        from leaderboard.models import ReferralPoints
-        from contributions.models import Contribution
-        from django.db.models import Count, Sum
-
-        # Get referrer's referral points
-        try:
-            rp = obj.referral_points
-            builder_pts = rp.builder_points
-            validator_pts = rp.validator_points
-        except ReferralPoints.DoesNotExist:
-            builder_pts = 0
-            validator_pts = 0
-
-        # Get all users referred by this user
-        referred_users = User.objects.filter(
-            referred_by=obj
-        ).select_related('validator', 'builder').annotate(
-            total_contributions=Count('contributions', distinct=True)
-        )
-
-        # Build the referral list with builder/validator breakdown
-        # Optimize: bulk query all contributions instead of N+1 queries
-        referred_user_ids = [u.id for u in referred_users]
-
-        builder_points_by_user = {
-            item['user_id']: item['total'] or 0
-            for item in Contribution.objects.filter(
-                user_id__in=referred_user_ids,
-                contribution_type__category__slug='builder'
-            ).values('user_id').annotate(total=Sum('frozen_global_points'))
-        }
-
-        validator_points_by_user = {
-            item['user_id']: item['total'] or 0
-            for item in Contribution.objects.filter(
-                user_id__in=referred_user_ids,
-                contribution_type__category__slug='validator'
-            ).values('user_id').annotate(total=Sum('frozen_global_points'))
-        }
-
-        referral_list = []
-        for referred_user in referred_users:
-            builder_contribution_points = builder_points_by_user.get(referred_user.id, 0)
-            validator_contribution_points = validator_points_by_user.get(referred_user.id, 0)
-            total_points = builder_contribution_points + validator_contribution_points
-
-            referral_list.append({
-                'id': referred_user.id,
-                'name': referred_user.name or 'Anonymous',
-                'address': referred_user.address,
-                'profile_image_url': referred_user.profile_image_url,
-                'total_points': total_points,
-                'builder_contribution_points': builder_contribution_points,
-                'validator_contribution_points': validator_contribution_points,
-                'created_at': referred_user.created_at,
-                'total_contributions': referred_user.total_contributions,
-                'is_validator': hasattr(referred_user, 'validator'),
-                'is_builder': hasattr(referred_user, 'builder'),
-            })
-
-        # Sort by total points (highest first)
-        referral_list.sort(key=lambda x: x['total_points'], reverse=True)
-
-        return {
-            'total_referrals': len(referral_list),
-            'builder_points': builder_pts,
-            'validator_points': validator_pts,
-            'referrals': referral_list
-        }
+        from leaderboard.models import get_referral_breakdown
+        return get_referral_breakdown(obj)
 
     def get_working_groups(self, obj):
         """

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -695,81 +695,9 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
 
     @action(detail=False, methods=['get'], permission_classes=[IsAuthenticated])
     def referrals(self, request):
-        """
-        Full referral details including referred users list with builder/validator breakdown.
-        Used by Profile and Referrals pages.
-        """
-        from leaderboard.models import ReferralPoints
-        from contributions.models import Contribution
-        from django.db.models import Count, Sum
-
-        user = request.user
-
-        # Get referrer's referral points
-        try:
-            rp = user.referral_points
-            builder_pts = rp.builder_points
-            validator_pts = rp.validator_points
-        except ReferralPoints.DoesNotExist:
-            builder_pts = 0
-            validator_pts = 0
-
-        # Get all users referred by the current user
-        referred_users = User.objects.filter(
-            referred_by=user
-        ).select_related('validator', 'builder').annotate(
-            total_contributions=Count('contributions', distinct=True)
-        )
-
-        # Build the referral list with builder/validator breakdown
-        # Optimize: bulk query all contributions instead of N+1 queries
-        referred_user_ids = [u.id for u in referred_users]
-
-        builder_points_by_user = {
-            item['user_id']: item['total'] or 0
-            for item in Contribution.objects.filter(
-                user_id__in=referred_user_ids,
-                contribution_type__category__slug='builder'
-            ).values('user_id').annotate(total=Sum('frozen_global_points'))
-        }
-
-        validator_points_by_user = {
-            item['user_id']: item['total'] or 0
-            for item in Contribution.objects.filter(
-                user_id__in=referred_user_ids,
-                contribution_type__category__slug='validator'
-            ).values('user_id').annotate(total=Sum('frozen_global_points'))
-        }
-
-        referral_list = []
-        for referred_user in referred_users:
-            builder_contribution_points = builder_points_by_user.get(referred_user.id, 0)
-            validator_contribution_points = validator_points_by_user.get(referred_user.id, 0)
-            total_points = builder_contribution_points + validator_contribution_points
-
-            referral_list.append({
-                'id': referred_user.id,
-                'name': referred_user.name or 'Anonymous',
-                'address': referred_user.address,
-                'profile_image_url': referred_user.profile_image_url,
-                'total_points': total_points,
-                'builder_contribution_points': builder_contribution_points,
-                'validator_contribution_points': validator_contribution_points,
-                'created_at': referred_user.created_at,
-                'total_contributions': referred_user.total_contributions,
-                'is_validator': hasattr(referred_user, 'validator'),
-                'is_builder': hasattr(referred_user, 'builder'),
-            })
-
-        # Sort by total points (highest first)
-        referral_list.sort(key=lambda x: x['total_points'], reverse=True)
-
-        return Response({
-            'total_referrals': len(referral_list),
-            'builder_points': builder_pts,
-            'validator_points': validator_pts,
-            'referrals': referral_list
-        })
+        """Full referral details. Used by Referrals page."""
+        from leaderboard.models import get_referral_breakdown
+        return Response(get_referral_breakdown(request.user))
 
     @action(detail=False, methods=['get'], permission_classes=[permissions.AllowAny])
     def search(self, request):


### PR DESCRIPTION
## Summary
- **Bug fix**: `validator-waitlist` contributions were incorrectly included in referral point calculations across 8 code paths — now excluded via `VALIDATOR_REFERRAL_EXCLUDED_SLUGS` constant
- **DRY refactor**: Extracted shared `get_referral_breakdown(user)` helper, replacing ~80 lines of near-identical code duplicated between `views.py` and `serializers.py`
- **Bulk recalc fix**: `recalculate_all_leaderboards()` had 3 locations calculating validator referral points without the exclusion — now consistent with all other paths

## Post-deploy: recalculate referral points

After deploying, run the management command to fix any existing inflated totals:

```bash
# Preview changes (dry run)
python manage.py recalculate_referral_points --dry-run

# Apply corrections
python manage.py recalculate_referral_points
```

## Files changed
| File | Change |
|------|--------|
| `backend/leaderboard/models.py` | Added `VALIDATOR_REFERRAL_EXCLUDED_SLUGS`, `get_referral_breakdown()` helper, fixed 3 locations in `recalculate_all_leaderboards()` |
| `backend/users/views.py` | Replaced 70-line `referrals()` with 3-line call to shared helper |
| `backend/users/serializers.py` | Replaced 80-line `get_referral_details()` with 5-line call to shared helper |
| `backend/leaderboard/management/commands/recalculate_referral_points.py` | Added exclusion filter to management command |
| `backend/leaderboard/tests/test_referral_points.py` | New test suite: exclusion logic + breakdown helper (6 tests) |

## Test plan
- [ ] Run `python manage.py recalculate_referral_points --dry-run` on staging to verify point corrections
- [ ] Verify `/api/v1/users/referrals/` returns correct breakdown (no validator-waitlist inflation)
- [ ] Verify `/api/v1/users/me/` referral_details field matches `/referrals/` endpoint
- [ ] Verify leaderboard totals are consistent after full recalculation
- [ ] Check Referrals page renders correctly in frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)