### PR TITLE
Redesign Builder Resources page

### DIFF
--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -208,6 +208,15 @@
             >
               Leaderboard
             </a>
+            <a
+              href="/builders/resources"
+              onclick={(e) => { e.preventDefault(); navigate('/builders/resources'); }}
+              class="flex items-center border-l-[1.5px] px-3 py-2 text-[14px] font-medium text-black tracking-[0.28px] {
+                isActive('/builders/resources') ? 'border-[#EE8D24]' : 'border-[#f5f5f5]'
+              }"
+            >
+              Resources
+            </a>
           </div>
         {/if}
       </div>
@@ -546,6 +555,15 @@
             }"
           >
             Leaderboard
+          </a>
+          <a
+            href="/builders/resources"
+            onclick={(e) => { e.preventDefault(); navigate('/builders/resources'); }}
+            class="flex items-center border-l-[1.5px] px-3 py-2 text-[14px] font-medium text-black tracking-[0.28px] {
+              isActive('/builders/resources') ? 'border-[#EE8D24]' : 'border-[#f5f5f5]'
+            }"
+          >
+            Resources
           </a>
         </div>
       {/if}

--- a/frontend/src/data/resources.js
+++ b/frontend/src/data/resources.js
@@ -1,264 +1,112 @@
-// Resources page data — single source of truth
+// Resources page data — single source of truth (builder-focused)
 // Edit this file to update content across the Resources page
 
 export const pageHeader = {
-  title: 'Resources for Builders',
-  subtitle: 'Everything you need to build on GenLayer — docs, tools, SDKs, and ecosystem projects in one place.',
+  title: 'Builder Resources',
+  subtitle: 'Everything you need to build on GenLayer.',
 };
 
-export const sections = [
-  { id: 'getting-started', label: 'Getting Started' },
-  { id: 'documentation', label: 'Docs' },
-  { id: 'ai-development', label: 'AI Tools' },
-  { id: 'bradbury-links', label: 'Bradbury Dev Links' },
-  { id: 'ecosystem', label: 'Ecosystem' },
-  { id: 'hackathon', label: 'Hackathon' },
-  { id: 'how-it-works', label: 'How It Works' },
-  { id: 'tracks', label: 'Tracks & Ideas' },
+export const communityLinks = [
+  { label: 'Discord', url: 'https://discord.gg/8Jm4v89VAu', color: '#5865F2' },
+  { label: 'Telegram', url: 'https://t.me/genlayer', color: '#26A5E4' },
+  { label: 'X', url: 'https://x.com/GenLayer', color: '#000000' },
+  { label: 'YouTube', url: 'https://www.youtube.com/@GenLayer', color: '#FF0000' },
 ];
 
-export const gettingStarted = {
-  tag: 'Recommended',
-  title: 'GenLayer Boilerplate',
-  description: 'The fastest way to start building on GenLayer. Clone the boilerplate, deploy your first Intelligent Contract, and connect a frontend — all in under 10 minutes.',
-  url: 'https://github.com/yeagerai/genlayer-boilerplate',
-  ctaLabel: 'View on GitHub',
-};
+export const sdks = [
+  { label: 'JavaScript SDK', url: 'https://www.npmjs.com/package/genlayer-js', icon: 'js' },
+  { label: 'Python SDK', url: 'https://pypi.org/project/genlayer-py/', icon: 'python' },
+  { label: 'GenLayer CLI', url: 'https://docs.genlayer.com/developers/intelligent-contracts/tools/genlayer-cli', icon: 'cli' },
+];
 
 export const documentation = [
-  {
-    tag: 'Docs',
-    title: 'Equivalence Principle',
-    description: 'Understand the core concept behind Intelligent Contracts — how GenLayer achieves deterministic results from non-deterministic AI outputs through validator consensus.',
-    url: 'https://docs.genlayer.com/concepts/equivalence-principle',
-    ctaLabel: 'Read documentation',
-  },
-  {
-    tag: 'Docs',
-    title: 'Development Setup & Quickstart',
-    description: 'Set up your local environment, install the GenLayer CLI, deploy your first contract, and connect it to a frontend application step by step.',
-    url: 'https://docs.genlayer.com/getting-started/setup',
-    ctaLabel: 'Read documentation',
-  },
+  { label: 'Developer Documentation', url: 'https://docs.genlayer.com/developers', description: 'Full reference for Intelligent Contracts, SDKs, and developer tools', icon: 'docs' },
+  { label: 'Equivalence Principle', url: 'https://docs.genlayer.com/developers/intelligent-contracts/equivalence-principle', description: 'How non-deterministic operations reach consensus across validators', icon: 'eq' },
+  { label: 'Python SDK API Reference', url: 'https://sdk.genlayer.com/main/api/index.html', description: 'Complete API reference for the Python SDK', icon: 'api' },
 ];
 
-export const aiDevelopment = [
-  {
-    tag: 'AI Tooling',
-    title: 'Claude Code Skills',
-    description: 'Pre-built Claude Code skills that understand GenLayer\'s architecture. Get AI-assisted contract development with context-aware suggestions and best practices.',
-    url: 'https://github.com/yeagerai/genlayer-claude-code-skills',
-    ctaLabel: 'View on GitHub',
-    installSteps: [
-      {
-        label: 'Install skills',
-        command: 'claude install-skills https://github.com/yeagerai/genlayer-claude-code-skills',
-      },
-    ],
-  },
-  {
-    tag: 'AI Tooling',
-    title: 'GenLayer MCP Server',
-    description: 'Model Context Protocol server for GenLayer. Connect any MCP-compatible AI assistant to GenLayer\'s documentation, contract templates, and deployment tools.',
-    url: 'https://github.com/yeagerai/genlayer-mcp-server',
-    ctaLabel: 'View on GitHub',
-    installSteps: [
-      {
-        label: 'Install via npx',
-        command: 'npx @anthropic-ai/claude-code mcp add genlayer -- npx -y genlayer-mcp-server',
-      },
-    ],
-  },
+export const boilerplates = [
+  { label: 'Project Boilerplate', url: 'https://github.com/genlayerlabs/genlayer-project-boilerplate', description: 'Starter template — clone, deploy a contract, and connect a frontend' },
+  { label: 'Bridge Boilerplate', url: 'https://github.com/genlayer-foundation/genlayer-studio-bridge-boilerplate', description: 'Bridge integration starter for cross-chain transfers' },
+  { label: 'Prediction Market Kit', url: 'https://github.com/courtofinternet/pm-kit', description: 'Full prediction market template powered by AI consensus' },
 ];
 
-export const bradburyLinks = {
-  network: {
-    title: 'Network',
-    items: [
-      { label: 'JSON-RPC Endpoint', value: 'https://studio-api.genlayer.com/api', copyable: true },
-      { label: 'WebSocket', value: 'wss://studio-api.genlayer.com/ws', copyable: true },
-      { label: 'Chain ID', value: '61_999', copyable: false },
-    ],
-  },
-  explorers: {
-    title: 'Explorers & Tools',
-    items: [
-      { label: 'GenLayer Explorer', url: 'https://explorer.genlayer.com' },
-      { label: 'GenLayer Studio', url: 'https://studio.genlayer.com' },
-      { label: 'GenLayer Simulator', url: 'https://simulator.genlayer.com' },
-    ],
-  },
-  sdks: {
-    title: 'SDKs & CLI',
-    items: [
-      {
-        label: 'GenLayer JS SDK',
-        package: 'genlayer-js',
-        version: 'latest',
-        installCommand: 'npm install genlayer-js',
-        url: 'https://www.npmjs.com/package/genlayer-js',
-      },
-      {
-        label: 'GenLayer Python SDK',
-        package: 'genlayer',
-        version: 'latest',
-        installCommand: 'pip install genlayer',
-        url: 'https://pypi.org/project/genlayer/',
-      },
-      {
-        label: 'GenLayer CLI',
-        package: 'genlayer-cli',
-        version: 'latest',
-        installCommand: 'npm install -g genlayer-cli',
-        url: 'https://www.npmjs.com/package/genlayer-cli',
-      },
-    ],
-  },
-};
-
-export const ecosystemProjects = [
-  {
-    title: 'Internet Court',
-    description: 'Decentralized arbitration platform for dispute resolution with AI-evaluated evidence.',
-    url: 'https://internetcourt.org',
-    track: 'Onchain Justice',
-  },
-  {
-    title: 'MergeProof',
-    description: 'Verified code contribution tracking and proof-of-work for open source developers.',
-    url: 'https://mergeproof.com',
-    track: 'Future of Work',
-  },
-  {
-    title: 'Molly.fun',
-    description: 'Social AI agent platform exploring agent-to-agent economic interactions.',
-    url: 'https://molly.fun',
-    track: 'Agentic Economy',
-  },
-  {
-    title: 'COFI Bets',
-    description: 'On-chain prediction market with AI-resolved outcomes through validator consensus.',
-    url: 'https://bet.courtofinternet.com/',
-    track: 'Prediction Markets',
-  },
-  {
-    title: 'Rally.fun',
-    description: 'Collaborative funding platform for community-driven initiatives and bounties.',
-    url: 'https://rally.fun',
-    track: 'Future of Work',
-  },
-  {
-    title: 'Argue.fun',
-    description: 'Structured debate platform with AI-judged arguments and community voting.',
-    url: 'https://argue.fun',
-    track: 'AI Governance',
-  },
-  {
-    title: 'P2P Betting',
-    description: 'Peer-to-peer betting platform with trustless settlement via Intelligent Contracts.',
-    url: 'https://p2p-betting-mu.vercel.app/create',
-    track: 'Prediction Markets',
-  },
-  {
-    title: 'Prediction Market Kit',
-    description: 'Open-source toolkit for building custom prediction markets on GenLayer.',
-    url: 'https://pmkit.courtofinternet.com/',
-    track: 'Prediction Markets',
-  },
-  {
-    title: 'Unstoppable',
-    description: 'Multiplayer coordination game exploring social dynamics and consensus mechanisms.',
-    url: 'https://unstoppable.fun/',
-    track: 'AI Gaming',
-  },
-  {
-    title: 'Mochi Quest',
-    description: 'Interactive AI game where players navigate consensus-based challenges together.',
-    url: 'https://guess-picture.onrender.com/mochi-quest',
-    track: 'AI Gaming',
-  },
-  {
-    title: 'Bridge Boilerplate',
-    description: 'Connect GenLayer Intelligent Contracts with EVM chains via LayerZero V2. Offload AI reasoning to GenLayer while keeping users and liquidity on Base/Ethereum.',
-    url: 'https://github.com/genlayer-foundation/genlayer-studio-bridge-boilerplate',
-    track: 'Infrastructure',
-  },
-  {
-    title: 'PM Kit',
-    description: 'Fully on-chain prediction market kit with cross-chain bridging, escrow, and trustless resolution via GenLayer validator consensus. Like Limitless, but decentralized.',
-    url: 'https://github.com/courtofinternet/pm-kit',
-    track: 'Prediction Markets',
-  },
+export const tools = [
+  { label: 'GenLayer Studio', url: 'https://studio.genlayer.com', description: 'Browser IDE for writing, testing, and deploying Intelligent Contracts' },
+  { label: 'Testnet Faucet', url: 'https://testnet-faucet.genlayer.foundation/', description: 'Claim 100 GEN tokens per day on Asimov or Bradbury testnets' },
+  { label: 'Asimov Explorer', url: 'https://explorer-asimov.genlayer.com', description: 'Browse transactions and contracts on testnet Asimov' },
+  { label: 'Bradbury Explorer', url: 'https://explorer-bradbury.genlayer.com', description: 'Browse transactions and contracts on testnet Bradbury' },
 ];
 
-export const hackathon = {
-  title: 'Testnet Bradbury Hackathon',
-  subtitle: 'Build Intelligent Contracts with AI consensus',
-  highlights: [
-    'Builder Points + $5,000 in prizes',
-    '6 tracks to choose from',
-    'Mentorship & funding opportunities',
+export const aiResources = {
+  links: [
+    { label: 'Python SDK API (LLM-friendly)', url: 'https://sdk.genlayer.com/main/_static/ai/api.txt', description: 'Plain-text API reference optimized for LLM consumption' },
+    { label: 'Claude Code Skills', url: 'https://skills.genlayer.com', description: 'AI skills for writing, linting, testing, and deploying contracts' },
   ],
-  ctaLabel: 'View Hackathon Details',
-  ctaPath: '/hackathon',
-};
+  metaprompt: `You are a GenLayer developer assistant. GenLayer is an L2 blockchain (ZKSync-based rollup) where Intelligent Contracts — Python classes inheriting from gl.Contract — can natively call LLMs and access the web.
 
-export const portalInfo = [
-  {
-    step: 1,
-    title: 'Sign Up',
-    description: 'Connect your wallet and create your builder profile on the GenLayer Portal.',
-    color: 'from-[#f8b93d] to-[#ee8d24]', // orange
-  },
-  {
-    step: 2,
-    title: 'Build & Deploy',
-    description: 'Write Intelligent Contracts, deploy to Bradbury testnet, and build your frontend.',
-    color: 'from-[#6da7f3] to-[#387de8]', // blue
-  },
-  {
-    step: 3,
-    title: 'Submit',
-    description: 'Submit your contributions through the portal to earn points and climb the leaderboard.',
-    color: 'from-[#a77fee] to-[#7f52e1]', // purple
-  },
-  {
-    step: 4,
-    title: 'Earn & Rank',
-    description: 'Accumulate points, unlock contributions, and rise through the builder ranks.',
-    color: 'from-[#3eb359] to-[#2d9a46]', // green
-  },
-];
+## What are Intelligent Contracts?
+Intelligent Contracts are Python smart contracts that go beyond traditional deterministic logic. They can call LLMs, fetch web data, and process unstructured information — all while maintaining blockchain consensus. Contracts inherit from gl.Contract, use @gl.public.write for state-changing methods and @gl.public.view for read-only methods. Storage uses TreeMap (key-value), DynArray (dynamic arrays), and u256 (integers). Raise UserError for user-facing failures.
+
+## The Equivalence Principle
+The core consensus mechanism for non-deterministic operations. A leader node executes an operation and proposes a result. Validators independently verify whether that result is acceptable — majority acceptance means consensus.
+- gl.eq_principle.strict_eq — exact match (for deterministic APIs like RPCs)
+- gl.eq_principle.prompt_comparative — LLM judges if two outputs are equivalent
+- gl.eq_principle.prompt_non_comparative — LLM validates leader result directly
+- gl.vm.run_nondet_unsafe — custom validator logic (most common in real contracts)
+Always extract structured data before comparing. Raw web/LLM output varies across nodes.
+
+## Development Tools
+- GenLayer Studio (https://studio.genlayer.com): Browser IDE for writing, testing, and deploying contracts
+- GenLayer CLI: Terminal tool for scaffolding, deploying, and interacting with contracts
+- Faucet (https://testnet-faucet.genlayer.foundation/): Get 100 GEN tokens/day on testnets
+
+## Active Testnets
+- Asimov: Explorer at https://explorer-asimov.genlayer.com
+- Bradbury: Explorer at https://explorer-bradbury.genlayer.com
+
+## Key References
+- Documentation: https://docs.genlayer.com/developers
+- Equivalence Principle: https://docs.genlayer.com/developers/intelligent-contracts/equivalence-principle
+- Python SDK full API: https://sdk.genlayer.com/main/_static/ai/api.txt
+- JS SDK: https://www.npmjs.com/package/genlayer-js
+- Python SDK: https://pypi.org/project/genlayer-py/
+- GenLayer CLI: https://docs.genlayer.com/developers/intelligent-contracts/tools/genlayer-cli
+- Project Boilerplate: https://github.com/genlayerlabs/genlayer-project-boilerplate
+- Bridge Boilerplate: https://github.com/genlayer-foundation/genlayer-studio-bridge-boilerplate
+- Prediction Market Kit: https://github.com/courtofinternet/pm-kit
+- Claude Code Skills: https://skills.genlayer.com (write, lint, test, deploy contracts via AI)`,
+};
 
 export const tracksAndIdeas = [
   {
     title: 'Agentic Economy Infrastructure',
     description: 'Build the infrastructure for AI agents to interact, transact, and coordinate autonomously.',
-    gradient: 'from-[#f8b93d] to-[#ee8d24]',
+    color: '#ee8521',
   },
   {
     title: 'AI Governance',
     description: 'AI-driven decisions and coordination between humans and autonomous agents.',
-    gradient: 'from-[#6da7f3] to-[#387de8]',
+    color: '#387de8',
   },
   {
     title: 'Prediction Markets & P2P Betting',
     description: 'Bet, predict, and trade on future outcomes with on-chain markets powered by AI consensus.',
-    gradient: 'from-[#a77fee] to-[#7f52e1]',
+    color: '#7f52e1',
   },
   {
     title: 'AI Gaming',
     description: 'Multiplayer games exploring coordination, social dynamics, and consensus mechanics.',
-    gradient: 'from-[#e85d75] to-[#c94058]',
+    color: '#c94058',
   },
   {
     title: 'Future of Work',
     description: 'AI-verified deliverables, reputation tracking, and outcome-based payment systems.',
-    gradient: 'from-[#3eb359] to-[#2d9a46]',
+    color: '#3eb359',
   },
   {
     title: 'Onchain Justice',
     description: 'Decentralized arbitration with AI-evaluated evidence and fair dispute resolution.',
-    gradient: 'from-[#f0923b] to-[#d6721e]',
+    color: '#d6721e',
   },
 ];

--- a/frontend/src/routes/Resources.svelte
+++ b/frontend/src/routes/Resources.svelte
@@ -1,32 +1,23 @@
 <script>
-  import { push } from 'svelte-spa-router';
-  import prizeBackground from '../assets/hackathon/prize-background.jpg';
-  import arrowRight from '../assets/hackathon/arrow-right.svg';
   import {
     pageHeader,
-    sections,
-    gettingStarted,
+    communityLinks,
+    sdks,
     documentation,
-    aiDevelopment,
-    bradburyLinks,
-    ecosystemProjects,
-    hackathon,
-    portalInfo,
+    boilerplates,
+    tools,
+    aiResources,
     tracksAndIdeas,
   } from '../data/resources.js';
 
-  // Track which commands have been copied
   let copiedStates = $state({});
 
   async function copyToClipboard(text, key) {
     try {
       await navigator.clipboard.writeText(text);
       copiedStates[key] = true;
-      setTimeout(() => {
-        copiedStates[key] = false;
-      }, 2000);
+      setTimeout(() => { copiedStates[key] = false; }, 2000);
     } catch {
-      // Fallback for older browsers
       const ta = document.createElement('textarea');
       ta.value = text;
       ta.style.position = 'fixed';
@@ -36,380 +27,229 @@
       document.execCommand('copy');
       document.body.removeChild(ta);
       copiedStates[key] = true;
-      setTimeout(() => {
-        copiedStates[key] = false;
-      }, 2000);
-    }
-  }
-
-  function scrollToSection(id) {
-    const el = document.getElementById(id);
-    if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      setTimeout(() => { copiedStates[key] = false; }, 2000);
     }
   }
 </script>
 
-<div class="flex flex-col gap-6 md:gap-8 max-w-[1200px] mx-auto pb-12 px-1 md:px-3">
+<div class="flex flex-col gap-6 max-w-[1100px] mx-auto pb-12 px-1 md:px-3">
 
-  <!-- A. Hero Header -->
-  <section class="flex flex-col gap-5 pt-4 md:pt-8">
-    <div class="flex flex-col gap-3">
-      <h1 class="text-[32px] md:text-[64px] font-display font-medium leading-[36px] md:leading-[68px] tracking-[-0.64px] md:tracking-[-1.28px] text-black">
+  <!-- Header: title + community links -->
+  <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4 pt-4 md:pt-8">
+    <div class="flex flex-col gap-1">
+      <h1 class="text-[28px] md:text-[36px] font-display font-medium leading-tight tracking-[-0.72px] text-black">
         {pageHeader.title}
       </h1>
-      <p class="text-[15px] md:text-[17px] leading-[24px] md:leading-[28px] tracking-[0.34px] text-[#6b6b6b] max-w-[700px]">
+      <p class="text-[15px] leading-[24px] tracking-[0.3px] text-[#6b6b6b]">
         {pageHeader.subtitle}
       </p>
     </div>
-
-    <!-- Quick-jump pills -->
-    <div class="flex flex-wrap gap-2">
-      {#each sections as section}
-        <button
-          onclick={() => scrollToSection(section.id)}
-          class="px-3 py-1.5 rounded-full text-[12px] md:text-[13px] font-medium text-[#6b6b6b] border border-[#e3e3e3] hover:border-[#ababab] hover:text-black transition-colors cursor-pointer bg-white"
-        >
-          {section.label}
-        </button>
-      {/each}
-    </div>
-
-    <!-- Gradient accent line -->
-    <div class="h-[2px] rounded-full" style="background: linear-gradient(to right, #f8b93d, #ee8d24, #a77fee, #7f52e1);"></div>
-  </section>
-
-  <!-- B. Getting Started -->
-  <section id="getting-started" class="scroll-mt-4">
-    <div class="relative rounded-lg p-6 md:p-8 overflow-hidden text-white"
-         style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 40%, #0f3460 100%);">
-      <!-- Decorative glows -->
-      <div class="absolute top-0 right-0 w-[300px] h-[300px] rounded-full opacity-[0.07]" style="background: radial-gradient(circle, #f8b93d, transparent 70%); transform: translate(30%, -30%);"></div>
-      <div class="absolute bottom-0 left-0 w-[200px] h-[200px] rounded-full opacity-[0.05]" style="background: radial-gradient(circle, #a77fee, transparent 70%); transform: translate(-30%, 30%);"></div>
-
-      <div class="relative flex flex-col gap-4">
-        <span class="inline-flex items-center self-start px-3 py-1 rounded-full text-[11px] font-semibold uppercase tracking-[0.5px]"
-              style="background: linear-gradient(135deg, #f8b93d, #ee8d24); color: #1a1a2e;">
-          {gettingStarted.tag}
-        </span>
-        <h2 class="text-[24px] md:text-[32px] font-display font-medium leading-[28px] md:leading-[40px] tracking-[-0.48px] md:tracking-[-0.64px]">
-          {gettingStarted.title}
-        </h2>
-        <p class="text-[14px] md:text-[16px] leading-[22px] md:leading-[26px] text-white/70 max-w-[600px]">
-          {gettingStarted.description}
-        </p>
-        <a href={gettingStarted.url} target="_blank" rel="noopener noreferrer"
-           class="inline-flex items-center gap-2 self-start bg-[#9e4bf6] hover:bg-[#8a3de0] text-white h-10 rounded-[20px] px-5 text-[14px] font-medium tracking-[0.28px] transition-colors">
-          {gettingStarted.ctaLabel}
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+    <div class="flex items-center gap-2 shrink-0">
+      {#each communityLinks as link}
+        <a href={link.url} target="_blank" rel="noopener noreferrer"
+           class="inline-flex items-center justify-center w-[34px] h-[34px] rounded-[8px] border border-[#f0f0f0] transition-all hover:shadow-md hover:scale-105 hover:border-transparent"
+           title={link.label}>
+          {#if link.label === 'Discord'}
+            <svg class="w-[18px] h-[18px]" viewBox="0 0 127.14 96.36" fill={link.color}><path d="M107.7 8.07A105.15 105.15 0 0081.47 0a72.06 72.06 0 00-3.36 6.83 97.68 97.68 0 00-29.11 0A72.37 72.37 0 0045.64 0a105.89 105.89 0 00-26.25 8.09C2.79 32.65-1.71 56.6.54 80.21a105.73 105.73 0 0032.17 16.15 77.7 77.7 0 006.89-11.11 68.42 68.42 0 01-10.85-5.18c.91-.66 1.8-1.34 2.66-2a75.57 75.57 0 0064.32 0c.87.71 1.76 1.39 2.66 2a68.68 68.68 0 01-10.87 5.19 77 77 0 006.89 11.1 105.25 105.25 0 0032.19-16.14c2.64-27.38-4.51-51.11-18.9-72.15zM42.45 65.69C36.18 65.69 31 60 31 53.05s5-12.68 11.43-12.68S54 46.06 53.89 53.05 48.84 65.69 42.45 65.69zm42.24 0C78.41 65.69 73.25 60 73.25 53.05s5-12.68 11.44-12.68S96.23 46.06 96.12 53.05 91.08 65.69 84.69 65.69z"/></svg>
+          {:else if link.label === 'Telegram'}
+            <svg class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill={link.color}><path d="M11.944 0A12 12 0 000 12a12 12 0 0012 12 12 12 0 0012-12A12 12 0 0012 0a12 12 0 00-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 01.171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.479.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg>
+          {:else if link.label === 'X'}
+            <svg class="w-[15px] h-[15px]" viewBox="0 0 24 24" fill={link.color}><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+          {:else if link.label === 'YouTube'}
+            <svg class="w-[18px] h-[18px]" viewBox="0 0 24 24" fill={link.color}><path d="M23.498 6.186a3.016 3.016 0 00-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 00.502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 002.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 002.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg>
+          {/if}
         </a>
-      </div>
-    </div>
-  </section>
-
-  <!-- C. Documentation & Core Concepts -->
-  <section id="documentation" class="flex flex-col gap-4 scroll-mt-4">
-    <h2 class="text-[24px] md:text-[32px] font-display font-medium leading-[28px] md:leading-[40px] tracking-[-0.48px] md:tracking-[-0.64px] text-black">
-      Documentation
-    </h2>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-      {#each documentation as doc}
-        <div class="bg-white border border-[#f0f0f0] rounded-lg p-5 flex flex-col gap-3" style="box-shadow: 0px 4px 12px 0px rgba(0,0,0,0.05);">
-          <span class="inline-flex items-center self-start px-2.5 py-1 rounded-full text-[11px] font-semibold uppercase tracking-[0.5px] bg-[#e8f0fe] text-[#387de8]">
-            {doc.tag}
-          </span>
-          <h3 class="text-[18px] md:text-[20px] font-medium leading-[22px] md:leading-[24px] tracking-[-0.4px] text-black">
-            {doc.title}
-          </h3>
-          <p class="text-[13px] md:text-[14px] leading-[20px] md:leading-[22px] text-[#6b6b6b] tracking-[0.28px]">
-            {doc.description}
-          </p>
-          <a href={doc.url} target="_blank" rel="noopener noreferrer"
-             class="inline-flex items-center gap-1 text-[#4083ea] text-[13px] font-medium tracking-[0.26px] hover:underline mt-auto">
-            {doc.ctaLabel}
-            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
-          </a>
-        </div>
       {/each}
     </div>
-  </section>
+  </div>
 
-  <!-- D. AI-Assisted Development -->
-  <section id="ai-development" class="flex flex-col gap-4 scroll-mt-4">
-    <h2 class="text-[24px] md:text-[32px] font-display font-medium leading-[28px] md:leading-[40px] tracking-[-0.48px] md:tracking-[-0.64px] text-black">
-      AI-Assisted Development
-    </h2>
-    <div class="rounded-lg p-4 md:p-6" style="background: linear-gradient(135deg, #f8f5ff, #f0ebff);">
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-        {#each aiDevelopment as tool, toolIdx}
-          <div class="bg-white border border-[#e8e0f5] rounded-lg p-5 flex flex-col gap-3" style="box-shadow: 0px 4px 12px 0px rgba(0,0,0,0.05);">
-            <span class="inline-flex items-center self-start px-2.5 py-1 rounded-full text-[11px] font-semibold uppercase tracking-[0.5px] bg-[#f3edff] text-[#7f52e1]">
-              {tool.tag}
-            </span>
-            <h3 class="text-[18px] md:text-[20px] font-medium leading-[22px] md:leading-[24px] tracking-[-0.4px] text-black">
-              {tool.title}
-            </h3>
-            <p class="text-[13px] md:text-[14px] leading-[20px] md:leading-[22px] text-[#6b6b6b] tracking-[0.28px]">
-              {tool.description}
-            </p>
+  <!-- ═══ SDKs row ═══ -->
+  <div class="flex items-center gap-3 flex-wrap">
+    <span class="text-[13px] font-medium text-[#6b6b6b] tracking-[0.26px]">SDKs</span>
+    {#each sdks as sdk}
+      <a href={sdk.url} target="_blank" rel="noopener noreferrer"
+         class="w-[44px] h-[44px] rounded-[10px] border border-[#f0f0f0] flex items-center justify-center group hover:border-[#ee8521]/40 hover:shadow-sm transition-all {sdk.icon === 'js' ? 'bg-[#F7DF1E]/5' : sdk.icon === 'python' ? 'bg-[#3776AB]/5' : 'bg-[#6b6b6b]/5'}"
+         title={sdk.label}>
+        {#if sdk.icon === 'js'}
+          <svg class="w-5 h-5" viewBox="0 0 24 24" fill="#F7DF1E"><path d="M0 0h24v24H0V0zm22.034 18.276c-.175-1.095-.888-2.015-3.003-2.873-.736-.345-1.554-.585-1.797-1.14-.091-.33-.105-.51-.046-.705.15-.646.915-.84 1.515-.66.39.12.75.42.976.9 1.034-.676 1.034-.676 1.755-1.125-.27-.42-.405-.6-.586-.78-.63-.705-1.469-1.065-2.834-1.034l-.705.089c-.676.165-1.32.525-1.71 1.005-1.14 1.291-.811 3.541.569 4.471 1.365 1.02 3.361 1.244 3.616 2.205.24 1.17-.87 1.545-1.966 1.41-.811-.18-1.26-.586-1.755-1.336l-1.83 1.051c.21.48.45.689.81 1.109 1.74 1.756 6.09 1.666 6.871-1.004.029-.09.24-.705.074-1.65l.046.067zm-8.983-7.245h-2.248c0 1.938-.009 3.864-.009 5.805 0 1.232.063 2.363-.138 2.711-.33.689-1.18.601-1.566.48-.396-.196-.597-.466-.83-.855-.063-.105-.11-.196-.127-.196l-1.825 1.125c.305.63.75 1.172 1.324 1.517.855.51 2.004.675 3.207.405.783-.226 1.458-.691 1.811-1.411.51-.93.402-2.07.397-3.346.012-2.054 0-4.109 0-6.179l.004-.056z"/></svg>
+        {:else if sdk.icon === 'python'}
+          <svg class="w-5 h-5" viewBox="0 0 24 24" fill="#3776AB"><path d="M14.25.18l.9.2.73.26.59.3.45.32.34.34.25.34.16.33.1.3.04.26.02.2-.01.13V8.5l-.05.63-.13.55-.21.46-.26.38-.3.31-.33.25-.35.19-.35.14-.33.1-.3.07-.26.04-.21.02H8.77l-.69.05-.59.14-.5.22-.41.27-.33.32-.27.35-.2.36-.15.37-.1.35-.07.32-.04.27-.02.21v3.06H3.17l-.21-.03-.28-.07-.32-.12-.35-.18-.36-.26-.36-.36-.35-.46-.32-.59-.28-.73-.21-.88-.14-1.05-.05-1.23.06-1.22.16-1.04.24-.87.32-.71.36-.57.4-.44.42-.33.42-.24.4-.16.36-.1.32-.05.24-.01h.16l.06.01h8.16v-.83H6.18l-.01-2.75-.02-.37.05-.34.11-.31.17-.28.25-.26.31-.23.38-.2.44-.18.51-.15.58-.12.64-.1.71-.06.77-.04.84-.02 1.27.05zm-6.3 1.98l-.23.33-.08.41.08.41.23.34.33.22.41.09.41-.09.33-.22.23-.34.08-.41-.08-.41-.23-.33-.33-.22-.41-.09-.41.09zm13.09 3.95l.28.06.32.12.35.18.36.27.36.35.35.47.32.59.28.73.21.88.14 1.04.05 1.23-.06 1.23-.16 1.04-.24.86-.32.71-.36.57-.4.45-.42.33-.42.24-.4.16-.36.09-.32.05-.24.02-.16-.01h-8.22v.82h5.84l.01 2.76.02.36-.05.34-.11.31-.17.29-.25.25-.31.24-.38.2-.44.17-.51.15-.58.13-.64.09-.71.07-.77.04-.84.01-1.27-.04-1.07-.14-.9-.2-.73-.25-.59-.3-.45-.33-.34-.34-.25-.34-.16-.33-.1-.3-.04-.25-.02-.2.01-.13v-5.34l.05-.64.13-.54.21-.46.26-.38.3-.32.33-.24.35-.2.35-.14.33-.1.3-.06.26-.04.21-.02.13-.01h5.84l.69-.05.59-.14.5-.21.41-.28.33-.32.27-.35.2-.36.15-.36.1-.35.07-.32.04-.28.02-.21V6.07h2.09l.14.01zm-6.47 14.25l-.23.33-.08.41.08.41.23.33.33.23.41.08.41-.08.33-.23.23-.33.08-.41-.08-.41-.23-.33-.33-.23-.41-.08-.41.08z"/></svg>
+        {:else}
+          <svg class="w-5 h-5 text-[#6b6b6b]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z" /></svg>
+        {/if}
+      </a>
+    {/each}
+  </div>
 
-            <!-- Install command blocks -->
-            {#each tool.installSteps as step, stepIdx}
-              <div class="flex flex-col gap-1.5">
-                <span class="text-[11px] text-[#ababab] uppercase tracking-[0.5px] font-medium">{step.label}</span>
-                <div class="flex items-center gap-2 rounded-md px-3 py-2.5 font-mono text-[12px] md:text-[13px] text-[#e3e3e3] overflow-x-auto"
-                     style="background: #1a1a2e;">
-                  <code class="flex-1 whitespace-nowrap">{step.command}</code>
-                  <button
-                    onclick={() => copyToClipboard(step.command, `ai-${toolIdx}-${stepIdx}`)}
-                    class="shrink-0 p-1 rounded hover:bg-white/10 transition-colors cursor-pointer"
-                    title="Copy to clipboard"
-                  >
-                    {#if copiedStates[`ai-${toolIdx}-${stepIdx}`]}
-                      <svg class="w-4 h-4 text-[#3eb359]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
-                    {:else}
-                      <svg class="w-4 h-4 text-[#ababab]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
-                    {/if}
-                  </button>
-                </div>
-              </div>
-            {/each}
+  <!-- ═══ TWO-COLUMN: Documentation + Tools ═══ -->
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
 
-            <a href={tool.url} target="_blank" rel="noopener noreferrer"
-               class="inline-flex items-center gap-1 text-[#7f52e1] text-[13px] font-medium tracking-[0.26px] hover:underline mt-auto">
-              {tool.ctaLabel}
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
-            </a>
-          </div>
-        {/each}
+    <!-- Documentation -->
+    <div class="flex flex-col gap-3">
+      <div class="flex items-center gap-[10px]">
+        <div class="relative flex-shrink-0" style="width: 28px; height: 28px;">
+          <img src="/assets/icons/hexagon-builder-light.svg" alt="" class="w-full h-full" />
+          <img src="/assets/icons/terminal-line-orange.svg" alt="" class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" style="width: 14px; height: 14px;" />
+        </div>
+        <h2 class="text-[17px] font-semibold text-black" style="letter-spacing: 0.34px;">Documentation</h2>
       </div>
-    </div>
-  </section>
-
-  <!-- E. Bradbury Developer Links -->
-  <section id="bradbury-links" class="flex flex-col gap-4 scroll-mt-4">
-    <h2 class="text-[24px] md:text-[32px] font-display font-medium leading-[28px] md:leading-[40px] tracking-[-0.48px] md:tracking-[-0.64px] text-black">
-      Bradbury Developer Links
-    </h2>
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
-
-      <!-- Network -->
-      <div class="bg-white border border-[#f0f0f0] rounded-lg p-5 flex flex-col gap-3" style="box-shadow: 0px 4px 12px 0px rgba(0,0,0,0.05);">
-        <h3 class="text-[16px] font-semibold leading-[20px] tracking-[0.32px] text-black">{bradburyLinks.network.title}</h3>
-        <div class="flex flex-col gap-2.5">
-          {#each bradburyLinks.network.items as item, idx}
-            <div class="flex flex-col gap-1">
-              <span class="text-[11px] text-[#ababab] uppercase tracking-[0.5px] font-medium">{item.label}</span>
-              {#if item.copyable}
-                <div class="flex items-center gap-2 rounded-md px-3 py-2 font-mono text-[11px] md:text-[12px] text-[#e3e3e3] overflow-x-auto"
-                     style="background: #1a1a2e;">
-                  <code class="flex-1 whitespace-nowrap">{item.value}</code>
-                  <button
-                    onclick={() => copyToClipboard(item.value, `net-${idx}`)}
-                    class="shrink-0 p-1 rounded hover:bg-white/10 transition-colors cursor-pointer"
-                    title="Copy"
-                  >
-                    {#if copiedStates[`net-${idx}`]}
-                      <svg class="w-3.5 h-3.5 text-[#3eb359]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
-                    {:else}
-                      <svg class="w-3.5 h-3.5 text-[#ababab]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
-                    {/if}
-                  </button>
-                </div>
+      <section class="bg-white border border-[#f0f0f0] rounded-[14px] p-[16px] flex flex-col flex-1">
+        {#each documentation as doc}
+          <a href={doc.url} target="_blank" rel="noopener noreferrer"
+             class="flex items-center gap-3 py-3 border-b border-[#f5f5f5] last:border-b-0 group hover:bg-[#fafafa] rounded-[4px] px-2 -mx-2 transition-colors">
+            <div class="w-[28px] h-[28px] rounded-[8px] flex items-center justify-center shrink-0 bg-[#ee8521]/10">
+              {#if doc.icon === 'docs'}
+                <svg class="w-[14px] h-[14px] text-[#ee8521]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" /></svg>
+              {:else if doc.icon === 'eq'}
+                <svg class="w-[14px] h-[14px] text-[#ee8521]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" /></svg>
               {:else}
-                <span class="text-[13px] font-mono text-[#6b6b6b]">{item.value}</span>
+                <svg class="w-[14px] h-[14px] text-[#ee8521]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5" /></svg>
               {/if}
             </div>
-          {/each}
-        </div>
-      </div>
-
-      <!-- Explorers & Tools -->
-      <div class="bg-white border border-[#f0f0f0] rounded-lg p-5 flex flex-col gap-3" style="box-shadow: 0px 4px 12px 0px rgba(0,0,0,0.05);">
-        <h3 class="text-[16px] font-semibold leading-[20px] tracking-[0.32px] text-black">{bradburyLinks.explorers.title}</h3>
-        <div class="flex flex-col gap-1">
-          {#each bradburyLinks.explorers.items as item}
-            <a href={item.url} target="_blank" rel="noopener noreferrer"
-               class="flex items-center justify-between py-2.5 px-1 border-b border-[#f5f5f5] last:border-b-0 group hover:bg-[#fafafa] rounded transition-colors">
-              <span class="text-[13px] md:text-[14px] text-black group-hover:text-[#4083ea] transition-colors">{item.label}</span>
-              <svg class="w-4 h-4 text-[#ababab] group-hover:text-[#4083ea] transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
-            </a>
-          {/each}
-        </div>
-      </div>
-
-      <!-- SDKs & CLI -->
-      <div class="bg-white border border-[#f0f0f0] rounded-lg p-5 flex flex-col gap-3" style="box-shadow: 0px 4px 12px 0px rgba(0,0,0,0.05);">
-        <h3 class="text-[16px] font-semibold leading-[20px] tracking-[0.32px] text-black">{bradburyLinks.sdks.title}</h3>
-        <div class="flex flex-col gap-3">
-          {#each bradburyLinks.sdks.items as sdk, idx}
-            <div class="flex flex-col gap-1.5">
-              <div class="flex items-center gap-2">
-                <a href={sdk.url} target="_blank" rel="noopener noreferrer" class="text-[13px] md:text-[14px] font-medium text-black hover:text-[#4083ea] transition-colors">
-                  {sdk.label}
-                </a>
-                <span class="px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#f0f0f0] text-[#6b6b6b]">{sdk.version}</span>
-              </div>
-              <div class="flex items-center gap-2 rounded-md px-3 py-2 font-mono text-[11px] md:text-[12px] text-[#e3e3e3] overflow-x-auto"
-                   style="background: #1a1a2e;">
-                <code class="flex-1 whitespace-nowrap">{sdk.installCommand}</code>
-                <button
-                  onclick={() => copyToClipboard(sdk.installCommand, `sdk-${idx}`)}
-                  class="shrink-0 p-1 rounded hover:bg-white/10 transition-colors cursor-pointer"
-                  title="Copy"
-                >
-                  {#if copiedStates[`sdk-${idx}`]}
-                    <svg class="w-3.5 h-3.5 text-[#3eb359]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
-                  {:else}
-                    <svg class="w-3.5 h-3.5 text-[#ababab]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
-                  {/if}
-                </button>
-              </div>
+            <div class="flex flex-col gap-0.5 flex-1 min-w-0">
+              <span class="text-[13px] font-medium text-black group-hover:text-[#ee8521] transition-colors">{doc.label}</span>
+              <span class="text-[11px] text-[#ababab]">{doc.description}</span>
             </div>
-          {/each}
+            <svg class="w-3.5 h-3.5 text-[#ababab] group-hover:text-[#ee8521] transition-colors shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+          </a>
+        {/each}
+      </section>
+    </div>
+
+    <!-- Tools -->
+    <div class="flex flex-col gap-3">
+      <div class="flex items-center gap-[10px]">
+        <div class="relative flex-shrink-0" style="width: 28px; height: 28px;">
+          <img src="/assets/icons/hexagon-light.svg" alt="" class="w-full h-full" />
+          <div
+            class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+            style="width: 14px; height: 14px; background-color: #7F52E1; -webkit-mask-image: url(/assets/icons/dashboard-fill-black.svg); mask-image: url(/assets/icons/dashboard-fill-black.svg); mask-size: contain; mask-repeat: no-repeat; mask-position: center;"
+          ></div>
         </div>
+        <h2 class="text-[17px] font-semibold text-black" style="letter-spacing: 0.34px;">Tools</h2>
+      </div>
+      <section class="bg-white border border-[#f0f0f0] rounded-[14px] p-[16px] flex flex-col flex-1">
+        {#each tools as tool}
+          <a href={tool.url} target="_blank" rel="noopener noreferrer"
+             class="flex items-center gap-3 py-3 border-b border-[#f5f5f5] last:border-b-0 group hover:bg-[#fafafa] rounded-[4px] px-2 -mx-2 transition-colors">
+            <div class="w-[28px] h-[28px] rounded-[8px] flex items-center justify-center shrink-0 bg-[#7f52e1]/10">
+              {#if tool.label === 'GenLayer Studio'}
+                <svg class="w-[14px] h-[14px] text-[#7f52e1]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z" /></svg>
+              {:else if tool.label === 'Testnet Faucet'}
+                <svg class="w-[14px] h-[14px] text-[#7f52e1]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+              {:else}
+                <svg class="w-[14px] h-[14px] text-[#7f52e1]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" /></svg>
+              {/if}
+            </div>
+            <div class="flex flex-col gap-0.5 flex-1 min-w-0">
+              <span class="text-[13px] font-medium text-black group-hover:text-[#7f52e1] transition-colors">{tool.label}</span>
+              <span class="text-[11px] text-[#ababab]">{tool.description}</span>
+            </div>
+            <svg class="w-3.5 h-3.5 text-[#ababab] group-hover:text-[#7f52e1] transition-colors shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+          </a>
+        {/each}
+      </section>
+    </div>
+  </div>
+
+  <!-- ═══ Boilerplates ═══ -->
+  <div class="flex flex-col gap-3">
+    <div class="flex items-center gap-[10px]">
+      <div class="relative flex-shrink-0" style="width: 28px; height: 28px;">
+        <img src="/assets/icons/hexagon-builder-light.svg" alt="" class="w-full h-full" />
+        <svg class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[14px] h-[14px]" viewBox="0 0 24 24" fill="#ee8521"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+      </div>
+      <h2 class="text-[17px] font-semibold text-black" style="letter-spacing: 0.34px;">Templates & Boilerplates</h2>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+      {#each boilerplates as bp}
+        <a href={bp.url} target="_blank" rel="noopener noreferrer"
+           class="bg-white border border-[#f0f0f0] rounded-[14px] p-4 flex flex-col gap-2 group hover:border-[#ee8521]/30 hover:shadow-sm transition-all">
+          <div class="flex items-center justify-between">
+            <span class="text-[13px] font-medium text-black group-hover:text-[#ee8521] transition-colors">{bp.label}</span>
+            <svg class="w-3.5 h-3.5 text-[#ababab] group-hover:text-[#ee8521] transition-colors shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+          </div>
+          <span class="text-[11px] text-[#ababab] leading-[17px]">{bp.description}</span>
+        </a>
+      {/each}
+    </div>
+  </div>
+
+  <!-- ═══ AI-Assisted Development ═══ -->
+  <div class="flex flex-col gap-3">
+    <div class="flex items-center gap-[10px]">
+      <div class="relative flex-shrink-0" style="width: 28px; height: 28px;">
+        <img src="/assets/icons/hexagon-builder-light.svg" alt="" class="w-full h-full" />
+        <svg class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[14px] h-[14px]" fill="none" stroke="#ee8521" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z" /></svg>
+      </div>
+      <h2 class="text-[17px] font-semibold text-black" style="letter-spacing: 0.34px;">AI-Assisted Development</h2>
+    </div>
+
+    <div class="bg-[#fafafa] border border-[#f0f0f0] rounded-[14px] p-[20px] flex flex-col gap-4">
+      <!-- Copy for LLMs -->
+      <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+        <div class="flex-1 min-w-0">
+          <p class="text-[13px] font-medium text-black">GenLayer Context Prompt</p>
+          <p class="text-[11px] text-[#ababab] mt-0.5">Copy a comprehensive GenLayer context prompt to use with any LLM — covers Intelligent Contracts, the Equivalence Principle, SDKs, testnets, and all key references.</p>
+        </div>
+        <button
+          onclick={() => copyToClipboard(aiResources.metaprompt, 'metaprompt')}
+          class="inline-flex items-center gap-1.5 px-4 py-2 rounded-[10px] text-[13px] font-medium transition-all cursor-pointer shrink-0 {copiedStates['metaprompt'] ? 'bg-[#e8fbe8] text-[#2d9a46]' : 'bg-[#101010] text-white hover:bg-[#2a2a2a]'}"
+        >
+          {#if copiedStates['metaprompt']}
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+            Copied!
+          {:else}
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>
+            Copy for LLMs
+          {/if}
+        </button>
       </div>
 
-    </div>
-  </section>
-
-  <!-- F. Ecosystem Projects -->
-  <section id="ecosystem" class="flex flex-col gap-4 scroll-mt-4">
-    <h2 class="text-[24px] md:text-[32px] font-display font-medium leading-[28px] md:leading-[40px] tracking-[-0.48px] md:tracking-[-0.64px] text-black">
-      Ecosystem Projects
-    </h2>
-    <div class="relative">
-      <!-- Edge fade masks -->
-      <div class="absolute left-0 top-0 bottom-0 w-6 z-10 pointer-events-none" style="background: linear-gradient(to right, white, transparent);"></div>
-      <div class="absolute right-0 top-0 bottom-0 w-6 z-10 pointer-events-none" style="background: linear-gradient(to left, white, transparent);"></div>
-
-      <div class="flex gap-3 overflow-x-auto pb-2 scroll-smooth" style="-ms-overflow-style: none; scrollbar-width: none;">
-        {#each ecosystemProjects as project}
-          <div class="w-[280px] shrink-0 bg-white border border-[#f0f0f0] rounded-lg p-5 flex flex-col gap-3" style="box-shadow: 0px 4px 12px 0px rgba(0,0,0,0.05);">
-            <span class="inline-flex items-center self-start px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-[0.5px] bg-[#f5f0ff] text-[#7f52e1]">
-              {project.track}
-            </span>
-            <h3 class="text-[16px] md:text-[18px] font-medium leading-[20px] md:leading-[22px] tracking-[-0.3px] text-black">
-              {project.title}
-            </h3>
-            <p class="text-[13px] leading-[20px] text-[#6b6b6b] tracking-[0.26px] flex-1">
-              {project.description}
-            </p>
-            <a href={project.url} target="_blank" rel="noopener noreferrer"
-               class="inline-flex items-center gap-1 text-[#4083ea] text-[13px] font-medium tracking-[0.26px] hover:underline mt-auto">
-              Visit project
-              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
-            </a>
-          </div>
+      <!-- AI resource links -->
+      <div class="flex flex-col sm:flex-row gap-3">
+        {#each aiResources.links as link}
+          <a href={link.url} target="_blank" rel="noopener noreferrer"
+             class="flex-1 bg-white border border-[#e8e8e8] rounded-[10px] p-3 flex items-center gap-3 group hover:border-[#101010]/20 hover:shadow-sm transition-all">
+            <div class="w-[28px] h-[28px] rounded-[8px] flex items-center justify-center shrink-0 bg-[#101010]/5">
+              {#if link.label.includes('API')}
+                <svg class="w-[14px] h-[14px] text-[#101010]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" /></svg>
+              {:else}
+                <svg class="w-[14px] h-[14px] text-[#101010]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" /></svg>
+              {/if}
+            </div>
+            <div class="flex flex-col gap-0.5 flex-1 min-w-0">
+              <span class="text-[12px] font-medium text-black group-hover:text-[#101010] transition-colors">{link.label}</span>
+              <span class="text-[10px] text-[#ababab]">{link.description}</span>
+            </div>
+            <svg class="w-3 h-3 text-[#ababab] group-hover:text-[#101010] transition-colors shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+          </a>
         {/each}
       </div>
     </div>
-  </section>
+  </div>
 
-  <!-- G. Hackathon Banner -->
-  <section id="hackathon" class="scroll-mt-4">
-    <div class="relative rounded-lg overflow-hidden">
-      <img src={prizeBackground} alt="" class="w-full h-auto min-h-[200px] object-cover" />
-      <div class="absolute inset-0 flex flex-col items-center justify-center gap-4 p-6 md:p-8">
-        <h2 class="text-white font-display font-medium text-[24px] md:text-[40px] leading-[28px] md:leading-[44px] tracking-[-0.48px] md:tracking-[-0.8px] text-center">
-          {hackathon.title}
-        </h2>
-        <p class="text-white/70 text-[14px] md:text-[16px] leading-[22px] md:leading-[26px] text-center max-w-[400px]">
-          {hackathon.subtitle}
-        </p>
-        <div class="flex flex-wrap justify-center gap-2">
-          {#each hackathon.highlights as hl}
-            <span class="inline-flex items-center px-3 py-1.5 rounded-full text-[11px] md:text-[12px] font-medium text-white/90"
-                  style="background: rgba(255,255,255,0.12); border: 1px solid rgba(255,255,255,0.18);">
-              {hl}
-            </span>
-          {/each}
-        </div>
-        <button
-          onclick={() => push('/hackathon')}
-          class="inline-flex items-center gap-2 bg-[#9e4bf6] hover:bg-[#8a3de0] text-white h-10 rounded-[20px] px-5 text-[14px] font-medium tracking-[0.28px] transition-colors cursor-pointer"
-        >
-          {hackathon.ctaLabel}
-          <img src={arrowRight} alt="" class="w-4 h-4 brightness-0 invert" />
-        </button>
+  <!-- ═══ Tracks & Ideas ═══ -->
+  <div class="flex flex-col gap-3">
+    <div class="flex items-center gap-[10px]">
+      <div class="relative flex-shrink-0 w-[28px] h-[28px]">
+        <svg viewBox="0 0 32 32" class="w-full h-full"><polygon points="16,0 29.86,8 29.86,24 16,32 2.14,24 2.14,8" fill="#101010"/></svg>
+        <img src="/assets/icons/gl-symbol-white.svg" alt="" class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" style="width: 14px; height: 14px;" />
       </div>
-    </div>
-  </section>
-
-  <!-- H. How the Portal Works -->
-  <section id="how-it-works" class="flex flex-col gap-5 scroll-mt-4">
-    <h2 class="text-[24px] md:text-[32px] font-display font-medium leading-[28px] md:leading-[40px] tracking-[-0.48px] md:tracking-[-0.64px] text-black">
-      How the Portal Works
-    </h2>
-
-    <!-- Desktop: horizontal timeline -->
-    <div class="hidden md:flex items-start gap-3">
-      {#each portalInfo as step, idx}
-        <div class="flex-1 flex flex-col items-center gap-3 text-center">
-          <div class="w-12 h-12 rounded-full flex items-center justify-center text-white font-display font-bold text-[20px] bg-gradient-to-br {step.color}">
-            {step.step}
-          </div>
-          <h3 class="text-[16px] font-semibold leading-[20px] text-black">{step.title}</h3>
-          <p class="text-[13px] leading-[20px] text-[#6b6b6b] tracking-[0.26px]">{step.description}</p>
-        </div>
-        {#if idx < portalInfo.length - 1}
-          <div class="flex items-center pt-5 shrink-0">
-            <svg class="w-6 h-6 text-[#e3e3e3]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
-          </div>
-        {/if}
-      {/each}
+      <h2 class="text-[17px] font-semibold text-black" style="letter-spacing: 0.34px;">Tracks & Ideas</h2>
     </div>
 
-    <!-- Mobile: vertical timeline -->
-    <div class="flex md:hidden flex-col gap-4">
-      {#each portalInfo as step}
-        <div class="flex items-start gap-4">
-          <div class="w-10 h-10 rounded-full flex items-center justify-center text-white font-display font-bold text-[16px] bg-gradient-to-br {step.color} shrink-0">
-            {step.step}
-          </div>
-          <div class="flex flex-col gap-1 pt-1">
-            <h3 class="text-[15px] font-semibold leading-[18px] text-black">{step.title}</h3>
-            <p class="text-[13px] leading-[20px] text-[#6b6b6b] tracking-[0.26px]">{step.description}</p>
-          </div>
-        </div>
-      {/each}
-    </div>
-
-    <button
-      onclick={() => push('/how-it-works')}
-      class="inline-flex items-center gap-1 self-start text-[#4083ea] text-[14px] font-medium tracking-[0.28px] hover:underline cursor-pointer bg-transparent border-none p-0"
-    >
-      Learn more about the portal
-      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
-    </button>
-  </section>
-
-  <!-- I. Tracks & Ideas -->
-  <section id="tracks" class="flex flex-col gap-4 scroll-mt-4">
-    <h2 class="text-[24px] md:text-[32px] font-display font-medium leading-[28px] md:leading-[40px] tracking-[-0.48px] md:tracking-[-0.64px] text-black">
-      Tracks & Ideas
-    </h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
       {#each tracksAndIdeas as track}
-        <div class="bg-white border border-[#f0f0f0] rounded-lg p-5 flex flex-col gap-2 relative overflow-hidden" style="box-shadow: 0px 4px 12px 0px rgba(0,0,0,0.05);">
-          <!-- Left gradient border accent -->
-          <div class="absolute left-0 top-0 bottom-0 w-[3px] bg-gradient-to-b {track.gradient}"></div>
-          <h3 class="text-[16px] md:text-[18px] font-medium leading-[20px] md:leading-[22px] tracking-[-0.3px] text-black pl-2">
-            {track.title}
-          </h3>
-          <p class="text-[13px] leading-[20px] text-[#6b6b6b] tracking-[0.26px] pl-2">
-            {track.description}
-          </p>
+        <div class="bg-white border border-[#f0f0f0] rounded-[14px] p-4 flex flex-col gap-2">
+          <div class="flex items-center gap-2">
+            <div class="w-2 h-2 rounded-full shrink-0" style="background-color: {track.color};"></div>
+            <span class="text-[13px] font-medium text-black">{track.title}</span>
+          </div>
+          <span class="text-[11px] text-[#ababab] leading-[17px]">{track.description}</span>
         </div>
       {/each}
     </div>
-  </section>
+  </div>
 
 </div>
-
-<style>
-  /* Hide scrollbar for ecosystem horizontal scroll */
-  div::-webkit-scrollbar {
-    display: none;
-  }
-</style>


### PR DESCRIPTION
## Summary
- Redesigned `/builders/resources` as a builder-focused page with 5 clear sections: SDKs, Documentation, Tools, Boilerplates, AI-Assisted Development, and Tracks & Ideas
- Added new resource URLs: Equivalence Principle docs, Python SDK API reference, testnet faucet, bridge boilerplate, prediction market kit
- Added AI section with comprehensive LLM metaprompt covering Intelligent Contracts, Equivalence Principle, SDKs, testnets, and all key references
- Added "Resources" sub-item under Builders in sidebar navigation (desktop + mobile)
- Removed validator/community sections from the page (builder-only scope)

## Test plan
- [ ] Navigate to `/builders/resources` and verify all 5 sections render correctly
- [ ] Click each external link and verify it opens the correct URL
- [ ] Test "Copy for LLMs" button — should copy metaprompt and show "Copied!" feedback
- [ ] Verify SDK icon squares link to correct package pages
- [ ] Check sidebar shows "Resources" under Builders section (desktop and mobile)
- [ ] Verify responsive layout on mobile breakpoints