### PR TITLE
Fix validator sync timeouts and add AI review calibration endpoint

### DIFF
--- a/.github/workflows/sync-validators.yml
+++ b/.github/workflows/sync-validators.yml
@@ -22,7 +22,11 @@ jobs:
           echo "Response: $body"
           echo "HTTP Code: $http_code"
 
-          if [ "$http_code" != "200" ] && [ "$http_code" != "202" ]; then
+          if [ "$http_code" = "200" ] || [ "$http_code" = "202" ]; then
+            echo "Sync triggered successfully"
+          elif [ "$http_code" = "409" ]; then
+            echo "Sync already in progress, skipping (not a failure)"
+          else
             echo "Sync failed with status $http_code"
             exit 1
           fi

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -70,6 +70,12 @@ backend/
   - Custom DRF serializer field for Google reCAPTCHA v2 validation
   - Validates tokens from frontend reCAPTCHA widget
   - Required for new contribution submissions only (not for edits)
+- **AI Review**: `contributions/ai_review/views.py`
+  - `/api/v1/ai-review/` - List pending submissions for the external AI review agent
+  - `/api/v1/ai-review/{id}/` - Retrieve a pending submission with evidence and user history
+  - `/api/v1/ai-review/{id}/propose/` - Submit an AI proposal for human approval
+  - `/api/v1/ai-review/reviewed/` - List reviewed submissions that had AI proposals for calibration
+  - `/api/v1/ai-review/templates/` - List review templates available to the AI review agent
 
 ### Node Upgrade (Sub-app)
 - **Models**: `contributions/node_upgrade/models.py`
@@ -90,6 +96,17 @@ backend/
   - `/api/v1/leaderboard/` - Get rankings
   - `/api/v1/leaderboard/stats/` - Global statistics
   - `/api/v1/leaderboard/user_stats/by-address/{address}/` - User-specific stats
+
+### Validators
+- **Models**: `validators/models.py`
+  - ValidatorWallet - Synced validator wallet metadata per network
+  - ValidatorWalletStatusSnapshot - Daily wallet status snapshots for uptime lookback
+  - SyncLock - Database-backed sync coordination row with owner token for cross-worker locking
+- **Views**: `validators/views.py`
+  - `/api/v1/validators/` - Validator profile CRUD for authenticated users
+  - `/api/v1/validators/me/` - GET/PATCH current validator profile
+  - `/api/v1/validators/wallets/` - Read-only validator wallet listing
+  - `/api/v1/validators/wallets/sync/` - POST cron-protected background sync trigger with DB-backed lock
 
 ### Database & Migrations
 - **Migrations**: `{app}/migrations/`
@@ -190,6 +207,13 @@ GET    /api/v1/multiplier-periods/
 # Steward Submissions (public metrics)
 GET    /api/v1/steward-submissions/stats/           (public - aggregate stats)
 GET    /api/v1/steward-submissions/daily-metrics/   (public - time-series data)
+
+# AI Review Agent
+GET    /api/v1/ai-review/
+GET    /api/v1/ai-review/{id}/
+POST   /api/v1/ai-review/{id}/propose/
+GET    /api/v1/ai-review/reviewed/
+GET    /api/v1/ai-review/templates/
 ```
 
 ## Environment Variables

--- a/backend/contributions/ai_review/serializers.py
+++ b/backend/contributions/ai_review/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from contributions.models import Evidence, SubmittedContribution
+from contributions.models import Evidence, SubmissionNote, SubmittedContribution
 from stewards.models import ReviewTemplate
 
 
@@ -109,6 +109,52 @@ class AIReviewSubmissionSerializer(serializers.ModelSerializer):
     def get_proposed_by_name(self, obj):
         if obj.proposed_by:
             return obj.proposed_by.name or str(obj.proposed_by.id)
+        return None
+
+
+class AIReviewNoteSerializer(serializers.ModelSerializer):
+    """Serializer for internal notes on reviewed submissions."""
+
+    class Meta:
+        model = SubmissionNote
+        fields = ['message', 'is_proposal', 'data', 'created_at']
+        read_only_fields = fields
+
+
+class AIReviewReviewedSubmissionSerializer(serializers.ModelSerializer):
+    """Serializer for reviewed submissions — includes review outcome and notes."""
+
+    contribution_type_name = serializers.CharField(
+        source='contribution_type.name', read_only=True,
+    )
+    contribution_type_slug = serializers.CharField(
+        source='contribution_type.slug', read_only=True,
+    )
+    category_name = serializers.SerializerMethodField()
+    evidence_items = AIReviewEvidenceSerializer(many=True, read_only=True)
+    internal_notes = AIReviewNoteSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = SubmittedContribution
+        fields = [
+            'id',
+            'contribution_type',
+            'contribution_type_name',
+            'contribution_type_slug',
+            'category_name',
+            'notes',
+            'state',
+            'staff_reply',
+            'reviewed_at',
+            'evidence_items',
+            'internal_notes',
+            'created_at',
+        ]
+        read_only_fields = fields
+
+    def get_category_name(self, obj):
+        if obj.contribution_type and obj.contribution_type.category:
+            return obj.contribution_type.category.name
         return None
 
 

--- a/backend/contributions/ai_review/views.py
+++ b/backend/contributions/ai_review/views.py
@@ -16,6 +16,7 @@ from users.models import User
 from .permissions import IsAIReviewToken
 from .serializers import (
     AIReviewProposeSerializer,
+    AIReviewReviewedSubmissionSerializer,
     AIReviewSubmissionSerializer,
     AIReviewTemplateSerializer,
     LightAIReviewSubmissionSerializer,
@@ -301,12 +302,70 @@ class AIReviewViewSet(
             user=ai_user,
             message=message,
             is_proposal=True,
+            data={
+                'action': data['proposed_action'],
+                'points': data.get('proposed_points'),
+                'staff_reply': data.get('proposed_staff_reply', ''),
+                'template_id': data.get('template_id'),
+                'confidence': confidence,
+                'reasoning': reasoning,
+            },
         )
 
         return Response(
             AIReviewSubmissionSerializer(submission).data,
             status=status.HTTP_200_OK,
         )
+
+    @action(detail=False, methods=['get'], url_path='reviewed')
+    def reviewed(self, request):
+        """
+        List reviewed submissions that had AI proposals.
+
+        Returns submissions with state in (accepted, rejected, more_info_needed)
+        that have at least one AI-created SubmissionNote with is_proposal=True.
+        Includes evidence, review outcome (state, staff_reply), and all internal notes.
+        """
+        ai_proposal_notes = SubmissionNote.objects.filter(
+            submitted_contribution=OuterRef('pk'),
+            is_proposal=True,
+            user__email=AI_STEWARD_EMAIL,
+        )
+
+        queryset = (
+            SubmittedContribution.objects
+            .filter(
+                state__in=['accepted', 'rejected', 'more_info_needed'],
+            )
+            .filter(Exists(ai_proposal_notes))
+            .select_related(
+                'contribution_type',
+                'contribution_type__category',
+            )
+            .prefetch_related('evidence_items', 'internal_notes')
+            .order_by('-reviewed_at')
+        )
+
+        # Apply filters from query params
+        state = request.query_params.get('state')
+        if state:
+            queryset = queryset.filter(state=state)
+
+        contribution_type = request.query_params.get('contribution_type')
+        if contribution_type:
+            queryset = queryset.filter(contribution_type_id=contribution_type)
+
+        category = request.query_params.get('category')
+        if category:
+            queryset = queryset.filter(contribution_type__category__slug=category)
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = AIReviewReviewedSubmissionSerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = AIReviewReviewedSubmissionSerializer(queryset, many=True)
+        return Response(serializer.data)
 
     @action(detail=False, methods=['get'], url_path='templates')
     def templates(self, request):

--- a/backend/contributions/tests/test_calibration_data.py
+++ b/backend/contributions/tests/test_calibration_data.py
@@ -291,6 +291,46 @@ class TestAIReviewNotes(APITestCase):
         self.assertIn('Tier 1', note.data['reasoning'])
 
 
+@override_settings(ALLOWED_HOSTS=['*'], AI_REVIEW_API_KEY='test-ai-review-key')
+class TestAIReviewAPI(APITestCase):
+    """Test that the AI review API stores calibration data correctly."""
+
+    def setUp(self):
+        self.fixtures = _create_test_fixtures()
+
+    def test_ai_propose_endpoint_stores_structured_note_data(self):
+        submission = self.fixtures['submission']
+
+        response = self.client.post(
+            f'/api/v1/ai-review/{submission.id}/propose/',
+            data={
+                'proposed_action': 'reject',
+                'proposed_staff_reply': 'Insufficient evidence.',
+                'template_id': self.fixtures['reject_template'].id,
+                'confidence': 'high',
+                'reasoning': 'The evidence provided does not support the claim.',
+            },
+            content_type='application/json',
+            HTTP_X_AI_REVIEW_KEY='test-ai-review-key',
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        note = SubmissionNote.objects.filter(
+            submitted_contribution=submission,
+            user=self.fixtures['ai_user'],
+            is_proposal=True,
+        ).first()
+
+        self.assertIsNotNone(note)
+        self.assertEqual(note.data['action'], 'reject')
+        self.assertEqual(note.data['points'], None)
+        self.assertEqual(note.data['staff_reply'], 'Insufficient evidence.')
+        self.assertEqual(note.data['template_id'], self.fixtures['reject_template'].id)
+        self.assertEqual(note.data['confidence'], 'high')
+        self.assertEqual(note.data['reasoning'], 'The evidence provided does not support the claim.')
+
+
 @override_settings(ALLOWED_HOSTS=['*'])
 class TestCalibrationComparison(APITestCase):
     """Test that AI vs human notes can be compared for calibration."""
@@ -453,3 +493,92 @@ class TestCalibrationComparison(APITestCase):
         self.assertEqual(calibration_pairs[0]['ai_action'], 'accept')
         self.assertEqual(calibration_pairs[0]['human_action'], 'reject')
         self.assertEqual(calibration_pairs[0]['ai_confidence'], 'medium')
+
+
+@override_settings(ALLOWED_HOSTS=['*'], AI_REVIEW_API_KEY='test-ai-review-key')
+class TestAIReviewedEndpoint(APITestCase):
+    """Test the external AI reviewed-submissions calibration endpoint."""
+
+    def setUp(self):
+        self.fixtures = _create_test_fixtures()
+
+    def _get_reviewed(self, **params):
+        return self.client.get(
+            '/api/v1/ai-review/reviewed/',
+            data=params,
+            HTTP_X_AI_REVIEW_KEY='test-ai-review-key',
+        )
+
+    def test_reviewed_endpoint_returns_reviewed_submission_with_ai_proposal(self):
+        submission = self.fixtures['submission']
+        ai_user = self.fixtures['ai_user']
+        steward_user = self.fixtures['steward_user']
+
+        submission.state = 'accepted'
+        submission.staff_reply = 'Approved by steward.'
+        submission.reviewed_by = steward_user
+        submission.reviewed_at = timezone.now()
+        submission.save()
+
+        SubmissionNote.objects.create(
+            submitted_contribution=submission,
+            user=ai_user,
+            message='AI proposal: accept',
+            is_proposal=True,
+            data={'action': 'accept', 'points': 5, 'confidence': 'medium'},
+        )
+        SubmissionNote.objects.create(
+            submitted_contribution=submission,
+            user=steward_user,
+            message='Reviewed: accept',
+            is_proposal=False,
+            data={'action': 'accept', 'points': 5},
+        )
+
+        response = self._get_reviewed()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(str(response.data['results'][0]['id']), str(submission.id))
+        self.assertEqual(response.data['results'][0]['state'], 'accepted')
+        self.assertEqual(len(response.data['results'][0]['internal_notes']), 2)
+
+    def test_reviewed_endpoint_excludes_human_only_proposals(self):
+        ai_submission = self.fixtures['submission']
+        ai_user = self.fixtures['ai_user']
+        steward_user = self.fixtures['steward_user']
+
+        ai_submission.state = 'rejected'
+        ai_submission.reviewed_by = steward_user
+        ai_submission.reviewed_at = timezone.now()
+        ai_submission.save()
+        SubmissionNote.objects.create(
+            submitted_contribution=ai_submission,
+            user=ai_user,
+            message='AI proposal: reject',
+            is_proposal=True,
+            data={'action': 'reject', 'points': None, 'confidence': 'high'},
+        )
+
+        human_only_submission = SubmittedContribution.objects.create(
+            user=self.fixtures['submitter'],
+            contribution_type=self.fixtures['ct'],
+            contribution_date=timezone.now(),
+            notes='Second submission',
+            state='more_info_needed',
+            reviewed_by=steward_user,
+            reviewed_at=timezone.now(),
+        )
+        SubmissionNote.objects.create(
+            submitted_contribution=human_only_submission,
+            user=steward_user,
+            message='Human proposal: more info',
+            is_proposal=True,
+            data={'action': 'more_info', 'staff_reply': 'Please add more detail.'},
+        )
+
+        response = self._get_reviewed()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(str(response.data['results'][0]['id']), str(ai_submission.id))

--- a/backend/validators/genlayer_validators_service.py
+++ b/backend/validators/genlayer_validators_service.py
@@ -2,6 +2,7 @@
 GenLayer blockchain integration service for validator wallet synchronization.
 Handles RPC calls to Staking, Factory, and ValidatorWallet contracts.
 """
+import time
 from typing import Dict, List, Optional, Any
 from django.conf import settings
 from django.utils import timezone
@@ -203,8 +204,10 @@ class GenLayerValidatorsService:
             List of validator wallet addresses
         """
         try:
+            t0 = time.time()
             with trace_external('web3', 'active_validators'):
                 validators = self.staking_contract.functions.activeValidators().call()
+            elapsed = time.time() - t0
             # Filter out invalid addresses
             valid_validators = [
                 addr for addr in validators
@@ -214,6 +217,7 @@ class GenLayerValidatorsService:
                     '0x0000000000000000000000000000000000000000'
                 ]
             ]
+            logger.info(f"[{self.network_key}] Fetched {len(valid_validators)} active validators in {elapsed:.2f}s")
             return valid_validators
         except Exception as e:
             logger.error(f"Error fetching active validators: {str(e)}")
@@ -231,10 +235,12 @@ class GenLayerValidatorsService:
             List of validator data with address, untilEpochBanned, permanently_banned
         """
         try:
+            t0 = time.time()
             with trace_external('web3', 'banned_validators'):
                 banned_list = self.staking_contract.functions.getAllBannedValidators(
                     start_index, size
                 ).call()
+            elapsed = time.time() - t0
 
             result = []
             for banned in banned_list:
@@ -244,6 +250,7 @@ class GenLayerValidatorsService:
                     'permanently_banned': banned[2]
                 })
 
+            logger.info(f"[{self.network_key}] Fetched {len(result)} banned validators in {elapsed:.2f}s")
             return result
         except Exception as e:
             logger.error(f"Error fetching banned validators: {str(e)}")
@@ -261,10 +268,12 @@ class GenLayerValidatorsService:
             List of validator data with address, untilEpochBanned, permanently_banned
         """
         try:
+            t0 = time.time()
             with trace_external('web3', 'quarantined_validators'):
                 quarantined_list = self.staking_contract.functions.getAllQuarantinedValidators(
                     start_index, size
                 ).call()
+            elapsed = time.time() - t0
 
             result = []
             for item in quarantined_list:
@@ -274,6 +283,7 @@ class GenLayerValidatorsService:
                     'permanently_banned': item[2]
                 })
 
+            logger.info(f"[{self.network_key}] Fetched {len(result)} quarantined validators in {elapsed:.2f}s")
             return result
         except Exception as e:
             logger.error(f"Error fetching quarantined validators: {str(e)}")
@@ -373,16 +383,24 @@ class GenLayerValidatorsService:
         from .models import ValidatorWallet, Validator
         from users.models import User
 
+        sync_start = time.time()
         stats = {
             'active_fetched': 0,
             'banned_fetched': 0,
             'quarantined_fetched': 0,
             'created': 0,
             'updated': 0,
-            'errors': 0
+            'errors': 0,
+            'total_to_process': 0,
+            'rpc_time_operator': 0.0,
+            'rpc_time_identity': 0.0,
+            'rpc_time_view': 0.0,
         }
 
         try:
+            # Phase 1: Fetch lists from blockchain
+            phase_start = time.time()
+
             # Fetch active validators
             active_addresses = self.fetch_active_validators()
             stats['active_fetched'] = len(active_addresses)
@@ -394,6 +412,9 @@ class GenLayerValidatorsService:
             # Fetch quarantined validators
             quarantined_data = self.fetch_quarantined_validators()
             stats['quarantined_fetched'] = len(quarantined_data)
+
+            phase1_elapsed = time.time() - phase_start
+            logger.info(f"[{self.network_key}] Phase 1 (fetch lists) completed in {phase1_elapsed:.2f}s")
 
             # Create lookup for quarantined validators
             quarantined_lookup = {}
@@ -423,13 +444,24 @@ class GenLayerValidatorsService:
             # Also include existing validators from DB to catch "zombie" validators
             # that disappeared from both active and banned lists
             existing_addresses = ValidatorWallet.objects.filter(network=self.network_key).values_list('address', flat=True)
+            db_count = 0
             for addr in existing_addresses:
                 all_addresses.add(addr.lower())
+                db_count += 1
 
             # Create lowercase set of active addresses for comparison
             active_addresses_lower = {addr.lower() for addr in active_addresses}
 
+            stats['total_to_process'] = len(all_addresses)
+            logger.info(
+                f"[{self.network_key}] Phase 2: Processing {len(all_addresses)} unique validators "
+                f"(active={len(active_addresses)}, banned={len(banned_data)}, "
+                f"quarantined={len(quarantined_data)}, existing_in_db={db_count})"
+            )
+
             # Process each validator
+            phase2_start = time.time()
+            processed = 0
             for address in all_addresses:
                 try:
                     self._process_validator(
@@ -439,17 +471,44 @@ class GenLayerValidatorsService:
                         quarantined_info=quarantined_lookup.get(address.lower()),
                         stats=stats
                     )
+                    processed += 1
+                    # Log progress every 50 validators
+                    if processed % 50 == 0:
+                        elapsed = time.time() - phase2_start
+                        avg = elapsed / processed
+                        remaining = (len(all_addresses) - processed) * avg
+                        logger.info(
+                            f"[{self.network_key}] Progress: {processed}/{len(all_addresses)} validators "
+                            f"({elapsed:.1f}s elapsed, ~{remaining:.1f}s remaining, "
+                            f"avg {avg:.2f}s/validator)"
+                        )
                 except Exception as e:
-                    logger.error(f"Error processing validator: {str(e)}")
+                    logger.error(f"Error processing validator {address}: {str(e)}", exc_info=True)
                     stats['errors'] += 1
 
+            phase2_elapsed = time.time() - phase2_start
+            logger.info(
+                f"[{self.network_key}] Phase 2 (process validators) completed in {phase2_elapsed:.2f}s "
+                f"(avg {phase2_elapsed / max(len(all_addresses), 1):.2f}s/validator)"
+            )
+            logger.info(
+                f"[{self.network_key}] RPC time breakdown: "
+                f"operator={stats['rpc_time_operator']:.2f}s, "
+                f"identity={stats['rpc_time_identity']:.2f}s, "
+                f"view={stats['rpc_time_view']:.2f}s"
+            )
+
             # Record status snapshots for today
+            phase3_start = time.time()
             self._record_status_snapshots()
+            logger.info(f"[{self.network_key}] Phase 3 (snapshots) completed in {time.time() - phase3_start:.2f}s")
 
         except Exception as e:
-            logger.error(f"Error during sync: {str(e)}")
+            logger.error(f"Error during sync for {self.network_key}: {str(e)}", exc_info=True)
             stats['errors'] += 1
 
+        total_elapsed = time.time() - sync_start
+        logger.info(f"[{self.network_key}] Total sync completed in {total_elapsed:.2f}s: {stats}")
         return stats
 
     def _process_validator(
@@ -487,7 +546,9 @@ class GenLayerValidatorsService:
         has_changes = is_new
 
         # Always fetch operator address to capture updates (like identity)
+        t0 = time.time()
         operator_address = self.fetch_operator_for_wallet(address)
+        stats['rpc_time_operator'] += time.time() - t0
         if operator_address:
             new_operator_address = operator_address.lower()
             if wallet.operator_address != new_operator_address:
@@ -506,7 +567,9 @@ class GenLayerValidatorsService:
                 pass
 
         # Always fetch identity to capture updates
+        t0 = time.time()
         identity = self.fetch_validator_identity(address)
+        stats['rpc_time_identity'] += time.time() - t0
         if identity:
             new_moniker = identity.get('moniker', '')
             new_logo_uri = identity.get('logo_uri', '')
@@ -521,7 +584,9 @@ class GenLayerValidatorsService:
                 has_changes = True
 
         # Always fetch validator view to get current stake values
+        t0 = time.time()
         validator_view = self.fetch_validator_view(address)
+        stats['rpc_time_view'] += time.time() - t0
         if validator_view:
             new_v_stake = validator_view.get('v_stake', '')
             new_d_stake = validator_view.get('d_stake', '')
@@ -613,20 +678,27 @@ class GenLayerValidatorsService:
         Skips networks without staking contract addresses configured.
         Returns dict of per-network stats.
         """
-        all_stats = {}
-        for network_key, config in settings.TESTNET_NETWORKS.items():
-            if not config.get('staking_contract_address'):
-                logger.info(f"Skipping network '{network_key}' - no staking contract configured")
-                continue
+        overall_start = time.time()
+        networks_to_sync = [
+            (k, c) for k, c in settings.TESTNET_NETWORKS.items()
+            if c.get('staking_contract_address')
+        ]
+        skipped = [k for k, c in settings.TESTNET_NETWORKS.items() if not c.get('staking_contract_address')]
+        if skipped:
+            logger.info(f"Skipping networks without staking contract: {skipped}")
+        logger.info(f"Starting sync for {len(networks_to_sync)} network(s): {[k for k, _ in networks_to_sync]}")
 
+        all_stats = {}
+        for network_key, config in networks_to_sync:
             logger.info(f"Syncing validators for network '{network_key}'...")
             try:
                 service = cls(network_key=network_key)
                 stats = service.sync_all_validators()
                 all_stats[network_key] = stats
-                logger.info(f"Network '{network_key}' sync complete: {stats}")
             except Exception as e:
-                logger.error(f"Error syncing network '{network_key}': {str(e)}")
+                logger.error(f"Error syncing network '{network_key}': {str(e)}", exc_info=True)
                 all_stats[network_key] = {'error': str(e)}
 
+        total_elapsed = time.time() - overall_start
+        logger.info(f"All networks sync completed in {total_elapsed:.2f}s: {all_stats}")
         return all_stats

--- a/backend/validators/migrations/0010_synclock.py
+++ b/backend/validators/migrations/0010_synclock.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('validators', '0009_per_network_node_versions'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SyncLock',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100, unique=True)),
+                ('owner_token', models.CharField(blank=True, db_index=True, max_length=32, null=True)),
+                ('acquired_at', models.DateTimeField(blank=True, null=True)),
+                ('heartbeat_at', models.DateTimeField(blank=True, null=True)),
+                ('released_at', models.DateTimeField(blank=True, null=True)),
+            ],
+            options={
+                'db_table': 'validators_sync_lock',
+            },
+        ),
+    ]

--- a/backend/validators/models.py
+++ b/backend/validators/models.py
@@ -95,3 +95,23 @@ class ValidatorWalletStatusSnapshot(BaseModel):
 
     def __str__(self):
         return f"{self.wallet.address[:10]}... {self.date} ({self.status})"
+
+
+class SyncLock(models.Model):
+    """
+    Database-backed advisory lock for cross-process sync coordination.
+    Stores an ownership token so only the sync that acquired the lock can
+    release it, and tracks heartbeats so long-running syncs are not mistaken
+    for stale work.
+    """
+    name = models.CharField(max_length=100, unique=True)
+    owner_token = models.CharField(max_length=32, null=True, blank=True, db_index=True)
+    acquired_at = models.DateTimeField(null=True, blank=True)
+    heartbeat_at = models.DateTimeField(null=True, blank=True)
+    released_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        db_table = 'validators_sync_lock'
+
+    def __str__(self):
+        return f"SyncLock({self.name}, acquired={self.acquired_at})"

--- a/backend/validators/tests/test_api.py
+++ b/backend/validators/tests/test_api.py
@@ -1,8 +1,12 @@
-from django.test import TestCase
+from datetime import timedelta
+
+from django.test import override_settings
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 from rest_framework import status
-from validators.models import Validator
+from django.utils import timezone
+from validators.models import SyncLock, Validator
+from validators.views import ValidatorWalletViewSet
 from contributions.models import Category
 
 User = get_user_model()
@@ -83,3 +87,49 @@ class ValidatorAPITestCase(APITestCase):
         validator = Validator.objects.get(user=self.user)
         self.assertEqual(validator.node_version_bradbury, '2.0.0')
         self.assertEqual(validator.node_version_asimov, '1.0.0')
+
+
+@override_settings(CRON_SYNC_TOKEN='test-cron-token')
+class ValidatorSyncLockTestCase(APITestCase):
+    def test_sync_returns_409_while_non_stale_lock_is_held(self):
+        SyncLock.objects.create(
+            name=ValidatorWalletViewSet.SYNC_LOCK_NAME,
+            owner_token='active-owner',
+            acquired_at=timezone.now(),
+            heartbeat_at=timezone.now(),
+            released_at=None,
+        )
+
+        response = self.client.post(
+            '/api/v1/validators/wallets/sync/',
+            HTTP_X_CRON_TOKEN='test-cron-token',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertIn('already in progress', response.data['message'])
+
+    def test_old_owner_cannot_release_reclaimed_stale_lock(self):
+        SyncLock.objects.create(
+            name=ValidatorWalletViewSet.SYNC_LOCK_NAME,
+            owner_token='old-owner',
+            acquired_at=timezone.now() - timedelta(seconds=ValidatorWalletViewSet.SYNC_LOCK_STALE_AFTER_SECONDS + 1),
+            heartbeat_at=timezone.now() - timedelta(seconds=ValidatorWalletViewSet.SYNC_LOCK_STALE_AFTER_SECONDS + 1),
+            released_at=None,
+        )
+
+        new_owner_token, elapsed_seconds = ValidatorWalletViewSet._acquire_sync_lock()
+
+        self.assertIsNotNone(new_owner_token)
+        self.assertIsNone(elapsed_seconds)
+
+        ValidatorWalletViewSet._release_sync_lock('old-owner')
+
+        lock_row = SyncLock.objects.get(name=ValidatorWalletViewSet.SYNC_LOCK_NAME)
+        self.assertEqual(lock_row.owner_token, new_owner_token)
+        self.assertIsNone(lock_row.released_at)
+
+        ValidatorWalletViewSet._release_sync_lock(new_owner_token)
+
+        lock_row.refresh_from_db()
+        self.assertIsNone(lock_row.owner_token)
+        self.assertIsNotNone(lock_row.released_at)

--- a/backend/validators/views.py
+++ b/backend/validators/views.py
@@ -1,13 +1,16 @@
 import logging
 import re
+import uuid
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from django.shortcuts import get_object_or_404
 from django.db.models import Min, Q, Count
+from django.db import IntegrityError, transaction
 from django.conf import settings
-from .models import Validator, ValidatorWallet
+from django.utils import timezone
+from .models import SyncLock, Validator, ValidatorWallet
 from .serializers import ValidatorWalletSerializer, LightValidatorWalletSerializer
 from .permissions import IsCronToken
 from .genlayer_validators_service import GenLayerValidatorsService
@@ -204,6 +207,9 @@ class ValidatorWalletViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = ValidatorWallet.objects.all()
     serializer_class = ValidatorWalletSerializer
     permission_classes = [AllowAny]
+    SYNC_LOCK_NAME = 'validator_sync'
+    SYNC_LOCK_STALE_AFTER_SECONDS = 1800
+    SYNC_LOCK_HEARTBEAT_INTERVAL_SECONDS = 60
 
     def get_queryset(self):
         """
@@ -229,6 +235,73 @@ class ValidatorWalletViewSet(viewsets.ReadOnlyModelViewSet):
             queryset = queryset.filter(network=network_filter)
 
         return queryset
+
+    @classmethod
+    def _ensure_sync_lock_row(cls):
+        try:
+            SyncLock.objects.get_or_create(name=cls.SYNC_LOCK_NAME)
+        except IntegrityError:
+            # Another request created the singleton row first.
+            pass
+
+    @classmethod
+    def _acquire_sync_lock(cls):
+        cls._ensure_sync_lock_row()
+
+        with transaction.atomic():
+            now = timezone.now()
+            lock_row = (
+                SyncLock.objects
+                .select_for_update()
+                .get(name=cls.SYNC_LOCK_NAME)
+            )
+
+            is_running = (
+                lock_row.owner_token is not None
+                and lock_row.heartbeat_at is not None
+                and (lock_row.released_at is None or lock_row.heartbeat_at > lock_row.released_at)
+            )
+
+            if is_running:
+                secs = (now - lock_row.heartbeat_at).total_seconds()
+                if secs <= cls.SYNC_LOCK_STALE_AFTER_SECONDS:
+                    return None, secs
+
+                logger.warning(
+                    "Stale sync lock detected (%ss since last heartbeat), force-reclaiming",
+                    f"{secs:.0f}",
+                )
+
+            lock_token = uuid.uuid4().hex
+            lock_row.owner_token = lock_token
+            lock_row.acquired_at = now
+            lock_row.heartbeat_at = now
+            lock_row.released_at = None
+            lock_row.save(update_fields=['owner_token', 'acquired_at', 'heartbeat_at', 'released_at'])
+
+        return lock_token, None
+
+    @classmethod
+    def _refresh_sync_lock(cls, lock_token):
+        refreshed = (
+            SyncLock.objects
+            .filter(name=cls.SYNC_LOCK_NAME, owner_token=lock_token)
+            .update(heartbeat_at=timezone.now())
+        )
+        if not refreshed:
+            logger.warning("Skipped sync lock heartbeat because ownership changed")
+        return bool(refreshed)
+
+    @classmethod
+    def _release_sync_lock(cls, lock_token):
+        now = timezone.now()
+        released = (
+            SyncLock.objects
+            .filter(name=cls.SYNC_LOCK_NAME, owner_token=lock_token)
+            .update(owner_token=None, heartbeat_at=now, released_at=now)
+        )
+        if not released:
+            logger.warning("Skipped sync lock release because ownership changed")
 
     def list(self, request, *args, **kwargs):
         """
@@ -327,21 +400,69 @@ class ValidatorWalletViewSet(viewsets.ReadOnlyModelViewSet):
 
         Runs the sync in a background thread and returns 202 Accepted immediately
         to avoid upstream proxy timeouts (504) on long-running syncs.
+        Uses a database lock (SELECT FOR UPDATE + timestamp check) to prevent
+        concurrent syncs across gunicorn workers.
         """
         import threading
+        import time
+        lock_token, elapsed_seconds = self._acquire_sync_lock()
+        if lock_token is None:
+            lock_row = SyncLock.objects.filter(name=self.SYNC_LOCK_NAME).only('acquired_at').first()
+            elapsed = ''
+            if lock_row and lock_row.acquired_at:
+                runtime_seconds = (timezone.now() - lock_row.acquired_at).total_seconds()
+                elapsed = f' (running for {runtime_seconds:.0f}s)'
+            logger.warning(f"Validator sync skipped: another sync is already in progress{elapsed}")
+            return Response({
+                'success': False,
+                'message': f'Sync already in progress{elapsed}',
+            }, status=status.HTTP_409_CONFLICT)
 
-        def _run_sync():
+        logger.info("Validator sync request accepted, starting background thread")
+        heartbeat_stop = threading.Event()
+
+        def _heartbeat():
             from django.db import connection
+
             try:
-                all_stats = GenLayerValidatorsService.sync_all_networks()
-                logger.info(f"Background validator sync completed: {all_stats}")
-            except Exception as e:
-                logger.error(f"Background validator sync failed: {e}")
+                while not heartbeat_stop.wait(self.SYNC_LOCK_HEARTBEAT_INTERVAL_SECONDS):
+                    try:
+                        if not self._refresh_sync_lock(lock_token):
+                            return
+                    except Exception:
+                        logger.error("Failed to refresh sync lock heartbeat", exc_info=True)
+                        return
             finally:
                 connection.close()
 
+        def _run_sync():
+            from django.db import connection
+            start = time.time()
+            try:
+                all_stats = GenLayerValidatorsService.sync_all_networks()
+                duration = time.time() - start
+                logger.info(f"Background validator sync completed in {duration:.1f}s: {all_stats}")
+            except Exception as e:
+                duration = time.time() - start
+                logger.error(f"Background validator sync failed after {duration:.1f}s: {e}", exc_info=True)
+            finally:
+                heartbeat_stop.set()
+                heartbeat_thread.join(timeout=1)
+                try:
+                    self._release_sync_lock(lock_token)
+                except Exception:
+                    logger.error("Failed to release sync lock", exc_info=True)
+                connection.close()
+
+        heartbeat_thread = threading.Thread(target=_heartbeat, daemon=True)
         thread = threading.Thread(target=_run_sync, daemon=True)
-        thread.start()
+        try:
+            heartbeat_thread.start()
+            thread.start()
+        except Exception:
+            heartbeat_stop.set()
+            self._release_sync_lock(lock_token)
+            raise
 
         return Response({
             'success': True,


### PR DESCRIPTION
## Summary

- **Validator sync fix**: The sync endpoint was timing out (504) because it ran synchronously. Now runs in a background thread with a database-backed lock (`SyncLock` model using `SELECT FOR UPDATE`) to prevent concurrent syncs across gunicorn workers. Includes stale lock recovery after 30 minutes.
- **Sync logging**: Added detailed per-network logging to the sync service for better production debugging.
- **GitHub Actions workflow**: Handle 409 (sync already in progress) as a non-failure status.
- **AI review calibration endpoint**: New `GET /api/v1/ai-review/reviewed/` endpoint that gives the AI agent read access to reviewed submissions that had proposals, including staff replies and internal notes — enabling the agent to learn from past review decisions.
- **Documentation**: Updated `backend/CLAUDE.md` with validator and AI review endpoint references.