### PR TITLE
Shorten OAuth popup redirect to origin to stay under X's 500-char state limit

### DIFF
--- a/frontend/src/components/SocialLink.svelte
+++ b/frontend/src/components/SocialLink.svelte
@@ -178,7 +178,7 @@
     isLinking = true;
 
     const backendUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000';
-    const redirectUrl = encodeURIComponent(window.location.href);
+    const redirectUrl = encodeURIComponent(`${window.location.origin}/`);
     const oauthUrl = `${backendUrl}${initiateUrl}?redirect=${redirectUrl}`;
 
     clearPopupMonitor();


### PR DESCRIPTION
## Summary
- The OAuth initiate flow was sending the user's full current URL (often a deep route like \`/#/participant/0xaf...\`) as the popup's redirect target.
- After the backend wraps that URL together with the encrypted PKCE \`code_verifier\` into a signed state token, the result can exceed X's documented 500-character limit on the \`state\` parameter, causing initiate to 500 with \`Unable to initiate Twitter OAuth\`.
- The popup's landing URL is throwaway — \`App.svelte\` reads the OAuth result query params on any frontend page, posts the result back to the opener, and the popup closes. The opener already sits on the deep page, so the popup only needs to land on the origin.

## Why this fixes the prod regression
- Dev was unaffected because dev URLs (\`localhost:5173\`) are short enough that even the full \`window.location.href\` keeps the signed state under 500 chars.
- Prod's \`https://portal.genlayer.foundation/#/participant/0xaf...\` is ~89 chars, which combined with the Fernet-encrypted code_verifier added in #532 / Twitter PKCE migration pushes the state past the 500-char cap.
- Reducing the redirect to \`window.location.origin + '/'\` (~35 chars) saves enough headroom on every platform (X, Discord, GitHub) to stay safely under the limit.

## Test plan
- [ ] From the homepage, link an X account end to end and confirm the popup closes and the parent shows the success toast.
- [ ] From a deep route (e.g. \`/#/participant/<address>\`), repeat the flow and confirm no 500.
- [ ] Repeat for Discord and GitHub.
- [ ] Verify the parent window stays on its original page after linking (it should — \`App.svelte\` only acts on the popup).