### PR TITLE
Fix community profile section and redesign highlight cards

### DIFF
--- a/frontend/src/components/portal/PortalHighlights.svelte
+++ b/frontend/src/components/portal/PortalHighlights.svelte
@@ -18,23 +18,25 @@
     }
   };
 
-  // Get colors based on category
-  function getCategoryColors(category) {
-    if (category === 'builder') {
-      return {
-        pillBg: 'rgba(238,141,36,0.1)',
-        pillText: '#ee8d24',
-        tagBorder: '#ee8d24',
-        tagText: '#ee8d24',
-      };
-    }
-    // validator, steward, or default
-    return {
-      pillBg: 'rgba(79,118,246,0.1)',
-      pillText: '#4f76f6',
-      tagBorder: '#4f76f6',
-      tagText: '#4f76f6',
+  function getCategoryColors(cat) {
+    const map = {
+      builder: {
+        pillBg: "rgba(238,133,33,0.1)", pillText: "#ee8521",
+        tagBorder: "#ee8521", tagText: "#ee8521",
+        tintedBg: "#FEF3E2",
+      },
+      validator: {
+        pillBg: "rgba(56,125,232,0.1)", pillText: "#387DE8",
+        tagBorder: "#387DE8", tagText: "#387DE8",
+        tintedBg: "#EBF3FE",
+      },
+      community: {
+        pillBg: "rgba(127,82,225,0.1)", pillText: "#7F52E1",
+        tagBorder: "#7F52E1", tagText: "#7F52E1",
+        tintedBg: "#F4ECFD",
+      },
     };
+    return map[cat] || map.validator;
   }
 
   onMount(async () => {
@@ -85,9 +87,9 @@
         <button
           onclick={() => push(`/contribution/${highlight.contribution}`)}
           class="flex-shrink-0 w-[300px] h-[180px] rounded-[8px] p-4 flex flex-col gap-2 text-left hover:shadow-md transition-shadow cursor-pointer"
-          style="border: 1px solid #f5f5f5;"
+          style="background: {colors.tintedBg};"
         >
-          <!-- Top row: avatar + username | points pill -->
+          <!-- Top row: avatar + username | points pill + highlight star -->
           <div class="flex items-center justify-between">
             <div class="flex items-center gap-2">
               {#if highlight.user_profile_image_url}
@@ -101,28 +103,30 @@
                 {highlight.user_name || `${highlight.user_address?.slice(0, 6)}...`}
               </span>
             </div>
-            <span
-              class="text-xs font-medium px-2 py-0.5 rounded-full"
-              style="background: {colors.pillBg}; color: {colors.pillText};"
-            >
-              {highlight.contribution_points} pts
-            </span>
+            <div class="flex items-center gap-2">
+              <span
+                class="text-xs font-medium px-2 py-0.5 rounded-full"
+                style="background: {colors.pillBg}; color: {colors.pillText};"
+              >
+                {highlight.contribution_points} pts
+              </span>
+              <div class="relative w-[32px] h-[32px] flex-shrink-0">
+                <img src="/assets/icons/hexagon-highlight.svg" alt="" class="w-full h-full" />
+                <div
+                  class="absolute inset-0 m-auto w-[16px] h-[16px]"
+                  style="background-color: #FFFFFF; -webkit-mask-image: url(/assets/icons/star-line.svg); mask-image: url(/assets/icons/star-line.svg); mask-size: contain; mask-repeat: no-repeat; mask-position: center;"
+                ></div>
+              </div>
+            </div>
           </div>
 
           <!-- Middle: title + description -->
           <div class="flex-1 min-h-0 overflow-hidden">
-            <div class="flex items-center gap-[6px]">
-              <div class="relative w-[20px] h-[20px] flex-shrink-0">
-                <img src="/assets/icons/hexagon-highlight.svg" alt="" class="w-full h-full" />
-                <div
-                  class="absolute inset-0 m-auto w-[10px] h-[10px]"
-                  style="background-color: #FFFFFF; -webkit-mask-image: url(/assets/icons/star-line.svg); mask-image: url(/assets/icons/star-line.svg); mask-size: contain; mask-repeat: no-repeat; mask-position: center;"
-                ></div>
-              </div>
-              <h3 class="text-sm font-medium text-black truncate">{highlight.title}</h3>
-            </div>
+            <h3 class="text-sm font-medium text-black truncate">
+              {highlight.title || highlight.contribution_type_name || 'Contribution'}
+            </h3>
             <p class="text-xs mt-1 line-clamp-3" style="color: #6b6b6b;">
-              {highlight.description}
+              {highlight.description || ''}
             </p>
           </div>
 

--- a/frontend/src/components/profile/CommunityProgressJourney.svelte
+++ b/frontend/src/components/profile/CommunityProgressJourney.svelte
@@ -125,9 +125,9 @@
                         platform="twitter"
                         platformLabel="X"
                         connection={participant?.twitter_connection}
-                        initiateUrl="/social-auth/twitter/authorize/"
+                        initiateUrl="/api/auth/twitter/"
                         onLinked={onSocialLinked}
-                        compact={true}
+                        compact={false}
                     />
                 {/if}
             </div>
@@ -211,9 +211,9 @@
                         platform="discord"
                         platformLabel="Discord"
                         connection={participant?.discord_connection}
-                        initiateUrl="/social-auth/discord/authorize/"
+                        initiateUrl="/api/auth/discord/"
                         onLinked={onSocialLinked}
-                        compact={true}
+                        compact={false}
                     />
                 {/if}
             </div>

--- a/frontend/src/components/profile/CommunityView.svelte
+++ b/frontend/src/components/profile/CommunityView.svelte
@@ -3,6 +3,7 @@
     import CategoryIcon from "../portal/CategoryIcon.svelte";
     import ProfileHighlights from "./ProfileHighlights.svelte";
     import ProfileRecentContributions from "./ProfileRecentContributions.svelte";
+    import CommunityProgressJourney from "./CommunityProgressJourney.svelte";
     import { showSuccess } from "../../lib/toastStore";
 
     let {
@@ -13,6 +14,11 @@
         isOwnProfile = false,
         communityStats = { totalContributions: 0, totalPoints: 0 },
         communityStatsLoading = false,
+        onSocialLinked = () => {},
+        onClaimX = () => {},
+        onClaimDiscord = () => {},
+        isClaimingX = false,
+        isClaimingDiscord = false,
     } = $props();
 
     let totalReferrals = $derived(
@@ -23,6 +29,13 @@
     let builderReferralPoints = $derived(referralPoints?.builder_points || 0);
     let validatorReferralPoints = $derived(
         referralPoints?.validator_points || 0,
+    );
+    let totalReferralPoints = $derived(builderReferralPoints + validatorReferralPoints);
+
+    let showJourney = $derived(
+        isOwnProfile &&
+        participant?.creator &&
+        !(participant?.has_community_link_x && participant?.has_community_link_discord)
     );
 
     function copyReferralLink() {
@@ -65,6 +78,20 @@
             Community Member
         </span>
     </div>
+
+    <!-- Social Link Journey (conditional) -->
+    {#if showJourney}
+        <div class="w-full mb-4">
+            <CommunityProgressJourney
+                {participant}
+                onSocialLinked={onSocialLinked}
+                {onClaimX}
+                {onClaimDiscord}
+                {isClaimingX}
+                {isClaimingDiscord}
+            />
+        </div>
+    {/if}
 
     <!-- Referral Program Banner -->
     <div
@@ -118,154 +145,8 @@
         </div>
     </div>
 
-    <!-- Metrics Row -->
+    <!-- Metrics Row: 3 cards -->
     <div class="flex flex-col md:flex-row gap-4 w-full">
-        <!-- Total Referrals Card -->
-        <div
-            class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative overflow-hidden"
-        >
-            {#if loading}
-                <div class="flex h-full items-center animate-pulse">
-                    <div
-                        class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"
-                    ></div>
-                    <div class="flex flex-col gap-2">
-                        <div class="h-7 w-16 bg-gray-200 rounded"></div>
-                        <div class="h-3 w-24 bg-gray-100 rounded"></div>
-                    </div>
-                </div>
-            {:else}
-                <div class="flex h-full items-center">
-                    <div
-                        class="w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
-                    >
-                        <CategoryIcon
-                            category="community"
-                            mode="hexagon"
-                            size={48}
-                        />
-                    </div>
-                    <div
-                        class="flex flex-col h-full items-start justify-center whitespace-nowrap z-10"
-                    >
-                        <p
-                            class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
-                        >
-                            {totalReferrals}
-                        </p>
-                        <p
-                            class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
-                        >
-                            Total Referrals
-                        </p>
-                    </div>
-                </div>
-            {/if}
-        </div>
-
-        <!-- Builder Referral Points Card -->
-        <div
-            class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative overflow-hidden"
-        >
-            {#if loading}
-                <div class="flex h-full items-center animate-pulse">
-                    <div
-                        class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"
-                    ></div>
-                    <div class="flex flex-col gap-2">
-                        <div class="h-7 w-16 bg-gray-200 rounded"></div>
-                        <div class="h-3 w-28 bg-gray-100 rounded"></div>
-                    </div>
-                </div>
-            {:else}
-                <div class="flex h-full items-center">
-                    <div
-                        class="w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
-                    >
-                        <CategoryIcon
-                            category="builder"
-                            mode="hexagon"
-                            size={48}
-                        />
-                        <div class="absolute -bottom-[2px] -right-[2px]">
-                            <CategoryIcon
-                                category="community"
-                                mode="hexagon"
-                                size={20}
-                            />
-                        </div>
-                    </div>
-                    <div
-                        class="flex flex-col h-full items-start justify-center whitespace-nowrap z-10"
-                    >
-                        <p
-                            class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
-                        >
-                            {builderReferralPoints}
-                        </p>
-                        <p
-                            class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
-                        >
-                            Builder Referral Points
-                        </p>
-                    </div>
-                </div>
-            {/if}
-        </div>
-
-        <!-- Validator Referral Points Card -->
-        <div
-            class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative overflow-hidden"
-        >
-            {#if loading}
-                <div class="flex h-full items-center animate-pulse">
-                    <div
-                        class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"
-                    ></div>
-                    <div class="flex flex-col gap-2">
-                        <div class="h-7 w-16 bg-gray-200 rounded"></div>
-                        <div class="h-3 w-28 bg-gray-100 rounded"></div>
-                    </div>
-                </div>
-            {:else}
-                <div class="flex h-full items-center">
-                    <div
-                        class="w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
-                    >
-                        <CategoryIcon
-                            category="validator"
-                            mode="hexagon"
-                            size={48}
-                        />
-                        <div class="absolute -bottom-[2px] -right-[2px]">
-                            <CategoryIcon
-                                category="community"
-                                mode="hexagon"
-                                size={20}
-                            />
-                        </div>
-                    </div>
-                    <div
-                        class="flex flex-col h-full items-start justify-center whitespace-nowrap z-10"
-                    >
-                        <p
-                            class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
-                        >
-                            {validatorReferralPoints}
-                        </p>
-                        <p
-                            class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
-                        >
-                            Validator Referral Points
-                        </p>
-                    </div>
-                </div>
-            {/if}
-        </div>
-    </div>
-
-    <!-- Community Contributions Stats -->
-    <div class="flex flex-col md:flex-row gap-4 w-full mt-4">
         <!-- Community Points Card -->
         <div
             class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative overflow-hidden"
@@ -308,14 +189,14 @@
                         <p
                             class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
                         >
-                            Total community points
+                            Community Points
                         </p>
                     </div>
                 </div>
             {/if}
         </div>
 
-        <!-- Community Contributions Count Card -->
+        <!-- Community Contributions Card -->
         <div
             class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative overflow-hidden"
         >
@@ -334,20 +215,11 @@
                     <div
                         class="w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
                     >
-                        <img
-                            src="/assets/icons/hexagon-community.svg"
-                            alt=""
-                            class="w-full h-full"
+                        <CategoryIcon
+                            category="community"
+                            mode="hexagon"
+                            size={48}
                         />
-                        <svg
-                            class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-6 h-6 text-white"
-                            viewBox="0 0 24 24"
-                            fill="currentColor"
-                        >
-                            <path
-                                d="M3 2.992C3 2.444 3.445 2 3.993 2h16.014A1 1 0 0 1 21 2.992v18.016a1 1 0 0 1-.993.992H3.993A.993.993 0 0 1 3 21.008V2.992zM5 4v16h14V4H5zm4.293 7.293l-2 2a1 1 0 0 0 0 1.414l2 2 1.414-1.414L9.414 14l1.293-1.293-1.414-1.414zm5.414 0l-1.414 1.414L14.586 14l-1.293 1.293 1.414 1.414 2-2a1 1 0 0 0 0-1.414l-2-2z"
-                            />
-                        </svg>
                     </div>
                     <div
                         class="flex flex-col h-full items-start justify-center whitespace-nowrap z-10"
@@ -360,8 +232,63 @@
                         <p
                             class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
                         >
-                            Total Contributions
+                            Community Contributions
                         </p>
+                    </div>
+                </div>
+            {/if}
+        </div>
+
+        <!-- Total Referrals Card (with builder/validator referral points breakdown) -->
+        <div
+            class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative overflow-hidden"
+        >
+            {#if loading}
+                <div class="flex h-full items-center animate-pulse">
+                    <div
+                        class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"
+                    ></div>
+                    <div class="flex flex-col gap-2">
+                        <div class="h-7 w-16 bg-gray-200 rounded"></div>
+                        <div class="h-3 w-24 bg-gray-100 rounded"></div>
+                    </div>
+                </div>
+            {:else}
+                <div class="flex h-full items-center">
+                    <div
+                        class="w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
+                    >
+                        <CategoryIcon
+                            category="community"
+                            mode="hexagon"
+                            size={48}
+                        />
+                    </div>
+                    <div
+                        class="flex flex-col h-full items-start justify-center z-10"
+                    >
+                        <p
+                            class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
+                        >
+                            {totalReferrals}
+                        </p>
+                        <div class="flex items-center gap-3 mt-1">
+                            <span class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b]">
+                                Total Referrals
+                            </span>
+                            {#if builderReferralPoints > 0 || validatorReferralPoints > 0}
+                                <div class="flex items-center gap-2">
+                                    <div class="flex items-center gap-[3px]">
+                                        <CategoryIcon category="builder" mode="hexagon" size={14} />
+                                        <span class="text-[11px] font-medium text-[#999] leading-[14px]">{builderReferralPoints} pts</span>
+                                    </div>
+                                    <div class="flex items-center gap-[3px]">
+                                        <CategoryIcon category="validator" mode="hexagon" size={14} />
+                                        <span class="text-[11px] font-medium text-[#999] leading-[14px]">{validatorReferralPoints} pts</span>
+                                    </div>
+                                </div>
+                            {/if}
+                        </div>
                     </div>
                 </div>
             {/if}

--- a/frontend/src/components/profile/ProfileHighlights.svelte
+++ b/frontend/src/components/profile/ProfileHighlights.svelte
@@ -24,20 +24,24 @@
     };
 
     function getCategoryColors(cat) {
-        if (cat === "builder") {
-            return {
-                pillBg: "rgba(238,141,36,0.1)",
-                pillText: "#ee8d24",
-                tagBorder: "#ee8d24",
-                tagText: "#ee8d24",
-            };
-        }
-        return {
-            pillBg: "rgba(79,118,246,0.1)",
-            pillText: "#4f76f6",
-            tagBorder: "#4f76f6",
-            tagText: "#4f76f6",
+        const map = {
+            builder: {
+                pillBg: "rgba(238,133,33,0.1)", pillText: "#ee8521",
+                tagBorder: "#ee8521", tagText: "#ee8521",
+                tintedBg: "#FEF3E2",
+            },
+            validator: {
+                pillBg: "rgba(56,125,232,0.1)", pillText: "#387DE8",
+                tagBorder: "#387DE8", tagText: "#387DE8",
+                tintedBg: "#EBF3FE",
+            },
+            community: {
+                pillBg: "rgba(127,82,225,0.1)", pillText: "#7F52E1",
+                tagBorder: "#7F52E1", tagText: "#7F52E1",
+                tintedBg: "#F4ECFD",
+            },
         };
+        return map[cat] || map.validator;
     }
 
     async function fetchHighlights() {
@@ -98,9 +102,9 @@
                     onclick={() =>
                         push(`/contribution/${highlight.contribution}`)}
                     class="flex-shrink-0 w-[300px] h-[180px] rounded-[8px] p-4 flex flex-col gap-2 text-left hover:shadow-md transition-shadow cursor-pointer"
-                    style="border: 1px solid #f5f5f5;"
+                    style="background: {colors.tintedBg};"
                 >
-                    <!-- Top row: avatar + username | points pill -->
+                    <!-- Top row: avatar + username | points pill + highlight star -->
                     <div class="flex items-center justify-between">
                         <div class="flex items-center gap-2">
                             {#if highlight.user_profile_image_url}
@@ -124,24 +128,33 @@
                                     `${highlight.user_address?.slice(0, 6)}...`}
                             </span>
                         </div>
-                        <span
-                            class="text-xs font-medium px-2 py-0.5 rounded-full"
-                            style="background: {colors.pillBg}; color: {colors.pillText};"
-                        >
-                            {highlight.contribution_points} pts
-                        </span>
+                        <div class="flex items-center gap-2">
+                            <span
+                                class="text-xs font-medium px-2 py-0.5 rounded-full"
+                                style="background: {colors.pillBg}; color: {colors.pillText};"
+                            >
+                                {highlight.contribution_points} pts
+                            </span>
+                            <div class="relative w-[32px] h-[32px] flex-shrink-0">
+                                <img src="/assets/icons/hexagon-highlight.svg" alt="" class="w-full h-full" />
+                                <div
+                                    class="absolute inset-0 m-auto w-[16px] h-[16px]"
+                                    style="background-color: #FFFFFF; -webkit-mask-image: url(/assets/icons/star-line.svg); mask-image: url(/assets/icons/star-line.svg); mask-size: contain; mask-repeat: no-repeat; mask-position: center;"
+                                ></div>
+                            </div>
+                        </div>
                     </div>
 
                     <!-- Middle: title + description -->
                     <div class="flex-1 min-h-0 overflow-hidden">
                         <h3 class="text-sm font-medium text-black truncate">
-                            {highlight.title}
+                            {highlight.title || highlight.contribution_type_name || "Contribution"}
                         </h3>
                         <p
                             class="text-xs mt-1 line-clamp-3"
                             style="color: #6b6b6b;"
                         >
-                            {highlight.description}
+                            {highlight.description || ""}
                         </p>
                     </div>
 

--- a/frontend/src/components/profile/ProfileRecentContributions.svelte
+++ b/frontend/src/components/profile/ProfileRecentContributions.svelte
@@ -26,20 +26,24 @@
     };
 
     function getCategoryColors(cat) {
-        if (cat === "builder") {
-            return {
-                pillBg: "rgba(238,141,36,0.1)",
-                pillText: "#ee8d24",
-                tagBorder: "#ee8d24",
-                tagText: "#ee8d24",
-            };
-        }
-        return {
-            pillBg: "rgba(79,118,246,0.1)",
-            pillText: "#4f76f6",
-            tagBorder: "#4f76f6",
-            tagText: "#4f76f6",
+        const map = {
+            builder: {
+                pillBg: "rgba(238,133,33,0.1)", pillText: "#ee8521",
+                tagBorder: "#ee8521", tagText: "#ee8521",
+                tintedBg: "#FEF3E2",
+            },
+            validator: {
+                pillBg: "rgba(56,125,232,0.1)", pillText: "#387DE8",
+                tagBorder: "#387DE8", tagText: "#387DE8",
+                tintedBg: "#EBF3FE",
+            },
+            community: {
+                pillBg: "rgba(127,82,225,0.1)", pillText: "#7F52E1",
+                tagBorder: "#7F52E1", tagText: "#7F52E1",
+                tintedBg: "#F4ECFD",
+            },
         };
+        return map[cat] || map.validator;
     }
 
     async function fetchContributions() {
@@ -115,9 +119,9 @@
                 <button
                     onclick={() => push(`/contribution/${realId}`)}
                     class="flex-shrink-0 w-[300px] h-[180px] rounded-[8px] p-4 flex flex-col gap-2 text-left hover:shadow-md transition-shadow cursor-pointer"
-                    style="border: 1px solid #f5f5f5;"
+                    style="background: {hasHighlight ? colors.tintedBg : '#FFFFFF'}; {hasHighlight ? '' : 'border: 1px solid #f5f5f5;'}"
                 >
-                    <!-- Top row: avatar + username | points pill -->
+                    <!-- Top row: avatar + username | points pill + highlight star -->
                     <div class="flex items-center justify-between">
                         <div class="flex items-center gap-2">
                             {#if user?.profile_image_url}
@@ -141,52 +145,48 @@
                                     `${user?.address?.slice(0, 6)}...`}
                             </span>
                         </div>
-                        <span
-                            class="text-xs font-medium px-2 py-0.5 rounded-full"
-                            style="background: {colors.pillBg}; color: {colors.pillText};"
-                        >
-                            {points} pts
-                        </span>
-                    </div>
-
-                    <!-- Middle: title + description -->
-                    <div class="flex-1 min-h-0 overflow-hidden">
-                        <div class="flex items-center gap-[6px]">
+                        <div class="flex items-center gap-2">
+                            <span
+                                class="text-xs font-medium px-2 py-0.5 rounded-full"
+                                style="background: {colors.pillBg}; color: {colors.pillText};"
+                            >
+                                {points} pts
+                            </span>
                             {#if hasHighlight}
-                                <div class="relative w-[20px] h-[20px] flex-shrink-0">
+                                <div class="relative w-[32px] h-[32px] flex-shrink-0">
                                     <img src="/assets/icons/hexagon-highlight.svg" alt="" class="w-full h-full" />
                                     <div
-                                        class="absolute inset-0 m-auto w-[10px] h-[10px]"
+                                        class="absolute inset-0 m-auto w-[16px] h-[16px]"
                                         style="background-color: #FFFFFF; -webkit-mask-image: url(/assets/icons/star-line.svg); mask-image: url(/assets/icons/star-line.svg); mask-size: contain; mask-repeat: no-repeat; mask-position: center;"
                                     ></div>
                                 </div>
                             {/if}
-                            <h3 class="text-sm font-medium text-black truncate">
-                                {#if hasHighlight}
-                                    {contrib.highlight.title}
-                                {:else if contrib.title}
-                                    {contrib.title}
-                                {:else}
-                                    {typeName}{#if count > 1}
-                                        <span
-                                            class="text-xs font-normal"
-                                            style="color: #999;"
-                                            >× {count}</span
-                                        >
-                                    {/if}
-                                {/if}
-                            </h3>
                         </div>
+                    </div>
+
+                    <!-- Middle: title + description -->
+                    <div class="flex-1 min-h-0 overflow-hidden">
+                        <h3 class="text-sm font-medium text-black truncate">
+                            {#if hasHighlight}
+                                {contrib.highlight.title || typeName}
+                            {:else if contrib.title}
+                                {contrib.title}
+                            {:else}
+                                {typeName}{#if count > 1}
+                                    <span
+                                        class="text-xs font-normal"
+                                        style="color: #999;"
+                                        >× {count}</span
+                                    >
+                                {/if}
+                            {/if}
+                        </h3>
                         <p
                             class="text-xs mt-1 line-clamp-3"
                             style="color: #6b6b6b;"
                         >
                             {#if hasHighlight}
                                 {contrib.highlight.description}
-                            {:else if contrib.title && contrib.notes}
-                                {contrib.notes}
-                            {:else if contrib.title}
-                                {typeName} contribution
                             {:else if contrib.notes}
                                 {contrib.notes}
                             {:else}

--- a/frontend/src/components/ui/HighlightCards.svelte
+++ b/frontend/src/components/ui/HighlightCards.svelte
@@ -66,8 +66,10 @@
     {#each highlights as highlight}
       {@const cat = highlight.contribution_type_category || category}
       {@const colors = getColors(cat)}
-      <div class="{cardWidthClass} h-[160px] rounded-[8px] p-4 flex flex-col gap-2 border border-[#f0f0f0] bg-white">
-        <!-- Top: avatar + username | points pill -->
+      <div class="{cardWidthClass} h-[160px] rounded-[8px] p-4 flex flex-col gap-2"
+        style="background: {colors.bg};"
+      >
+        <!-- Top: avatar + username | points pill + highlight star -->
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-2">
             <Avatar user={getUserObj(highlight)} size="xs" clickable={false} />
@@ -75,28 +77,30 @@
               {highlight.user_name || `${highlight.user_address?.slice(0, 6)}...`}
             </span>
           </div>
-          <span
-            class="text-xs font-medium px-2 py-0.5 rounded-full"
-            style="background: {colors.bg}; color: {colors.text};"
-          >
-            {formatPoints(highlight.contribution_points)} pts
-          </span>
+          <div class="flex items-center gap-2">
+            <span
+              class="text-xs font-medium px-2 py-0.5 rounded-full"
+              style="background: rgba(255,255,255,0.6); color: {colors.text};"
+            >
+              {formatPoints(highlight.contribution_points)} pts
+            </span>
+            <div class="relative w-[32px] h-[32px] flex-shrink-0">
+              <img src="/assets/icons/hexagon-highlight.svg" alt="" class="w-full h-full" />
+              <div
+                class="absolute inset-0 m-auto w-[16px] h-[16px]"
+                style="background-color: #FFFFFF; -webkit-mask-image: url(/assets/icons/star-line.svg); mask-image: url(/assets/icons/star-line.svg); mask-size: contain; mask-repeat: no-repeat; mask-position: center;"
+              ></div>
+            </div>
+          </div>
         </div>
 
         <!-- Middle: title + description -->
         <div class="flex-1 min-h-0 overflow-hidden">
-          <div class="flex items-center gap-[6px]">
-            <div class="relative w-[20px] h-[20px] flex-shrink-0">
-              <img src="/assets/icons/hexagon-highlight.svg" alt="" class="w-full h-full" />
-              <div
-                class="absolute inset-0 m-auto w-[10px] h-[10px]"
-                style="background-color: #FFFFFF; -webkit-mask-image: url(/assets/icons/star-line.svg); mask-image: url(/assets/icons/star-line.svg); mask-size: contain; mask-repeat: no-repeat; mask-position: center;"
-              ></div>
-            </div>
-            <h3 class="text-[14px] font-semibold text-black line-clamp-1">{highlight.title}</h3>
-          </div>
+          <h3 class="text-[14px] font-semibold text-black line-clamp-1">
+            {highlight.title || highlight.contribution_type_name || 'Contribution'}
+          </h3>
           <p class="text-[12px] mt-1 text-[#6b6b6b] line-clamp-2">
-            {highlight.description}
+            {highlight.description || ''}
           </p>
         </div>
 
@@ -104,7 +108,7 @@
         <div class="flex items-center justify-between">
           <span
             class="text-xs px-2 py-0.5 rounded-full"
-            style="background: {colors.bg}; color: {colors.text};"
+            style="border: 1px solid {colors.text}; color: {colors.text};"
           >
             {highlight.contribution_type_name || cat}
           </span>

--- a/frontend/src/routes/Profile.svelte
+++ b/frontend/src/routes/Profile.svelte
@@ -28,7 +28,6 @@
   import RankingsWidget from "../components/profile/RankingsWidget.svelte";
   import JourneyActions from "../components/profile/JourneyActions.svelte";
   import ProgressJourney from "../components/profile/ProgressJourney.svelte";
-  import CommunityProgressJourney from "../components/profile/CommunityProgressJourney.svelte";
   import RoleView from "../components/profile/RoleView.svelte";
   import StewardView from "../components/profile/StewardView.svelte";
   import CommunityView from "../components/profile/CommunityView.svelte";
@@ -898,7 +897,7 @@
 
       <!-- Community Section -->
       {#if participant?.creator}
-        <div class="w-full mb-16 pt-10 border-t border-gray-100 mt-10">
+        <div id="community-journey-section" class="w-full mb-16 pt-10 border-t border-gray-100 mt-10">
           <CommunityView
             {participant}
             {referralData}
@@ -907,43 +906,12 @@
             {isOwnProfile}
             communityStats={communityStats}
             communityStatsLoading={!communityStatsLoaded}
+            onSocialLinked={handleCommunityLinked}
+            onClaimX={handleClaimX}
+            onClaimDiscord={handleClaimDiscord}
+            {isClaimingX}
+            {isClaimingDiscord}
           />
-        </div>
-      {/if}
-
-      <!-- Community Journey (ongoing - has creator but not completed social links) -->
-      {#if participant?.creator && !(participant?.has_community_link_x && participant?.has_community_link_discord) && isOwnProfile}
-        <div
-          id="community-journey-section"
-          class="w-full mb-16 pt-10 border-t border-gray-100 mt-10"
-        >
-          <div class="w-full flex flex-col items-start mt-8">
-            <div class="flex items-center gap-[10px] mb-4">
-              <div
-                class="relative flex-shrink-0"
-                style="width: 32px; height: 32px;"
-              >
-                <CategoryIcon category="community" mode="hexagon" size={32} />
-              </div>
-              <h2
-                class="text-[20px] font-semibold text-black"
-                style="letter-spacing: 0.4px;"
-              >
-                Community Journey
-              </h2>
-            </div>
-
-            <div class="w-full">
-              <CommunityProgressJourney
-                {participant}
-                onSocialLinked={handleCommunityLinked}
-                onClaimX={handleClaimX}
-                onClaimDiscord={handleClaimDiscord}
-                {isClaimingX}
-                {isClaimingDiscord}
-              />
-            </div>
-          </div>
         </div>
       {/if}
 


### PR DESCRIPTION
## Summary

- **Fix OAuth URLs** in CommunityProgressJourney — social link buttons now use correct `/api/auth/` routes instead of broken `/social-auth/` paths, and use full-width colored buttons instead of compact pills
- **Consolidate community metrics** from 5 cards across 2 rows to 3 cards in a single row: Community Points, Community Contributions, and Total Referrals (with inline builder/validator referral points breakdown)
- **Integrate CommunityProgressJourney into CommunityView** — removes the separate journey section from Profile.svelte, showing it conditionally within the community section when social links are incomplete
- **Redesign contribution highlight cards** — highlighted cards now use category-tinted backgrounds (orange/blue/purple) with an inline 32px gold hexagonal star icon next to the points pill; regular cards remain white with border
- **Update category colors** across all card components (ProfileHighlights, PortalHighlights, ProfileRecentContributions, HighlightCards) to support builder, validator, and community categories consistently

## Test plan
- [ ] Click "Link X" and "Link Discord" from community journey — should open correct OAuth popups
- [ ] Community section shows 3 metric cards: Points, Contributions, Referrals
- [ ] Referral card shows builder/validator points breakdown with mini hexagon icons
- [ ] Highlighted contribution cards have tinted background + inline gold star
- [ ] Regular contribution cards have white background, no star
- [ ] Community category cards use purple tinting