### PR TITLE
Fix community leaderboard ranking and profile referral points

### DIFF
--- a/backend/leaderboard/views.py
+++ b/backend/leaderboard/views.py
@@ -506,7 +506,7 @@ class LeaderboardViewSet(viewsets.ReadOnlyModelViewSet):
 
         referral_qs = ReferralPoints.objects.select_related('user').annotate(
             total_points=F('builder_points') + F('validator_points')
-        ).filter(user__visible=True, total_points__gt=0)
+        ).filter(user__visible=True, total_points__gt=0).order_by('-total_points')
 
         # Aggregate totals at DB level
         totals = referral_qs.aggregate(

--- a/frontend/src/routes/Profile.svelte
+++ b/frontend/src/routes/Profile.svelte
@@ -404,6 +404,12 @@
             .getReferrals()
             .then((response) => {
               referralData = response.data;
+              if (response.data && (referralPoints.builder_points === 0 && referralPoints.validator_points === 0)) {
+                referralPoints = {
+                  builder_points: response.data.builder_points || 0,
+                  validator_points: response.data.validator_points || 0,
+                };
+              }
             })
             .catch(() => {
               referralData = null;
@@ -414,6 +420,10 @@
         }
       } else if (participant?.referral_details) {
         referralData = participant.referral_details;
+        referralPoints = {
+          builder_points: participant.referral_details.builder_points || 0,
+          validator_points: participant.referral_details.validator_points || 0,
+        };
       }
 
       if (participant.validator) fetchValidatorWallets();


### PR DESCRIPTION
## Summary
- **Community leaderboard ranking**: Added missing `.order_by('-total_points')` to the community endpoint queryset — results were returned in arbitrary database order, causing incorrect rankings (e.g., user with 228 pts ranked above user with 382 pts)
- **Profile referral points display**: `CommunityView` showed 0/0 for builder/validator referral points because `referralPoints` was only populated from leaderboard entries (which may not exist for community-only users). Now populated from `referral_details` data which is always available from the `by-address` API

## Files changed
| File | Change |
|------|--------|
| `backend/leaderboard/views.py` | Added `.order_by('-total_points')` to community queryset |
| `frontend/src/routes/Profile.svelte` | Populate `referralPoints` from `referral_details` for both own and non-own profiles |

## Test plan
- [ ] Verify community leaderboard shows users sorted by total referral points (highest first)
- [ ] Verify profile page shows correct builder/validator referral points in Community section
- [ ] Verify own profile referral points match `/api/v1/users/referral_points/` response
- [ ] Verify non-own profile referral points match community leaderboard values