### PR TITLE
Truncate hero card title to one line and description to two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable user-facing changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Overview hero banner card now clamps the project title to one line and the description to two lines, with ellipsis on overflow (4368281)
 - Overview hero banner is more compact on desktop and no longer leaves a large empty gap inside the text card when the description is short or the View Project button is missing; titles and descriptions now ellipsize cleanly when they overflow (2e75620)
 - Overview hero banner now keeps a fixed-height text card and a steadier image ratio across descriptions and the optional View Project button; profile X and GitHub pills link out to those platforms, the banner gradient only renders when no banner image is uploaded, and Community XP is renamed to Community Points. Referral points no longer count Builder, Builder Welcome, or Validator Waitlist contributions from referred users (a04d4a5)
 - Mission-host contribution types: admins can mark a non-submittable type as visible in the public Contributions list so it appears alongside submittable types; direct submissions to non-submittable types are blocked server-side and users are routed through an active mission. Contribution cards and profile history now show the mission name with the parent type as a subtitle, so past submissions keep their mission identity after a mission ends. The portal submit form shows inline per-slot URL errors and rejects pasted non-URL content (a5b7d7f)

--- a/frontend/src/components/portal/HeroBanner.svelte
+++ b/frontend/src/components/portal/HeroBanner.svelte
@@ -134,10 +134,10 @@
             <img src="/assets/icons/verified-badge-fill.svg" alt="Verified" class="w-4 h-4 flex-shrink-0">
           </div>
         {/if}
-        <h2 class="font-display text-[32px] font-medium text-white leading-[38px] line-clamp-2 h-[76px] overflow-hidden" style="letter-spacing: -1.28px;">
+        <h2 class="font-display text-[32px] font-medium text-white leading-[38px] line-clamp-1 h-[38px] overflow-hidden" style="letter-spacing: -1.28px;">
           {hero.title}
         </h2>
-        <p class="text-white/80 text-sm max-w-[280px] line-clamp-3 h-[60px] overflow-hidden" style="letter-spacing: 0.28px;">
+        <p class="text-white/80 text-sm max-w-[280px] line-clamp-2 h-[40px] overflow-hidden" style="letter-spacing: 0.28px;">
           {hero.description}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- Hero card title now clamps to a single line with ellipsis, description clamps to two lines with ellipsis.
- Title and description slot heights tightened so the frosted-glass card shrinks to fit the reduced content.

## Test plan
- [ ] Visit Overview, verify featured hero card with long title shows one line + ellipsis.
- [ ] Verify long description truncates to two lines + ellipsis.
- [ ] Confirm card and outer banner still align cleanly across desktop, tablet, and mobile.