### PR TITLE
Wire Twitter and Discord OAuth redirect URIs into App Runner deploy

### DIFF
--- a/backend/deploy-apprunner.sh
+++ b/backend/deploy-apprunner.sh
@@ -224,9 +224,11 @@ if aws apprunner describe-service --service-arn arn:aws:apprunner:$REGION:$ACCOU
           "SOCIAL_ENCRYPTION_KEY": "$SSM_PREFIX/prod/social_encryption_key",
           "TWITTER_CLIENT_ID": "$SSM_PREFIX/prod/twitter_client_id",
           "TWITTER_CLIENT_SECRET": "$SSM_PREFIX/prod/twitter_client_secret",
+          "TWITTER_REDIRECT_URI": "$SSM_PREFIX/prod/twitter_redirect_uri",
           "DISCORD_CLIENT_ID": "$SSM_PREFIX/prod/discord_client_id",
           "DISCORD_CLIENT_SECRET": "$SSM_PREFIX/prod/discord_client_secret",
-          "DISCORD_GUILD_ID": "$SSM_PREFIX/prod/discord_guild_id"
+          "DISCORD_GUILD_ID": "$SSM_PREFIX/prod/discord_guild_id",
+          "DISCORD_REDIRECT_URI": "$SSM_PREFIX/prod/discord_redirect_uri"
         },
         "StartCommand": "./startup.sh gunicorn --bind 0.0.0.0:8000 --timeout 180 --workers 2 tally.wsgi:application"
       },
@@ -319,9 +321,11 @@ else
           "SOCIAL_ENCRYPTION_KEY": "$SSM_PREFIX/prod/social_encryption_key",
           "TWITTER_CLIENT_ID": "$SSM_PREFIX/prod/twitter_client_id",
           "TWITTER_CLIENT_SECRET": "$SSM_PREFIX/prod/twitter_client_secret",
+          "TWITTER_REDIRECT_URI": "$SSM_PREFIX/prod/twitter_redirect_uri",
           "DISCORD_CLIENT_ID": "$SSM_PREFIX/prod/discord_client_id",
           "DISCORD_CLIENT_SECRET": "$SSM_PREFIX/prod/discord_client_secret",
-          "DISCORD_GUILD_ID": "$SSM_PREFIX/prod/discord_guild_id"
+          "DISCORD_GUILD_ID": "$SSM_PREFIX/prod/discord_guild_id",
+          "DISCORD_REDIRECT_URI": "$SSM_PREFIX/prod/discord_redirect_uri"
         },
         "StartCommand": "./startup.sh gunicorn --bind 0.0.0.0:8000 --timeout 180 --workers 2 tally.wsgi:application"
       },


### PR DESCRIPTION
## Summary
- Adds `TWITTER_REDIRECT_URI` and `DISCORD_REDIRECT_URI` to the prod App Runner deploy script, in both the create and update branches.
- Without these mappings, prod fell back to the defaults derived from `BACKEND_URL` in `settings.py`, so the URIs sent to X and Discord could not be controlled via SSM.
- Mirrors how `deploy-apprunner-dev.sh` already wires these variables.

## Why
- Discord rejected the OAuth flow with `Invalid OAuth2 redirect_uri` because the URI sent by the backend was not in Discord's allowlist and could not be overridden without a code change.
- Twitter OAuth had a related env-var gap (combined with the missing `SOCIAL_ENCRYPTION_KEY`).
- Now that the SSM parameters `/tally/prod/twitter_redirect_uri` and `/tally/prod/discord_redirect_uri` exist, this PR connects them to the running service on the next deploy.

## Test plan
- [ ] Run `./backend/deploy-apprunner.sh` and confirm the new env vars appear in the App Runner service configuration.
- [ ] After deploy, hit `GET /api/auth/discord/?redirect=...` and confirm the redirect target uses the App Runner host.
- [ ] After deploy, hit `GET /api/auth/twitter/?redirect=...` and confirm Twitter no longer 500s (requires `SOCIAL_ENCRYPTION_KEY` to also be set in SSM).
- [ ] Verify both redirect URIs are registered exactly in the Discord and X developer portals.