### PR TITLE
Fix AI review endpoints returning 404

### DIFF
--- a/backend/contributions/ai_review/urls.py
+++ b/backend/contributions/ai_review/urls.py
@@ -1,8 +1,8 @@
-from rest_framework.routers import DefaultRouter
+from rest_framework.routers import SimpleRouter
 
 from .views import AIReviewViewSet
 
-router = DefaultRouter()
+router = SimpleRouter()
 router.register(r'', AIReviewViewSet, basename='ai-review')
 
 urlpatterns = router.urls


### PR DESCRIPTION
## Summary
- Switch from `DefaultRouter` to `SimpleRouter` in `contributions/ai_review/urls.py`
- `DefaultRouter` with empty prefix registration generates an API root view that conflicts with the list endpoint when nested via `include()`, causing all ai-review endpoints to return 404
- `SimpleRouter` doesn't add the root view, resolving the conflict

## Test plan
- [ ] Deploy to dev and verify `GET /api/v1/ai-review/` returns submission list (not 404)
- [ ] Verify `GET /api/v1/ai-review/templates/` returns templates
- [ ] Verify `GET /api/v1/ai-review/{uuid}/` returns submission detail