### PR TITLE
feat: add GET /ai-review/proposed/ endpoint

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -74,6 +74,7 @@ backend/
   - `/api/v1/ai-review/` - List pending submissions for the external AI review agent
   - `/api/v1/ai-review/{id}/` - Retrieve a pending submission with evidence and user history
   - `/api/v1/ai-review/{id}/propose/` - Submit an AI proposal for human approval
+  - `/api/v1/ai-review/proposed/` - List pending submissions with AI proposals awaiting steward review
   - `/api/v1/ai-review/reviewed/` - List reviewed submissions that had AI proposals for calibration
   - `/api/v1/ai-review/templates/` - List review templates available to the AI review agent
 
@@ -213,6 +214,7 @@ GET    /api/v1/ai-review/
 GET    /api/v1/ai-review/{id}/
 POST   /api/v1/ai-review/{id}/propose/     (create new proposal)
 PUT    /api/v1/ai-review/{id}/propose/     (update existing proposal)
+GET    /api/v1/ai-review/proposed/     (pending AI proposals awaiting steward review)
 GET    /api/v1/ai-review/reviewed/
 GET    /api/v1/ai-review/templates/
 ```

--- a/backend/contributions/ai_review/serializers.py
+++ b/backend/contributions/ai_review/serializers.py
@@ -80,7 +80,12 @@ class AIReviewSubmissionSerializer(serializers.ModelSerializer):
             'user_history',
             'has_proposal',
             'proposed_action',
+            'proposed_points',
+            'proposed_staff_reply',
+            'proposed_confidence',
+            'proposed_template',
             'proposed_by_name',
+            'proposed_at',
             'created_at',
         ]
         read_only_fields = fields

--- a/backend/contributions/ai_review/views.py
+++ b/backend/contributions/ai_review/views.py
@@ -203,13 +203,16 @@ class AIReviewViewSet(
         return AIReviewSubmissionSerializer
 
     def get_queryset(self):
+        qs = SubmittedContribution.objects.filter(
+            state='pending',
+            reviewed_by__isnull=True,
+        )
+        # The list endpoint only returns unproposed submissions;
+        # retrieve allows accessing proposed ones too (needed for PUT /propose/).
+        if self.action == 'list':
+            qs = qs.filter(proposed_action__isnull=True)
         return (
-            SubmittedContribution.objects.filter(
-                state='pending',
-                proposed_action__isnull=True,
-                reviewed_by__isnull=True,
-            )
-            .select_related(
+            qs.select_related(
                 'contribution_type',
                 'contribution_type__category',
                 'user',
@@ -345,6 +348,49 @@ class AIReviewViewSet(
         return self._validate_and_apply_proposal(
             submission, serializer.validated_data, ai_user, is_update=is_update,
         )
+
+    @action(detail=False, methods=['get'], url_path='proposed')
+    def proposed(self, request):
+        """
+        List pending submissions that have an AI proposal awaiting steward review.
+
+        Returns submissions where state='pending', proposed_action is set,
+        and reviewed_by is NULL (steward hasn't finalized yet).
+        Use GET /ai-review/{id}/ to retrieve full proposal details for any
+        submission returned here.
+        """
+        queryset = (
+            SubmittedContribution.objects.filter(
+                state='pending',
+                proposed_action__isnull=False,
+                reviewed_by__isnull=True,
+            )
+            .select_related(
+                'contribution_type',
+                'contribution_type__category',
+                'user',
+                'proposed_by',
+            )
+            .prefetch_related('evidence_items')
+            .order_by('-proposed_at')
+        )
+
+        # Apply the same filterset as the main list endpoint
+        filterset = self.filterset_class(
+            data=request.query_params,
+            queryset=queryset,
+            request=request,
+        )
+        if filterset.is_valid():
+            queryset = filterset.qs
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = LightAIReviewSubmissionSerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = LightAIReviewSubmissionSerializer(queryset, many=True)
+        return Response(serializer.data)
 
     @action(detail=False, methods=['get'], url_path='reviewed')
     def reviewed(self, request):


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/ai-review/proposed/` to list pending submissions with AI proposals awaiting steward review.
- Fixes `get_queryset` so `GET /ai-review/{id}/` no longer 404s on proposed submissions, enabling the PUT `/propose/` update workflow.
- Exposes proposal detail fields (`proposed_points`, `proposed_confidence`, `proposed_template`, `proposed_at`, `proposed_staff_reply`) on the detail serializer.

## Test plan
- [ ] `GET /ai-review/proposed/` returns only pending submissions with `proposed_action` set and `reviewed_by` null
- [ ] `GET /ai-review/{id}/` works for both proposed and unproposed submissions
- [ ] `GET /ai-review/` (list) still excludes proposed submissions
- [ ] Filters (category, contribution_type, etc.) work on the proposed endpoint
- [ ] `PUT /ai-review/{id}/propose/` still works after retrieving ID from proposed endpoint