### PR TITLE
Fix admin crash on contribution type from orphaned M2M migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable user-facing changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Fix admin 500 when opening a contribution type: the `required_evidence_url_types` M2M was folded into an already-applied migration, so environments on the previous 0050 never got the table. Split it into its own migration so it actually runs (1bc0024)
 - Validator Waitlist no longer awards 20 points; historical waitlist contributions are zeroed out and leaderboards rebuilt. Only selected validators (and builders, for builder contributions) can submit to those categories; ineligible users now see a category-themed explainer linking to their profile Journeys section (77a3dec)
 - Required evidence URL types per contribution type: admins can now declare one or more required URL types on a contribution type, and submissions must include at least one URL whose detected type matches; the submit form shows a dedicated required-evidence field and the edit form surfaces a live-status banner (d9c3a1c)
 - Evidence URL type detection and validation for contribution submissions with duplicate checking and handle ownership verification (3a20426)

--- a/backend/contributions/migrations/0050_evidence_url_types.py
+++ b/backend/contributions/migrations/0050_evidence_url_types.py
@@ -164,21 +164,6 @@ class Migration(migrations.Migration):
             name='accepted_evidence_url_types',
             field=models.ManyToManyField(blank=True, help_text='Accepted evidence URL types. Empty means all types are accepted.', related_name='contribution_types', to='contributions.evidenceurltype'),
         ),
-        # 2b. Add "required" M2M on ContributionType: at least one submitted
-        #     URL must match one of these; required types are implicitly accepted.
-        migrations.AddField(
-            model_name='contributiontype',
-            name='required_evidence_url_types',
-            field=models.ManyToManyField(
-                blank=True,
-                help_text=(
-                    'If set, at least one submitted evidence URL must match one of '
-                    'these types. Required types are implicitly accepted.'
-                ),
-                related_name='required_by_contribution_types',
-                to='contributions.evidenceurltype',
-            ),
-        ),
         # 3. Add FK on Evidence
         migrations.AddField(
             model_name='evidence',

--- a/backend/contributions/migrations/0052_contributiontype_required_evidence_url_types.py
+++ b/backend/contributions/migrations/0052_contributiontype_required_evidence_url_types.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contributions', '0051_zero_validator_waitlist_points'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='contributiontype',
+            name='required_evidence_url_types',
+            field=models.ManyToManyField(
+                blank=True,
+                help_text=(
+                    'If set, at least one submitted evidence URL must match one of '
+                    'these types. Required types are implicitly accepted.'
+                ),
+                related_name='required_by_contribution_types',
+                to='contributions.evidenceurltype',
+            ),
+        ),
+    ]


### PR DESCRIPTION
## Summary
Opening a contribution type in the Django admin 500s on dev with `relation "contributions_contributiontype_required_evidence_url_types" does not exist`. Root cause: commit d9c3a1c appended the `required_evidence_url_types` M2M `AddField` to migration 0050 *in place* after 0050 had already been deployed, and Django keys applied migrations by name — so the edit was silently skipped and the through-table never got created.

## Fix
- Remove the retroactively-added `AddField` from `0050_evidence_url_types.py` so the file matches what was originally deployed.
- Add `0052_contributiontype_required_evidence_url_types.py` with that `AddField`, so Django actually runs it on environments stuck on the old 0050. `makemigrations --check` reports no drift; `sqlmigrate 0052` creates exactly the missing table.

## Test plan
- [ ] Deploy to dev and confirm `migrate` applies 0052.
- [ ] Verify `/admin/contributions/contributiontype/42/change/` loads without error.
- [ ] Edit a contribution type and save required evidence URL types.