### PR TITLE
Fix: add merge migration for contributions app

### DIFF
--- a/backend/contributions/migrations/0041_merge_submissions_and_featured.py
+++ b/backend/contributions/migrations/0041_merge_submissions_and_featured.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contributions', '0033_submissionnote_data_field'),
+        ('contributions', '0040_convert_featured_images_to_cloudinary'),
+    ]
+
+    operations = []


### PR DESCRIPTION
## Summary
- Adds merge migration (`0041`) to resolve conflicting leaf nodes in the contributions migration graph
- The submissions branch (PR #476) introduced `0033_submissionnote_data_field` while dev continued to `0040_convert_featured_images_to_cloudinary`, both branching from `0032`
- This caused `manage.py migrate` to fail on App Runner startup, rolling back every deploy since the submissions merge

## Test plan
- [ ] Verify App Runner deploy succeeds (no more `ROLLBACK_SUCCEEDED`)
- [ ] Verify `ai-review/` endpoints are accessible on dev