### PR TITLE
Shorten OAuth popup redirect to origin to stay under X's 500-char sta…

### DIFF
--- a/frontend/src/components/SocialLink.svelte
+++ b/frontend/src/components/SocialLink.svelte
@@ -178,7 +178,7 @@
     isLinking = true;
 
     const backendUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000';
-    const redirectUrl = encodeURIComponent(window.location.href);
+    const redirectUrl = encodeURIComponent(`${window.location.origin}/`);
     const oauthUrl = `${backendUrl}${initiateUrl}?redirect=${redirectUrl}`;
 
     clearPopupMonitor();


### PR DESCRIPTION
…te limit (#575)

The OAuth initiate flow was sending the user's full current URL (often a deep participant route like /#/participant/0xaf...) as the popup's redirect target. After the backend wraps that URL plus the encrypted PKCE code_verifier into a signed state token, the result can exceed X's documented 500-character limit on the state parameter, causing the initiate request to bail out with a 500.

The popup's landing URL is throwaway: App.svelte detects the OAuth result query params on any frontend page, posts the result back to the opener, and the popup closes. The opener already sits on the deep page, so we can safely point the popup at window.location.origin instead of the full href.

## Claude Implementation Notes
- frontend/src/components/SocialLink.svelte: Build the OAuth redirect from window.location.origin instead of window.location.href so the signed state token stays under X's 500-character cap on long deep-link routes.