### PR TITLE
Wire Twitter and Discord OAuth redirect URIs into App Runner deploy (…

### DIFF
--- a/backend/deploy-apprunner.sh
+++ b/backend/deploy-apprunner.sh
@@ -224,9 +224,11 @@ if aws apprunner describe-service --service-arn arn:aws:apprunner:$REGION:$ACCOU
           "SOCIAL_ENCRYPTION_KEY": "$SSM_PREFIX/prod/social_encryption_key",
           "TWITTER_CLIENT_ID": "$SSM_PREFIX/prod/twitter_client_id",
           "TWITTER_CLIENT_SECRET": "$SSM_PREFIX/prod/twitter_client_secret",
+          "TWITTER_REDIRECT_URI": "$SSM_PREFIX/prod/twitter_redirect_uri",
           "DISCORD_CLIENT_ID": "$SSM_PREFIX/prod/discord_client_id",
           "DISCORD_CLIENT_SECRET": "$SSM_PREFIX/prod/discord_client_secret",
-          "DISCORD_GUILD_ID": "$SSM_PREFIX/prod/discord_guild_id"
+          "DISCORD_GUILD_ID": "$SSM_PREFIX/prod/discord_guild_id",
+          "DISCORD_REDIRECT_URI": "$SSM_PREFIX/prod/discord_redirect_uri"
         },
         "StartCommand": "./startup.sh gunicorn --bind 0.0.0.0:8000 --timeout 180 --workers 2 tally.wsgi:application"
       },
@@ -319,9 +321,11 @@ else
           "SOCIAL_ENCRYPTION_KEY": "$SSM_PREFIX/prod/social_encryption_key",
           "TWITTER_CLIENT_ID": "$SSM_PREFIX/prod/twitter_client_id",
           "TWITTER_CLIENT_SECRET": "$SSM_PREFIX/prod/twitter_client_secret",
+          "TWITTER_REDIRECT_URI": "$SSM_PREFIX/prod/twitter_redirect_uri",
           "DISCORD_CLIENT_ID": "$SSM_PREFIX/prod/discord_client_id",
           "DISCORD_CLIENT_SECRET": "$SSM_PREFIX/prod/discord_client_secret",
-          "DISCORD_GUILD_ID": "$SSM_PREFIX/prod/discord_guild_id"
+          "DISCORD_GUILD_ID": "$SSM_PREFIX/prod/discord_guild_id",
+          "DISCORD_REDIRECT_URI": "$SSM_PREFIX/prod/discord_redirect_uri"
         },
         "StartCommand": "./startup.sh gunicorn --bind 0.0.0.0:8000 --timeout 180 --workers 2 tally.wsgi:application"
       },


### PR DESCRIPTION
…#573)

The App Runner deploy configuration did not map TWITTER_REDIRECT_URI or DISCORD_REDIRECT_URI from SSM, so prod fell back to the defaults derived from BACKEND_URL in settings.py. That made it impossible to point OAuth at the App Runner host without a code change, and contributed to the "Invalid OAuth2 redirect_uri" failure on Discord and the broken Twitter flow.

Both env vars are now wired into the create and update branches of the prod deploy script, mirroring how the dev script already handles them.

## Claude Implementation Notes
- backend/deploy-apprunner.sh: Add TWITTER_REDIRECT_URI and DISCORD_REDIRECT_URI entries to RuntimeEnvironmentSecrets in both the update and create branches.