### PR TITLE
Remove mission dropdown from steward submissions filter

### DIFF
--- a/frontend/src/routes/StewardSubmissions.svelte
+++ b/frontend/src/routes/StewardSubmissions.svelte
@@ -24,7 +24,6 @@
 
   // Filters - Status dropdown + mission dropdown + search bar
   let stateFilter = $state('pending');
-  let missionFilter = $state('');
   let missions = $state([]);
   let searchQuery = $state('');
   let stewardsList = $state([]);
@@ -59,7 +58,6 @@
     // Sync filters from URL
     const params = new URLSearchParams($querystring);
     if (params.has('status')) stateFilter = params.get('status');
-    if (params.has('mission')) missionFilter = params.get('mission');
     if (params.has('q')) searchQuery = params.get('q');
 
     // Prefetch missions for both categories to warm the cache
@@ -189,7 +187,6 @@
   function updateURL() {
     const urlParams = new URLSearchParams();
     if (stateFilter) urlParams.set('status', stateFilter);
-    if (missionFilter) urlParams.set('mission', missionFilter);
     if (searchQuery) urlParams.set('q', searchQuery);
     const newUrl = urlParams.toString() ? `?${urlParams.toString()}` : '';
     window.history.replaceState({}, '', `#/stewards/submissions${newUrl}`);
@@ -218,11 +215,6 @@
       // Add status from dropdown (overrides search query if present)
       if (stateFilter) {
         params.state = stateFilter;
-      }
-
-      // Add mission filter
-      if (missionFilter) {
-        params.mission = missionFilter;
       }
 
       params.page = currentPage;
@@ -498,25 +490,6 @@
           <option value="accepted">Accepted</option>
           <option value="rejected">Rejected</option>
           <option value="more_info_needed">More Info Needed</option>
-        </select>
-      </div>
-
-      <!-- Mission Filter -->
-      <div class="w-full md:w-56 flex-shrink-0">
-        <label for="mission-filter" class="block text-sm font-medium text-gray-700 mb-1">
-          Mission
-        </label>
-        <select
-          id="mission-filter"
-          bind:value={missionFilter}
-          onchange={handleFilterChange}
-          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
-        >
-          <option value="">All</option>
-          <option value="none">No Mission</option>
-          {#each missions as mission}
-            <option value={mission.id}>{mission.name}</option>
-          {/each}
         </select>
       </div>
 


### PR DESCRIPTION
## Summary
- Remove the mission filter dropdown from the steward submissions page since mission filtering is now handled through the search bar.
- Drop the `missionFilter` state, its URL query-param sync, and the corresponding API param so the filter row only contains the status dropdown and the search input.