### PR TITLE
Stop awarding points for validator waitlist and gate submissions by role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable user-facing changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Validator Waitlist no longer awards 20 points; historical waitlist contributions are zeroed out and leaderboards rebuilt. Only selected validators (and builders, for builder contributions) can submit to those categories; ineligible users now see a category-themed explainer linking to their profile Journeys section (77a3dec)
 - Required evidence URL types per contribution type: admins can now declare one or more required URL types on a contribution type, and submissions must include at least one URL whose detected type matches; the submit form shows a dedicated required-evidence field and the edit form surfaces a live-status banner (d9c3a1c)
 - Evidence URL type detection and validation for contribution submissions with duplicate checking and handle ownership verification (3a20426)
 - Direct Cloudinary image upload from Django admin for featured content (ce4c157)

--- a/backend/contributions/migrations/0051_zero_validator_waitlist_points.py
+++ b/backend/contributions/migrations/0051_zero_validator_waitlist_points.py
@@ -1,0 +1,49 @@
+from django.db import migrations
+
+
+def zero_validator_waitlist_points(apps, schema_editor):
+    ContributionType = apps.get_model('contributions', 'ContributionType')
+    Contribution = apps.get_model('contributions', 'Contribution')
+
+    ContributionType.objects.filter(slug='validator-waitlist').update(
+        min_points=0,
+        max_points=0,
+        is_submittable=False,
+    )
+
+    Contribution.objects.filter(contribution_type__slug='validator-waitlist').update(
+        points=0,
+        frozen_global_points=0,
+    )
+
+    from leaderboard.models import recalculate_all_leaderboards
+    recalculate_all_leaderboards()
+
+
+def restore_validator_waitlist_points(apps, schema_editor):
+    # Only restores the ContributionType metadata. Per-Contribution point
+    # values are destructively overwritten by the forward operation and
+    # cannot be recovered here, so rolling this migration back leaves every
+    # historical validator-waitlist Contribution permanently at 0 points.
+    ContributionType = apps.get_model('contributions', 'ContributionType')
+
+    ContributionType.objects.filter(slug='validator-waitlist').update(
+        min_points=20,
+        max_points=20,
+        is_submittable=True,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contributions', '0050_evidence_url_types'),
+        ('leaderboard', '0014_add_referral_points_model'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            zero_validator_waitlist_points,
+            restore_validator_waitlist_points,
+        ),
+    ]

--- a/backend/contributions/tests/test_validator_category_gating.py
+++ b/backend/contributions/tests/test_validator_category_gating.py
@@ -1,0 +1,99 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from rest_framework.test import APIClient
+from rest_framework import status
+
+from contributions.models import Contribution, ContributionType, Category
+from validators.models import Validator
+
+User = get_user_model()
+
+
+class ValidatorCategorySubmitGatingTest(TestCase):
+    """Only users with a Validator profile may submit validator-category contributions.
+
+    Having the validator-waitlist contribution no longer grants submit access.
+    """
+
+    def setUp(self):
+        self.validator_category, _ = Category.objects.get_or_create(
+            slug='validator',
+            defaults={'name': 'Validator', 'description': 'Validator contributions'},
+        )
+        self.waitlist_type, _ = ContributionType.objects.get_or_create(
+            slug='validator-waitlist',
+            defaults={
+                'name': 'Validator Waitlist',
+                'description': 'Joined the validator waitlist',
+                'category': self.validator_category,
+                'min_points': 0,
+                'max_points': 0,
+            },
+        )
+        self.node_running_type, _ = ContributionType.objects.get_or_create(
+            slug='node-running',
+            defaults={
+                'name': 'Node Running',
+                'description': 'Running a validator node',
+                'category': self.validator_category,
+                'min_points': 10,
+                'max_points': 100,
+            },
+        )
+
+        self.waitlist_user = User.objects.create_user(
+            email='waitlist@test.com',
+            address='0x1111111111111111111111111111111111111111',
+            password='testpass123',
+        )
+        self.plain_user = User.objects.create_user(
+            email='plain@test.com',
+            address='0x2222222222222222222222222222222222222222',
+            password='testpass123',
+        )
+        self.validator_user = User.objects.create_user(
+            email='validator@test.com',
+            address='0x3333333333333333333333333333333333333333',
+            password='testpass123',
+        )
+        Validator.objects.create(user=self.validator_user)
+
+        Contribution.objects.create(
+            user=self.waitlist_user,
+            contribution_type=self.waitlist_type,
+            points=0,
+            frozen_global_points=0,
+            contribution_date=timezone.now(),
+        )
+
+        self.client = APIClient()
+
+    def _post_submission(self, user, contribution_type):
+        self.client.force_authenticate(user=user)
+        return self.client.post(
+            '/api/v1/submissions/',
+            {
+                'contribution_type': contribution_type.id,
+                'contribution_date': timezone.now().date().isoformat(),
+                'notes': 'Attempted submission',
+                'recaptcha': 'test-token',
+            },
+            format='json',
+        )
+
+    def test_user_without_validator_profile_is_blocked(self):
+        response = self._post_submission(self.plain_user, self.node_running_type)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn('Only validators', response.data['error'])
+
+    def test_waitlist_user_without_validator_profile_is_blocked(self):
+        """A user with only the waitlist contribution cannot submit validator contributions."""
+        response = self._post_submission(self.waitlist_user, self.node_running_type)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn('Only validators', response.data['error'])
+
+    def test_user_with_validator_profile_passes_gating(self):
+        response = self._post_submission(self.validator_user, self.node_running_type)
+        # May be 201 or 400 depending on recaptcha config, but must not be 403
+        self.assertNotEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -678,16 +678,10 @@ class SubmittedContributionViewSet(viewsets.ModelViewSet):
                             status=status.HTTP_403_FORBIDDEN
                         )
                     if contribution_type.category.slug == 'validator' and not hasattr(request.user, 'validator'):
-                        # Allow users on the validator waitlist to submit validator contributions
-                        has_waitlist = Contribution.objects.filter(
-                            user=request.user,
-                            contribution_type__slug='validator-waitlist'
-                        ).exists()
-                        if not has_waitlist:
-                            return Response(
-                                {'error': 'You must complete the Validator Waitlist journey before submitting validator contributions.'},
-                                status=status.HTTP_403_FORBIDDEN
-                            )
+                        return Response(
+                            {'error': 'Only validators can submit validator contributions. Join the Validator Waitlist to be considered for selection.'},
+                            status=status.HTTP_403_FORBIDDEN
+                        )
                     # Check required social accounts for this contribution type
                     if contribution_type.required_social_accounts:
                         connection_map = {

--- a/backend/leaderboard/tests/test_recalculation.py
+++ b/backend/leaderboard/tests/test_recalculation.py
@@ -47,10 +47,15 @@ class LeaderboardRecalculationTest(TestCase):
                 'name': 'Validator Waitlist',
                 'description': 'Join the validator waitlist',
                 'category': self.validator_category,
-                'min_points': 1,
-                'max_points': 1
+                'min_points': 0,
+                'max_points': 0
             }
         )
+        # Waitlist contributions are 0-point flags; force bounds in case
+        # a previous migration left them at non-zero values.
+        self.waitlist_type.min_points = 0
+        self.waitlist_type.max_points = 0
+        self.waitlist_type.save()
         
         self.validator_type, _ = ContributionType.objects.get_or_create(
             slug='validator',
@@ -153,15 +158,15 @@ class LeaderboardRecalculationTest(TestCase):
     
     def test_recalculate_all_leaderboards_with_waitlist(self):
         """Test recalculation with waitlist users."""
-        # Create waitlist contributions
+        # Create waitlist contribution (0-point flag)
         Contribution.objects.create(
             user=self.user1,
             contribution_type=self.waitlist_type,
-            points=1,
-            frozen_global_points=1,
+            points=0,
+            frozen_global_points=0,
             contribution_date=timezone.now() - timezone.timedelta(days=10)
         )
-        
+
         Contribution.objects.create(
             user=self.user1,
             contribution_type=self.node_running_type,
@@ -169,34 +174,34 @@ class LeaderboardRecalculationTest(TestCase):
             frozen_global_points=100,  # 50 * 2.0 multiplier
             contribution_date=timezone.now() - timezone.timedelta(days=5)
         )
-        
+
         # Recalculate
         result = recalculate_all_leaderboards()
-        
+
         # Check result
         self.assertIn('1 users', result)
         self.assertIn('4 leaderboards', result)
-        
+
         # Check user is on waitlist leaderboard
         waitlist_entry = LeaderboardEntry.objects.filter(
             user=self.user1,
             type='validator-waitlist'
         ).first()
         self.assertIsNotNone(waitlist_entry)
-        self.assertEqual(waitlist_entry.total_points, 101)  # 1 + 100
+        self.assertEqual(waitlist_entry.total_points, 100)  # 0 + 100
         self.assertEqual(waitlist_entry.rank, 1)
     
     def test_recalculate_with_graduation(self):
         """Test recalculation when user graduates from waitlist to validator."""
-        # User starts on waitlist
+        # User starts on waitlist (0-point flag)
         Contribution.objects.create(
             user=self.user1,
             contribution_type=self.waitlist_type,
-            points=1,
-            frozen_global_points=1,
+            points=0,
+            frozen_global_points=0,
             contribution_date=timezone.now() - timezone.timedelta(days=10)
         )
-        
+
         # Add some validator category contributions
         Contribution.objects.create(
             user=self.user1,
@@ -261,21 +266,21 @@ class LeaderboardRecalculationTest(TestCase):
     
     def test_recalculate_with_multiple_users(self):
         """Test recalculation with multiple users in different states."""
-        # User 1: On waitlist
+        # User 1: On waitlist (0-point flag)
         Contribution.objects.create(
             user=self.user1,
             contribution_type=self.waitlist_type,
-            points=1,
-            frozen_global_points=1,
+            points=0,
+            frozen_global_points=0,
             contribution_date=timezone.now() - timezone.timedelta(days=10)
         )
-        
+
         # User 2: Graduated validator
         Contribution.objects.create(
             user=self.user2,
             contribution_type=self.waitlist_type,
-            points=1,
-            frozen_global_points=1,
+            points=0,
+            frozen_global_points=0,
             contribution_date=timezone.now() - timezone.timedelta(days=20)
         )
         Contribution.objects.create(
@@ -297,8 +302,8 @@ class LeaderboardRecalculationTest(TestCase):
         Contribution.objects.create(
             user=self.user3,
             contribution_type=self.waitlist_type,
-            points=1,
-            frozen_global_points=1,
+            points=0,
+            frozen_global_points=0,
             contribution_date=timezone.now() - timezone.timedelta(days=10)
         )
         
@@ -419,12 +424,12 @@ class LeaderboardRecalculationTest(TestCase):
     
     def test_frozen_graduation_points(self):
         """Test that graduation points are properly frozen."""
-        # User on waitlist with some points
+        # User on waitlist (0-point flag)
         Contribution.objects.create(
             user=self.user1,
             contribution_type=self.waitlist_type,
-            points=1,
-            frozen_global_points=1,
+            points=0,
+            frozen_global_points=0,
             contribution_date=timezone.now() - timezone.timedelta(days=10)
         )
         Contribution.objects.create(

--- a/backend/leaderboard/tests/test_referral_points.py
+++ b/backend/leaderboard/tests/test_referral_points.py
@@ -36,8 +36,8 @@ class ReferralPointsExclusionTest(TestCase):
             slug='validator-waitlist',
             description='Joined the validator waitlist',
             category=self.validator_category,
-            min_points=20,
-            max_points=20,
+            min_points=0,
+            max_points=0,
         )
         self.node_running_type = ContributionType.objects.create(
             name='Node Running',
@@ -102,7 +102,7 @@ class ReferralPointsExclusionTest(TestCase):
     def test_validator_waitlist_excluded_from_referral_sum(self):
         """Referred user with only validator-waitlist should give referrer 0 validator referral points."""
         # Give referred user the waitlist badge + a builder contribution (so they pass eligibility gate)
-        self._create_contribution(self.referred_user, self.waitlist_type, 20)
+        self._create_contribution(self.referred_user, self.waitlist_type, 0)
         self._create_contribution(self.referred_user, self.blog_type, 50)
 
         # Trigger referral update
@@ -131,7 +131,7 @@ class ReferralPointsExclusionTest(TestCase):
 
     def test_mixed_contributions_excludes_badge(self):
         """Referred user with waitlist (20) + node-running (100) should give referrer 10, not 12."""
-        self._create_contribution(self.referred_user, self.waitlist_type, 20)
+        self._create_contribution(self.referred_user, self.waitlist_type, 0)
         self._create_contribution(self.referred_user, self.node_running_type, 100)
 
         contribution = Contribution.objects.filter(
@@ -145,14 +145,14 @@ class ReferralPointsExclusionTest(TestCase):
 
     def test_eligible_user_filter_unchanged(self):
         """Eligibility gate still works: user with ONLY onboarding badges is not eligible."""
-        self._create_contribution(self.referred_user, self.waitlist_type, 20)
+        self._create_contribution(self.referred_user, self.waitlist_type, 0)
 
         eligible_ids = get_eligible_referred_user_ids(self.referrer)
         self.assertEqual(len(eligible_ids), 0)
 
     def test_eligible_user_with_real_contribution(self):
         """User with real contribution passes eligibility gate."""
-        self._create_contribution(self.referred_user, self.waitlist_type, 20)
+        self._create_contribution(self.referred_user, self.waitlist_type, 0)
         self._create_contribution(self.referred_user, self.node_running_type, 100)
 
         eligible_ids = get_eligible_referred_user_ids(self.referrer)
@@ -160,7 +160,7 @@ class ReferralPointsExclusionTest(TestCase):
 
     def test_recalculate_matches_update(self):
         """recalculate_referrer_points gives same result as update_referrer_points."""
-        self._create_contribution(self.referred_user, self.waitlist_type, 20)
+        self._create_contribution(self.referred_user, self.waitlist_type, 0)
         self._create_contribution(self.referred_user, self.node_running_type, 100)
         self._create_contribution(self.referred_user, self.blog_type, 50)
 
@@ -207,8 +207,8 @@ class ReferralBreakdownHelperTest(TestCase):
             slug='validator-waitlist',
             description='Joined the validator waitlist',
             category=self.validator_category,
-            min_points=20,
-            max_points=20,
+            min_points=0,
+            max_points=0,
         )
         self.node_running_type = ContributionType.objects.create(
             name='Node Running',
@@ -301,7 +301,7 @@ class ReferralBreakdownHelperTest(TestCase):
 
     def test_excludes_validator_waitlist_from_per_user_breakdown(self):
         """Per-user validator points exclude validator-waitlist contributions."""
-        self._create_contribution(self.referred_user_a, self.waitlist_type, 20)
+        self._create_contribution(self.referred_user_a, self.waitlist_type, 0)
         self._create_contribution(self.referred_user_a, self.node_running_type, 100)
 
         # Trigger stored referral point calculation

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -421,7 +421,7 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
             contribution = Contribution.objects.create(
                 user=user,
                 contribution_type=waitlist_type,
-                points=20,
+                points=0,
                 contribution_date=timezone.now(),
                 notes='Joined the validator waitlist'
             )

--- a/frontend/src/components/portal/submit-contribution/SubmitContribution.svelte
+++ b/frontend/src/components/portal/submit-contribution/SubmitContribution.svelte
@@ -16,6 +16,9 @@
   let submitting = $state(false);
   let error = $state("");
 
+  let isValidator = $derived(!!$userStore.user?.validator);
+  let isBuilder = $derived(!!$userStore.user?.builder);
+
   // reCAPTCHA state
   let recaptchaToken = $state("");
   let recaptchaWidgetId = $state(null);
@@ -26,6 +29,48 @@
   let missions = $state([]);
   let loadingTypes = $state(true);
   let selectedCategory = $state("builder"); // Default to builder
+  let canSubmitCurrentCategory = $derived.by(() => {
+    if (selectedCategory === "validator") return isValidator;
+    if (selectedCategory === "builder") return isBuilder;
+    return true;
+  });
+
+  let journeysHref = $derived(
+    $userStore.user?.address
+      ? `#/participant/${$userStore.user.address}`
+      : "#/",
+  );
+
+  let gatingTheme = $derived.by(() => {
+    if (selectedCategory === "validator") {
+      return {
+        bg: "bg-blue-50",
+        border: "border-blue-200",
+        icon: "text-blue-500",
+        title: "text-blue-900",
+        body: "text-blue-800",
+        link: "text-blue-700 hover:text-blue-900",
+      };
+    }
+    if (selectedCategory === "builder") {
+      return {
+        bg: "bg-orange-50",
+        border: "border-orange-200",
+        icon: "text-orange-500",
+        title: "text-orange-900",
+        body: "text-orange-800",
+        link: "text-orange-700 hover:text-orange-900",
+      };
+    }
+    return {
+      bg: "bg-purple-50",
+      border: "border-purple-200",
+      icon: "text-purple-500",
+      title: "text-purple-900",
+      body: "text-purple-800",
+      link: "text-purple-700 hover:text-purple-900",
+    };
+  });
   let selectedType = $state(null);
   let selectedMission = $state(null);
   let selectedMissionData = $state(null);
@@ -791,7 +836,58 @@
         </button>
       </div>
 
+      {#if !canSubmitCurrentCategory}
+        <div
+          class="flex items-start gap-3 rounded-[8px] border {gatingTheme.border} {gatingTheme.bg} p-4"
+        >
+          <svg
+            class="h-5 w-5 flex-shrink-0 {gatingTheme.icon} mt-0.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M13 16h-1v-4h-1m1-4h.01M12 20a8 8 0 100-16 8 8 0 000 16z"
+            />
+          </svg>
+          <div class="flex flex-col gap-1">
+            {#if selectedCategory === "validator"}
+              <p class="text-sm font-semibold {gatingTheme.title}">
+                Validators only
+              </p>
+              <p class="text-sm {gatingTheme.body}">
+                This category is reserved for selected validators. Start your
+                validator journey from your profile to be considered.
+              </p>
+              <a
+                href={journeysHref}
+                class="text-sm font-medium underline {gatingTheme.link} mt-1"
+                >Go to your journeys</a
+              >
+            {:else if selectedCategory === "builder"}
+              <p class="text-sm font-semibold {gatingTheme.title}">
+                Builders only
+              </p>
+              <p class="text-sm {gatingTheme.body}">
+                Complete your Builder journey from your profile to unlock
+                builder submissions.
+              </p>
+              <a
+                href={journeysHref}
+                class="text-sm font-medium underline {gatingTheme.link} mt-1"
+                >Go to your journeys</a
+              >
+            {/if}
+          </div>
+        </div>
+      {/if}
+
       <!-- Type Search/Dropdown Selection -->
+      {#if canSubmitCurrentCategory}
       <div class="relative w-full" bind:this={dropdownRef}>
         <div
           class="border {error && !formData.contribution_type
@@ -917,6 +1013,7 @@
           </div>
         {/if}
       </div>
+      {/if}
 
       <!-- Selection Info (shows details of selected type or mission) -->
       {#if selectedType && !showTypeDropdown}
@@ -1345,7 +1442,7 @@
     <div class="flex gap-[8px] items-center mt-2 pb-[60px]">
       <button
         type="submit"
-        disabled={submitting || evidenceRequiredAccounts.length > 0 || hasEvidencePatternMismatch}
+        disabled={submitting || !canSubmitCurrentCategory || evidenceRequiredAccounts.length > 0 || hasEvidencePatternMismatch}
         class="bg-[#9e4bf6] flex gap-[8px] h-[40px] items-center justify-center px-[20px] rounded-[20px] hover:bg-[#8b3ced] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
       >
         <span


### PR DESCRIPTION
## Summary
- Validator Waitlist no longer awards 20 points; a data migration zeroes existing waitlist contributions and rebuilds all leaderboards. The waitlist record is preserved so users still appear on the waitlist leaderboard.
- Submit-contribution flow now gates both validator- and builder-category types by role (Validator / Builder profile). Ineligible users see a category-themed explainer linking to their profile "Your Journeys" section instead of the type dropdown.
- Backend tests updated to match the zero-point waitlist; new test file covers the new category gating paths.

## Test plan
- [ ] Run \`python manage.py migrate\` on a copy of the dev DB; verify \`ContributionType(validator-waitlist).min_points/max_points == 0\`, every waitlist Contribution has \`points == frozen_global_points == 0\`, and leaderboard totals for affected users drop by exactly 20 per waitlist contribution.
- [ ] \`python manage.py test contributions leaderboard users\` — all green.
- [ ] As a non-validator, POST a validator-category contribution → 403. As a validator → 201.
- [ ] Frontend: log in as builder (no validator profile) — builder and community tabs work normally; validator tab shows the blue explainer linking to Journeys. Log in as validator — validator tab works. Log in as user with neither role — both builder (orange) and validator (blue) panels show and link to Journeys.
- [ ] POST /api/v1/users/start_validator_journey/ creates the waitlist contribution with 0 points.