### PR TITLE
Fix hackathon winners data, description, and layout

### DIFF
--- a/frontend/src/components/hackathon/ProjectCard.svelte
+++ b/frontend/src/components/hackathon/ProjectCard.svelte
@@ -69,7 +69,7 @@
   let hasBg = $derived(screenshot && !isLogoOnly);
 </script>
 
-<div class="flex flex-col gap-3 w-full">
+<div class="flex flex-col gap-3 w-full h-full">
   <!-- Card Image Area -->
   <a
     href={cardHref}
@@ -140,7 +140,9 @@
 
   <!-- Description (not shown for large/grand winner variant — handled in page layout) -->
   {#if variant !== 'large' && description}
-    <p class="text-[17px] leading-[28px] text-[#6b6b6b] tracking-[0.34px]">{description}</p>
+    <p class="text-[17px] leading-[28px] text-[#6b6b6b] tracking-[0.34px] flex-1">{description}</p>
+  {:else if variant !== 'large'}
+    <div class="flex-1"></div>
   {/if}
 
   <!-- Action buttons (not shown for large/grand winner variant) -->

--- a/frontend/src/data/hackathonWinners.js
+++ b/frontend/src/data/hackathonWinners.js
@@ -3,19 +3,19 @@
 // Update this file with real winner data and Cloudinary URLs.
 
 export const hackathonStats = [
-  { value: '92', label: 'BUIDLs' },
+  { value: '135', label: 'BUIDLs' },
   { value: '280', label: 'Hackers' },
   { value: '2 Weeks', label: 'Duration' },
 ];
 
 export const trackSubmissions = [
-  { name: 'Subjective Consensus (Bradbury Special)', count: 17 },
-  { name: 'Prediction Markets & P2P Betting', count: 16 },
-  { name: 'Onchain Justice', count: 14 },
-  { name: 'Agentic Economy Infrastructure', count: 13 },
-  { name: 'AI Governance', count: 12 },
-  { name: 'AI Gaming', count: 10 },
-  { name: 'Future of Work', count: 10 },
+  { name: 'Agentic Economy Infrastructure', count: 26 },
+  { name: 'Subjective Consensus (Bradbury Special)', count: 24 },
+  { name: 'Prediction Markets & P2P Betting', count: 21 },
+  { name: 'Onchain Justice', count: 19 },
+  { name: 'AI Gaming', count: 16 },
+  { name: 'Future of Work', count: 15 },
+  { name: 'AI Governance', count: 14 },
 ];
 
 export const grandWinner = {

--- a/frontend/src/data/hackathonWinners.js
+++ b/frontend/src/data/hackathonWinners.js
@@ -24,8 +24,12 @@ export const grandWinner = {
   avatar: 'https://res.cloudinary.com/dfqmoeawa/image/upload/v1776103540/buildersclaw-logo_fhlv2d.jpg',
   screenshot: 'https://res.cloudinary.com/dfqmoeawa/image/upload/v1776103539/buildersclaw-bg_dpt9ig.png',
   category: 'Agentic Economy Infrastructure',
-  description: 'A platform where companies post coding challenges with real prize money and builders compete by shipping working code through AI agents. A GenLayer intelligent contract automatically evaluates every submission, scoring codebases against challenge requirements through multi-validator consensus. Judging is fully on-chain and verifiable — smart contracts handle escrow and payouts, so the best code wins on merit.',
-  descriptionBold: 'Companies source real solutions, builders earn by shipping, and AI consensus replaces the judging panel.',
+  descriptionIntro: 'BuildersClaw connects companies that need real code with builders ready to ship it. Companies post coding challenges with prize money, and builders compete by submitting working solutions through AI agents.',
+  descriptionBullets: [
+    'A GenLayer intelligent contract evaluates every submission automatically, scoring code against challenge requirements through multi-validator consensus.',
+    'Smart contracts handle escrow and payouts — funds are locked when a challenge is created and released to the winner once judging is complete.',
+    'All judging happens on-chain and is fully verifiable. No human panel, no subjective opinions — the best code wins on merit.',
+  ],
   links: {
     project: 'https://dorahacks.io/buidl/41425',
     youtube: 'https://www.youtube.com/watch?v=p3NGRS7TzF8',

--- a/frontend/src/data/hackathonWinners.js
+++ b/frontend/src/data/hackathonWinners.js
@@ -27,8 +27,8 @@ export const grandWinner = {
   descriptionIntro: 'BuildersClaw connects companies that need real code with builders ready to ship it. Companies post coding challenges with prize money, and builders compete by submitting working solutions through AI agents.',
   descriptionBullets: [
     'A GenLayer intelligent contract evaluates every submission automatically, scoring code against challenge requirements through multi-validator consensus.',
-    'Smart contracts handle escrow and payouts — funds are locked when a challenge is created and released to the winner once judging is complete.',
-    'All judging happens on-chain and is fully verifiable. No human panel, no subjective opinions — the best code wins on merit.',
+    'Smart contracts handle escrow and payouts. Funds are locked when a challenge is created and released to the winner once judging is complete.',
+    'All judging happens on-chain and is fully verifiable. No human panel, no subjective opinions. The best code wins on merit.',
   ],
   links: {
     project: 'https://dorahacks.io/buidl/41425',

--- a/frontend/src/data/hackathonWinners.js
+++ b/frontend/src/data/hackathonWinners.js
@@ -24,7 +24,7 @@ export const grandWinner = {
   avatar: 'https://res.cloudinary.com/dfqmoeawa/image/upload/v1776103540/buildersclaw-logo_fhlv2d.jpg',
   screenshot: 'https://res.cloudinary.com/dfqmoeawa/image/upload/v1776103539/buildersclaw-bg_dpt9ig.png',
   category: 'Agentic Economy Infrastructure',
-  description: 'Companies post coding challenges with real prize money, and builders compete by shipping working code through AI agents. A GenLayer intelligent contract evaluates every submission automatically, scoring codebases against challenge requirements through multi-validator consensus. The judging is fully on-chain and verifiable, with a two-stage evaluation pipeline and partial field matching to ensure fair, nuanced scoring. Smart contracts handle escrow and payouts, so the best code wins on merit, not opinions.',
+  description: 'A platform where companies post coding challenges with real prize money and builders compete by shipping working code through AI agents. A GenLayer intelligent contract automatically evaluates every submission, scoring codebases against challenge requirements through multi-validator consensus. Judging is fully on-chain and verifiable — smart contracts handle escrow and payouts, so the best code wins on merit.',
   descriptionBold: 'Companies source real solutions, builders earn by shipping, and AI consensus replaces the judging panel.',
   links: {
     project: 'https://dorahacks.io/buidl/41425',

--- a/frontend/src/routes/HackathonWinners.svelte
+++ b/frontend/src/routes/HackathonWinners.svelte
@@ -64,7 +64,7 @@
   $effect(() => {
     setPageMeta({
       title: 'Hackathon Winners - Testnet Bradbury',
-      description: 'Meet the winners of GenLayer\'s Testnet Bradbury Hackathon. 92 BUIDLs, 280 hackers, built in 2 weeks.',
+      description: 'Meet the winners of GenLayer\'s Testnet Bradbury Hackathon. 135 BUIDLs, 280 hackers, built in 2 weeks.',
       image: 'https://portal.genlayer.foundation/assets/hackathon_og_image.png',
       url: 'https://portal.genlayer.foundation/#/hackathon-winners',
     });
@@ -202,7 +202,7 @@
     <div class="flex-1 flex flex-col gap-4">
       <h2 class="text-[24px] md:text-[40px] font-display font-medium leading-[32px] md:leading-[48px] tracking-[-0.48px] md:tracking-[-0.8px] text-black">What happens when builders get access to AI consensus</h2>
       <p class="text-[#6b6b6b] text-[15px] md:text-[17px] leading-[24px] md:leading-[28px] tracking-[0.34px]">
-        92 teams took GenLayer's Intelligent Contracts and built products that make subjective decisions on-chain, from courtrooms to prediction markets to autonomous agent economies.
+        135 teams took GenLayer's Intelligent Contracts and built products that make subjective decisions on-chain, from courtrooms to prediction markets to autonomous agent economies.
       </p>
       <div class="space-y-2">
         <div class="flex items-center gap-3">
@@ -222,7 +222,7 @@
         Every submission pushed the boundaries of what's possible on-chain. Here are the winners.
       </p>
       <a href="https://dorahacks.io/hackathon/genlayer-bradbury/buidl" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-[#4083ea] text-[14px] font-medium tracking-[0.28px] hover:underline">
-        Explore all 92 projects →
+        Explore all 135 projects →
       </a>
 
       <!-- BUIDLs by Tracks -->

--- a/frontend/src/routes/HackathonWinners.svelte
+++ b/frontend/src/routes/HackathonWinners.svelte
@@ -314,13 +314,16 @@
       <!-- Right: Description + Action buttons -->
       <div class="flex-1 flex flex-col justify-between gap-4">
         <div class="text-[#6b6b6b] text-[15px] md:text-[17px] leading-[24px] md:leading-[28px] tracking-[0.34px]">
-          <p>
-            <strong class="text-black">{grandWinner.name}</strong> {grandWinner.description}
-          </p>
-          {#if grandWinner.descriptionBold}
-            <p class="mt-4">
-              <strong class="text-black">In short:</strong> {grandWinner.descriptionBold.replace('In short: ', '')}
-            </p>
+          <p>{grandWinner.descriptionIntro}</p>
+          {#if grandWinner.descriptionBullets}
+            <ul class="mt-3 space-y-2">
+              {#each grandWinner.descriptionBullets as bullet}
+                <li class="flex gap-2">
+                  <span class="text-[#9e4bf6] mt-[2px] shrink-0">•</span>
+                  <span>{bullet}</span>
+                </li>
+              {/each}
+            </ul>
           {/if}
         </div>
         <div class="flex gap-2 items-start w-full">


### PR DESCRIPTION
## Summary
- Restructure BuildersClaw grand winner description with clear intro and bullet points instead of flat paragraph with "In short"
- Fix track winner cards so action buttons align at the same height regardless of description length
- Update BUIDLs count from 92 to 135 across all hardcoded references (stats, meta, about section, explore link)
- Correct track submission counts and ordering to match official data