### PR TITLE
Allow studio URLs and require all-URL duplicate for rejection

### DIFF
--- a/backend/contributions/management/commands/review_submissions.py
+++ b/backend/contributions/management/commands/review_submissions.py
@@ -100,7 +100,11 @@ def rule_duplicate_evidence_url(submission, evidence_items,
                                 url_to_sub_ids, accepted_urls,
                                 skip_pending=False,
                                 submitted_created_at=None):
-    """Any evidence URL already exists in a pending/accepted submission.
+    """Reject only when ALL evidence URLs are duplicates.
+
+    A submission with multiple evidence URLs is only rejected if every single
+    URL already exists elsewhere. If at least one URL is unique, the submission
+    passes this rule.
 
     URLs are normalized (query params, fragments, trailing slashes stripped)
     before comparison to prevent cosmetic variants from bypassing the check.
@@ -109,43 +113,68 @@ def rule_duplicate_evidence_url(submission, evidence_items,
         skip_pending: If True, only reject when an older submitted duplicate
             already exists. This keeps `--submission-id` runs deterministic.
     """
-    for e in evidence_items:
-        if not e.url:
-            continue
-        normalized = _normalize_url(e.url)
-        # Check converted/accepted contributions (always deterministic)
-        if normalized in accepted_urls:
-            return (
-                'Reject: Duplicate Submission',
-                f'Tier 1 auto-reject: Evidence URL already exists in an '
-                f'accepted contribution: {e.url[:100]}',
-            )
-        # Check pending/accepted submitted contributions (exclude self)
-        others = (url_to_sub_ids.get(normalized) or set()) - {submission.id}
-        if not others:
-            continue
+    urls_with_evidence = [(e, _normalize_url(e.url))
+                          for e in evidence_items if e.url]
+    if not urls_with_evidence:
+        return None
 
-        if not skip_pending:
-            return (
-                'Reject: Duplicate Submission',
-                f'Tier 1 auto-reject: Evidence URL already exists in another '
-                f'submission: {e.url[:100]}',
-            )
+    # Check each URL; collect reasons but only reject if ALL are duplicates.
+    duplicate_reasons = []
+    for evidence, normalized in urls_with_evidence:
+        reason = _check_single_url_duplicate(
+            submission, evidence, normalized,
+            url_to_sub_ids, accepted_urls,
+            skip_pending, submitted_created_at,
+        )
+        if reason is None:
+            # At least one URL is unique — submission passes.
+            return None
+        duplicate_reasons.append(reason)
 
-        submission_key = (submission.created_at, str(submission.id))
-        created_at_lookup = submitted_created_at or {}
-        if any(
-            (
-                created_at_lookup.get(other_id, submission.created_at),
-                str(other_id),
-            ) < submission_key
-            for other_id in others
-        ):
-            return (
-                'Reject: Duplicate Submission',
-                f'Tier 1 auto-reject: Evidence URL already exists in an older '
-                f'submission: {e.url[:100]}',
-            )
+    # All URLs are duplicates — use the first reason for the rejection message.
+    return duplicate_reasons[0]
+
+
+def _check_single_url_duplicate(submission, evidence, normalized,
+                                url_to_sub_ids, accepted_urls,
+                                skip_pending, submitted_created_at):
+    """Check whether a single normalized URL is a duplicate.
+
+    Returns (template_label, crm_reason) if duplicate, or None if unique.
+    """
+    # Check converted/accepted contributions (always deterministic)
+    if normalized in accepted_urls:
+        return (
+            'Reject: Duplicate Submission',
+            f'Tier 1 auto-reject: Evidence URL already exists in an '
+            f'accepted contribution: {evidence.url[:100]}',
+        )
+    # Check pending/accepted submitted contributions (exclude self)
+    others = (url_to_sub_ids.get(normalized) or set()) - {submission.id}
+    if not others:
+        return None
+
+    if not skip_pending:
+        return (
+            'Reject: Duplicate Submission',
+            f'Tier 1 auto-reject: Evidence URL already exists in another '
+            f'submission: {evidence.url[:100]}',
+        )
+
+    submission_key = (submission.created_at, str(submission.id))
+    created_at_lookup = submitted_created_at or {}
+    if any(
+        (
+            created_at_lookup.get(other_id, submission.created_at),
+            str(other_id),
+        ) < submission_key
+        for other_id in others
+    ):
+        return (
+            'Reject: Duplicate Submission',
+            f'Tier 1 auto-reject: Evidence URL already exists in an older '
+            f'submission: {evidence.url[:100]}',
+        )
     return None
 
 

--- a/backend/contributions/migrations/0043_seed_blocklisted_urls.py
+++ b/backend/contributions/migrations/0043_seed_blocklisted_urls.py
@@ -7,14 +7,6 @@ from django.db import migrations
 
 INITIAL_BLOCKLISTED_URLS = [
     {
-        'url_prefix': 'https://studio.genlayer.com/run-debug',
-        'reason': 'Studio IDE debugging page — not evidence of work',
-    },
-    {
-        'url_prefix': 'https://studio.genlayer.com/contracts',
-        'reason': 'Studio contracts editor — not evidence of work',
-    },
-    {
         'url_prefix': 'https://points.genlayer.foundation',
         'reason': 'The points platform itself — not evidence of work',
     },

--- a/backend/contributions/tests/test_review_submissions.py
+++ b/backend/contributions/tests/test_review_submissions.py
@@ -110,21 +110,10 @@ class RuleBlocklistedUrlTest(Tier1RuleTestBase):
     """Test rule_blocklisted_url."""
 
     BLOCKLIST = [
-        'https://studio.genlayer.com/run-debug',
-        'https://studio.genlayer.com/contracts',
         'https://points.genlayer.foundation',
         'https://www.genlayer.com',
         'https://genlayer.com',
     ]
-
-    def test_catches_studio_url(self):
-        sub = self._create_submission(notes='My work')
-        ev = self._add_evidence(
-            sub, url='https://studio.genlayer.com/run-debug',
-        )
-        result = rule_blocklisted_url(sub, [ev], self.BLOCKLIST)
-        self.assertIsNotNone(result)
-        self.assertEqual(result[0], 'Reject: Invalid Evidence URL')
 
     def test_catches_points_url(self):
         sub = self._create_submission(notes='My work')
@@ -133,20 +122,22 @@ class RuleBlocklistedUrlTest(Tier1RuleTestBase):
         )
         result = rule_blocklisted_url(sub, [ev], self.BLOCKLIST)
         self.assertIsNotNone(result)
-
-    def test_catches_studio_url_with_fragment(self):
-        sub = self._create_submission(notes='My work')
-        ev = self._add_evidence(
-            sub, url='https://studio.genlayer.com/run-debug#something',
-        )
-        result = rule_blocklisted_url(sub, [ev], self.BLOCKLIST)
-        self.assertIsNotNone(result)
+        self.assertEqual(result[0], 'Reject: Invalid Evidence URL')
 
     def test_catches_genlayer_com(self):
         sub = self._create_submission(notes='My work')
         ev = self._add_evidence(sub, url='https://genlayer.com')
         result = rule_blocklisted_url(sub, [ev], self.BLOCKLIST)
         self.assertIsNotNone(result)
+
+    def test_allows_studio_url(self):
+        """studio.genlayer.com is a valid evidence URL."""
+        sub = self._create_submission(notes='My work')
+        ev = self._add_evidence(
+            sub, url='https://studio.genlayer.com/run-debug',
+        )
+        result = rule_blocklisted_url(sub, [ev], self.BLOCKLIST)
+        self.assertIsNone(result)
 
     def test_passes_real_evidence(self):
         sub = self._create_submission(notes='My work')
@@ -160,7 +151,7 @@ class RuleBlocklistedUrlTest(Tier1RuleTestBase):
         """If one URL is blocklisted but another is real, don't reject."""
         sub = self._create_submission(notes='My work')
         ev1 = self._add_evidence(
-            sub, url='https://studio.genlayer.com/run-debug',
+            sub, url='https://points.genlayer.foundation/#/submit',
         )
         ev2 = self._add_evidence(
             sub, url='https://github.com/user/real-project',
@@ -278,6 +269,42 @@ class RuleDuplicateEvidenceUrlTest(Tier1RuleTestBase):
         url_lookup, accepted_urls = self._build_lookup()
         result = rule_duplicate_evidence_url(
             newer, [ev], url_lookup, accepted_urls,
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], 'Reject: Duplicate Submission')
+
+    def test_passes_if_at_least_one_url_unique(self):
+        """Submission with one duplicate and one unique URL should pass."""
+        other_sub = self._create_submission(
+            user=self.other_user, notes='Their work',
+        )
+        self._add_evidence(other_sub, url='https://example.com/shared')
+
+        my_sub = self._create_submission(notes='My work')
+        ev1 = self._add_evidence(my_sub, url='https://example.com/shared')
+        ev2 = self._add_evidence(my_sub, url='https://example.com/unique')
+
+        url_lookup, accepted_urls = self._build_lookup()
+        result = rule_duplicate_evidence_url(
+            my_sub, [ev1, ev2], url_lookup, accepted_urls,
+        )
+        self.assertIsNone(result)
+
+    def test_rejects_when_all_urls_are_duplicates(self):
+        """Submission where ALL URLs are duplicates should be rejected."""
+        other_sub = self._create_submission(
+            user=self.other_user, notes='Their work',
+        )
+        self._add_evidence(other_sub, url='https://example.com/post-a')
+        self._add_evidence(other_sub, url='https://example.com/post-b')
+
+        my_sub = self._create_submission(notes='My work')
+        ev1 = self._add_evidence(my_sub, url='https://example.com/post-a')
+        ev2 = self._add_evidence(my_sub, url='https://example.com/post-b')
+
+        url_lookup, accepted_urls = self._build_lookup()
+        result = rule_duplicate_evidence_url(
+            my_sub, [ev1, ev2], url_lookup, accepted_urls,
         )
         self.assertIsNotNone(result)
         self.assertEqual(result[0], 'Reject: Duplicate Submission')


### PR DESCRIPTION
## Summary
- Removed `studio.genlayer.com` URLs (run-debug, contracts) from the blocklisted URL seed migration — these are valid evidence URLs
- Changed the duplicate evidence rule so a submission is only rejected when **all** of its evidence URLs are duplicates; if at least one URL is unique, the submission passes
- Updated tests to reflect both changes: new test for partial-duplicate pass, all-duplicate reject, and studio URL allowance

## Test plan
- [ ] Verify submissions with `studio.genlayer.com` URLs are no longer auto-rejected by the blocklist rule
- [ ] Verify a submission with mixed URLs (one duplicate + one unique) passes the duplicate check
- [ ] Verify a submission where all URLs are duplicates is still rejected
- [ ] Run `python manage.py review_submissions --dry-run` against existing data to confirm behavior