### PR TITLE
feat: show accurate on-chain validator counts on Testnets page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable user-facing changes to this project will be documented in this file.
 
 - Direct Cloudinary image upload from Django admin for featured content (ce4c157)
 - Responsive hero banner images for tablet and mobile (e5c01b5)
+- Testnets page now shows accurate on-chain active validator count as the primary metric, with total participants shown below for context
 
 ## 2026-03-30 — Fix Testnet Metrics
 

--- a/backend/validators/views.py
+++ b/backend/validators/views.py
@@ -470,6 +470,29 @@ class ValidatorWalletViewSet(viewsets.ReadOnlyModelViewSet):
         }, status=status.HTTP_202_ACCEPTED)
 
     @action(detail=False, methods=['get'])
+    def stats(self, request):
+        """
+        Lightweight endpoint returning validator wallet status counts per network.
+        No wallet data is serialized — just aggregated counts.
+        """
+        network_breakdown = ValidatorWallet.objects.values(
+            'network', 'status'
+        ).annotate(count=Count('id')).order_by('network', 'status')
+
+        network_stats = {}
+        for entry in network_breakdown:
+            net = entry['network']
+            if net not in network_stats:
+                network_stats[net] = {
+                    'total': 0, 'active': 0,
+                    'quarantined': 0, 'banned': 0, 'inactive': 0,
+                }
+            network_stats[net][entry['status']] = entry['count']
+            network_stats[net]['total'] += entry['count']
+
+        return Response({'network_stats': network_stats})
+
+    @action(detail=False, methods=['get'])
     def networks(self, request):
         """Return available network names and explorer URLs."""
         networks = []

--- a/frontend/src/components/GlobalDashboard.svelte
+++ b/frontend/src/components/GlobalDashboard.svelte
@@ -8,7 +8,7 @@
   import { showError } from "../lib/toastStore";
 
   // State management
-  let networkStats = $state({ asimov: { total: 0 }, bradbury: { total: 0 } });
+  let networkStats = $state({ asimov: { total: 0, onChainActive: 0 }, bradbury: { total: 0, onChainActive: 0 } });
   let networks = $state([]);
   let asimovLeaderboard = $state([]);
   let bradburyLeaderboard = $state([]);
@@ -25,6 +25,7 @@
         bradburyLeaderboardRes,
         waitlistLeaderboardRes,
         networksRes,
+        walletStatsRes,
       ] = await Promise.all([
         leaderboardAPI.getLeaderboardByType("validator", "asc", {
           network: "asimov",
@@ -33,7 +34,8 @@
           network: "bradbury",
         }),
         leaderboardAPI.getWaitlistTop(5),
-        validatorsAPI.getNetworks().catch(() => ({ data: [] })), // Handle if not found
+        validatorsAPI.getNetworks().catch(() => ({ data: [] })),
+        validatorsAPI.getWalletStats().catch(() => ({ data: null })),
       ]);
 
       // Process leaderboards — full list for count, top 5 for display
@@ -66,10 +68,17 @@
         bradbury.explorer_url = "https://explorer.testnet-chain.genlayer.com/";
       networks = [asimov, bradbury];
 
-      // Validator count per network from leaderboard entries (active on-chain validators)
+      // Validator counts: on-chain active from wallet stats, total from leaderboard entries
+      const wStats = walletStatsRes.data?.network_stats || {};
       networkStats = {
-        asimov: { total: asimovFull.length },
-        bradbury: { total: bradburyFull.length },
+        asimov: {
+          total: asimovFull.length,
+          onChainActive: wStats.asimov?.active ?? 0,
+        },
+        bradbury: {
+          total: bradburyFull.length,
+          onChainActive: wStats.bradbury?.active ?? 0,
+        },
       };
 
       loading = false;
@@ -238,9 +247,13 @@
               <span
                 class="text-[32px] font-display font-medium leading-[25px] text-[#2563eb]"
                 style="letter-spacing: -0.96px;"
-                >{networkStats.asimov.total}</span
+                >{networkStats.asimov.onChainActive}</span
               >
-              <span class="text-[13px] text-gray-500">Active Validators</span>
+              <span class="text-[13px] text-gray-500">Active On-Chain</span>
+            </div>
+            <div class="flex items-baseline gap-1.5 mt-1.5">
+              <span class="text-[14px] font-display font-medium text-gray-400">{networkStats.asimov.total}</span>
+              <span class="text-[12px] text-gray-400">total participants</span>
             </div>
           </div>
 
@@ -366,9 +379,13 @@
               <span
                 class="text-[32px] font-display font-medium leading-[25px] text-[#0284c7]"
                 style="letter-spacing: -0.96px;"
-                >{networkStats.bradbury.total}</span
+                >{networkStats.bradbury.onChainActive}</span
               >
-              <span class="text-[13px] text-gray-500">Validators</span>
+              <span class="text-[13px] text-gray-500">Active On-Chain</span>
+            </div>
+            <div class="flex items-baseline gap-1.5 mt-1.5">
+              <span class="text-[14px] font-display font-medium text-gray-400">{networkStats.bradbury.total}</span>
+              <span class="text-[12px] text-gray-400">total participants</span>
             </div>
           </div>
 

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -146,7 +146,8 @@ export const validatorsAPI = {
   },
   getMyValidatorWallets: () => api.get('/validators/my-wallets/'),
   linkValidatorWalletsByOperator: (operatorAddress) => api.post('/validators/link-by-operator/', { operator_address: operatorAddress }),
-  getNetworks: () => api.get('/validators/wallets/networks/')
+  getNetworks: () => api.get('/validators/wallets/networks/'),
+  getWalletStats: () => api.get('/validators/wallets/stats/'),
 };
 
 // Builders API


### PR DESCRIPTION
## Summary

The Testnets page was showing inflated validator counts (e.g., "35 Active Validators" for Asimov) because it counted all LeaderboardEntry records, including users who signed up but never ran a node. In reality, only ~5 validators are actively running on-chain.

**Changes:**
- **Backend:** New lightweight `/api/v1/validators/wallets/stats/` endpoint that returns per-network validator wallet status counts (active, inactive, banned, quarantined) without serializing wallet data
- **Frontend:** Testnets page now shows the real on-chain active count as the primary metric, with total participants displayed below for context
- **Fix:** Changed `|| 0` to `?? 0` for proper nullish coalescing on numeric values

## Pre-Landing Review
No critical issues. 2 informational notes:
- Silent "0" display when stats API fails (acceptable given `.catch()` fallback)
- Hardcoded status keys in stats endpoint (matches model's STATUS_CHOICES exactly)

## Test plan
- [ ] Backend: Hit `/api/v1/validators/wallets/stats/` and confirm response shape with `network_stats` per network
- [ ] Frontend: Testnets page shows accurate on-chain active count (small number) with total participants below
- [ ] Frontend: Top 5 leaderboard display unchanged
- [ ] Frontend: Bradbury card displays same pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)