### PR TITLE
Polish profile rank widget and CTA messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable user-facing changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Profile Ranking widget hides the Community tab and shows community points that match the Community section, the bottom CTA banner skips users tied with the viewer when computing the next rank and greets rank-1 users with a category-aware message, and the Profile Edit banner drops the purple gradient overlay once a banner image is uploaded (d74f7fd)
 - Overview hero banner card now clamps the project title to one line and the description to two lines, with ellipsis on overflow (4368281)
 - Overview hero banner is more compact on desktop and no longer leaves a large empty gap inside the text card when the description is short or the View Project button is missing; titles and descriptions now ellipsize cleanly when they overflow (2e75620)
 - Overview hero banner now keeps a fixed-height text card and a steadier image ratio across descriptions and the optional View Project button; profile X and GitHub pills link out to those platforms, the banner gradient only renders when no banner image is uploaded, and Community XP is renamed to Community Points. Referral points no longer count Builder, Builder Welcome, or Validator Waitlist contributions from referred users (a04d4a5)

--- a/frontend/src/components/profile/RankingsWidget.svelte
+++ b/frontend/src/components/profile/RankingsWidget.svelte
@@ -9,6 +9,7 @@
         isOwnProfile = false,
         builderStats = null,
         validatorStats = null,
+        communityStats = null,
         overallPoints = 0,
         referralPoints = { builder_points: 0, validator_points: 0 },
     } = $props();
@@ -30,7 +31,6 @@
         const tabs = [];
         if (isBuilder) tabs.push("Builders");
         if (isValidator) tabs.push("Validators");
-        if (isCreator) tabs.push("Community");
         return tabs;
     });
 
@@ -56,11 +56,6 @@
         activeList = [];
 
         try {
-            if (tab === "Community") {
-                await loadCommunityTab();
-                return;
-            }
-
             let apiType;
             if (tab === "Builders") apiType = "builder";
             else if (tab === "Validators") {
@@ -145,75 +140,6 @@
         }
     }
 
-    async function loadCommunityTab() {
-        try {
-            const topRes = await (leaderboardAPI as any).getCommunity({
-                limit: 4,
-                user_address: participant?.address,
-            });
-
-            const results = topRes.data?.results || [];
-            const userRankFromApi = topRes.data?.user_rank;
-
-            if (userRankFromApi) {
-                communityRank = userRankFromApi;
-            }
-
-            const top4 = results.map((u: any) => ({
-                user_address: u.address,
-                user_name: u.name,
-                name: u.name,
-                address: u.address,
-                profile_image_url: u.profile_image_url,
-                total_points: u.total_points || u.total_referral_points || 0,
-                points: u.total_points || u.total_referral_points || 0,
-                _displayRank: u.rank,
-            }));
-
-            const userInTop4 = top4.some(
-                (u: any) =>
-                    u.address?.toLowerCase() ===
-                    participant?.address?.toLowerCase(),
-            );
-
-            if (userInTop4 || !participant || !userRankFromApi) {
-                activeList = top4;
-            } else {
-                const offset = Math.max(0, userRankFromApi - 2);
-                const contextRes = await (leaderboardAPI as any).getCommunity({
-                    limit: 3,
-                    offset: offset,
-                });
-                const contextUsers = (contextRes.data?.results || []).map(
-                    (u: any) => ({
-                        user_address: u.address,
-                        user_name: u.name,
-                        name: u.name,
-                        address: u.address,
-                        profile_image_url: u.profile_image_url,
-                        total_points:
-                            u.total_points || u.total_referral_points || 0,
-                        points: u.total_points || u.total_referral_points || 0,
-                        _displayRank: u.rank,
-                    }),
-                );
-
-                let constructedList = [];
-                if (top4.length > 0) {
-                    constructedList.push(top4[0]);
-                }
-                constructedList.push({ isEllipsis: true });
-                constructedList.push(...contextUsers);
-                activeList = constructedList;
-            }
-        } catch (err) {
-            console.error(err);
-            error = "Failed to load community leaderboard";
-        } finally {
-            loading = false;
-        }
-    }
-
     let initializedForAddress = $state(null);
 
     $effect(() => {
@@ -288,10 +214,7 @@
         );
     }
 
-    let userCommunityPoints = $derived(
-        (referralPoints?.builder_points || 0) +
-            (referralPoints?.validator_points || 0),
-    );
+    let userCommunityPoints = $derived(communityStats?.totalPoints || 0);
 
     let rightPanelStats = $derived({
         builder: participant?.leaderboard_entries?.find(
@@ -337,6 +260,7 @@
 
         <!-- Main Content Layout -->
         <div class="flex flex-col lg:flex-row gap-6">
+            {#if availableTabs.length > 0}
             <!-- Left: Leaderboard (50%) -->
             <div class="w-full lg:w-1/2 flex flex-col pt-2 min-h-[300px]">
                 <!-- Tabs Header -->
@@ -384,23 +308,6 @@
                     {:else if error}
                         <div class="text-sm text-gray-500 py-4 text-center">
                             {error}
-                        </div>
-                    {:else if activeTab === "Community" && userCommunityPoints === 0}
-                        <div
-                            class="flex flex-col items-center justify-center py-8 px-4 text-center"
-                        >
-                            <CategoryIcon
-                                category="community"
-                                mode="hexagon"
-                                size={40}
-                            />
-                            <p class="text-[14px] font-medium text-black mt-3">
-                                No ranking yet
-                            </p>
-                            <p class="text-[13px] text-[#6b6b6b] mt-1">
-                                Refer at least one user to appear in the
-                                community ranking
-                            </p>
                         </div>
                     {:else if activeList.length === 0}
                         <div class="text-sm text-gray-500 py-4 text-center">
@@ -496,9 +403,14 @@
                     {/if}
                 </div>
             </div>
+            {/if}
 
-            <!-- Right: Context Stats (50%) -->
-            <div class="w-full lg:w-1/2 flex flex-col gap-3 pt-[36px]">
+            <!-- Right: Context Stats (50% when leaderboard is shown, otherwise full width) -->
+            <div
+                class="w-full {availableTabs.length > 0
+                    ? 'lg:w-1/2'
+                    : ''} flex flex-col gap-3 pt-[36px]"
+            >
                 <!-- Builder Stat -->
                 {#if isBuilder}
                     <div

--- a/frontend/src/components/shared/CTABanner.svelte
+++ b/frontend/src/components/shared/CTABanner.svelte
@@ -92,6 +92,7 @@
             }
 
             const userRank = targetEntry.rank;
+            const userPoints = targetEntry.total_points || 0;
             rankLabel = roleLabelMap[eligibleEntryType] || "Overall";
 
             if (userRank <= 1) {
@@ -100,19 +101,32 @@
                 return;
             }
 
-            // Fetch the user one rank above in the same leaderboard
+            // Fetch all users above the current user (capped at 100) so we can
+            // skip anyone tied with the user and find the closest rank with
+            // strictly more points.
+            const fetchLimit = Math.min(userRank - 1, 100);
             const res = await leaderboardAPI.getLeaderboard({
                 type: eligibleEntryType,
-                offset: userRank - 2,
-                limit: 1,
+                offset: Math.max(0, userRank - 1 - fetchLimit),
+                limit: fetchLimit,
             });
             const results = res.data?.results || res.data || [];
-            if (results.length > 0) {
-                const userAbove = results[0];
-                const abovePoints = userAbove.total_points || 0;
-                const userPoints = targetEntry.total_points || 0;
-                pointsToNextRank = Math.max(0, abovePoints - userPoints);
-                nextRank = userRank - 1;
+            // Walk from the rank closest to the user upward until we find a
+            // user with strictly more points.
+            let targetUser = null;
+            for (let i = results.length - 1; i >= 0; i--) {
+                const r = results[i];
+                if ((r.total_points || 0) > userPoints) {
+                    targetUser = r;
+                    break;
+                }
+            }
+            if (targetUser) {
+                pointsToNextRank = Math.max(
+                    0,
+                    (targetUser.total_points || 0) - userPoints,
+                );
+                nextRank = targetUser.rank;
             }
         } catch (err) {
             // Silently fail - banner will show without rank info
@@ -169,7 +183,7 @@
                             class="text-[#dcdcdc] text-[13px] font-medium tracking-[0.2px]"
                         >
                             {#if isTopRank}
-                                You're #1!
+                                You lead the {rankLabel} ranks!
                             {:else if pointsToNextRank !== null}
                                 {pointsToNextRank} Points to {rankLabel} Rank #{nextRank}
                             {:else}
@@ -300,7 +314,7 @@
                                 style="letter-spacing: 0.24px;"
                             >
                                 {#if isTopRank}
-                                    You're #1!
+                                    You lead the {rankLabel} ranks!
                                 {:else if pointsToNextRank !== null}
                                     {pointsToNextRank} Points to {rankLabel} Rank #{nextRank}
                                 {:else}

--- a/frontend/src/routes/Profile.svelte
+++ b/frontend/src/routes/Profile.svelte
@@ -781,6 +781,7 @@
           {isOwnProfile}
           {builderStats}
           {validatorStats}
+          {communityStats}
           {overallPoints}
           {referralPoints}
         />

--- a/frontend/src/routes/ProfileEdit.svelte
+++ b/frontend/src/routes/ProfileEdit.svelte
@@ -352,13 +352,15 @@
     >
       <!-- Banner Image -->
       <div
-        class="h-[200px] relative overflow-hidden bg-gradient-to-r from-purple-600 via-indigo-500 to-sky-400 group flex items-center justify-center"
+        class="h-[200px] relative overflow-hidden group flex items-center justify-center {bannerImageUrl
+          ? ''
+          : 'bg-gradient-to-r from-purple-600 via-indigo-500 to-sky-400'}"
       >
         {#if bannerImageUrl}
           <img
             src={bannerImageUrl}
             alt="Banner"
-            class="w-full h-full object-cover mix-blend-overlay opacity-80"
+            class="w-full h-full object-cover"
           />
         {/if}
         <label


### PR DESCRIPTION
## Summary

- Profile Ranking widget: drop the Community tab and source community points from `communityStats.totalPoints` so the widget matches the Community section; the leaderboard column collapses for community-only members so the section is never stuck loading.
- Profile CTA banner: walk past users tied with the viewer when computing the next rank (no more "0 Points to Rank #N") and replace the rank-1 copy with a category-aware "You lead the {role} ranks!".
- Profile Edit banner: when a banner image is uploaded, drop the purple/indigo gradient and the `mix-blend-overlay opacity-80` so banners render at their natural colors.

## Test plan

- [ ] Open a profile with builder + community roles and confirm only Builders/Validators tabs appear in Ranking and Community Points match the Community section value.
- [ ] Open a community-only profile and confirm the right-hand cards render full width without a stuck loading panel.
- [ ] Find a profile tied with the rank above and confirm the CTA pill points to the next non-tied rank instead of showing 0.
- [ ] Verify the rank-1 user sees "You lead the {role} ranks!" in both the Profile dark CTA and the landing-page light CTA.
- [ ] On `/profile`, upload a banner image and confirm the gradient and overlay are gone; remove it and confirm the gradient returns.