### PR TITLE
Split Referrals from Community into its own profile section

### DIFF
--- a/frontend/src/components/profile/CommunityView.svelte
+++ b/frontend/src/components/profile/CommunityView.svelte
@@ -4,13 +4,9 @@
     import ProfileHighlights from "./ProfileHighlights.svelte";
     import ProfileRecentContributions from "./ProfileRecentContributions.svelte";
     import CommunityProgressJourney from "./CommunityProgressJourney.svelte";
-    import { showSuccess } from "../../lib/toastStore";
 
     let {
         participant = null,
-        referralData = null,
-        referralPoints = { builder_points: 0, validator_points: 0 },
-        loading = false,
         isOwnProfile = false,
         communityStats = { totalContributions: 0, totalPoints: 0 },
         communityStatsLoading = false,
@@ -21,28 +17,11 @@
         isClaimingDiscord = false,
     } = $props();
 
-    let totalReferrals = $derived(
-        referralData?.total_referrals ||
-            participant?.creator?.total_referrals ||
-            0,
-    );
-    let builderReferralPoints = $derived(referralPoints?.builder_points || 0);
-    let validatorReferralPoints = $derived(
-        referralPoints?.validator_points || 0,
-    );
-    let totalReferralPoints = $derived(builderReferralPoints + validatorReferralPoints);
-
     let showJourney = $derived(
         isOwnProfile &&
         participant?.creator &&
         !(participant?.has_community_link_x && participant?.has_community_link_discord)
     );
-
-    function copyReferralLink() {
-        const referralLink = `https://portal.genlayer.foundation/?ref=${participant?.referral_code || ""}`;
-        navigator.clipboard.writeText(referralLink);
-        showSuccess("Referral link copied!");
-    }
 </script>
 
 <div class="w-full flex flex-col items-start mt-8">
@@ -93,59 +72,7 @@
         </div>
     {/if}
 
-    <!-- Referral Program Banner -->
-    <div
-        class="bg-[#f4ecfd] w-full rounded-[9px] shadow-[0px_4px_20px_0px_rgba(0,0,0,0.02)] p-[20px] mb-4"
-    >
-        <div
-            class="flex flex-col md:flex-row md:items-end md:justify-between gap-4"
-        >
-            <div class="flex flex-col gap-[4px]">
-                <p
-                    class="font-['Switzer'] font-semibold text-[20px] text-black leading-[25px] tracking-[0.4px]"
-                >
-                    Invite and earn forever.
-                </p>
-                <p
-                    class="font-['Switzer'] text-[14px] text-[#6b6b6b] leading-[21px] tracking-[0.28px]"
-                >
-                    For each builder referred who submits at least one
-                    contribution, you receive 10% of the points that the builder
-                    earns permanently.
-                </p>
-            </div>
-            {#if isOwnProfile}
-                <button
-                    onclick={copyReferralLink}
-                    class="bg-[#1a1c1d] flex gap-[8px] h-[40px] items-center justify-center px-[16px] rounded-[20px] hover:bg-black transition-colors shrink-0"
-                >
-                    <svg
-                        class="w-4 h-4 text-white"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                    >
-                        <path
-                            d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
-                        ></path>
-                        <path
-                            d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
-                        ></path>
-                    </svg>
-                    <span
-                        class="font-['Switzer'] font-medium text-[14px] text-white leading-[21px] tracking-[0.28px] whitespace-nowrap"
-                    >
-                        Copy Referral Link
-                    </span>
-                </button>
-            {/if}
-        </div>
-    </div>
-
-    <!-- Metrics Row: 3 cards -->
+    <!-- Metrics Row: 2 cards -->
     <div class="flex flex-col md:flex-row gap-4 w-full">
         <!-- Community Points Card -->
         <div
@@ -239,60 +166,6 @@
             {/if}
         </div>
 
-        <!-- Total Referrals Card (with builder/validator referral points breakdown) -->
-        <div
-            class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative overflow-hidden"
-        >
-            {#if loading}
-                <div class="flex h-full items-center animate-pulse">
-                    <div
-                        class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"
-                    ></div>
-                    <div class="flex flex-col gap-2">
-                        <div class="h-7 w-16 bg-gray-200 rounded"></div>
-                        <div class="h-3 w-24 bg-gray-100 rounded"></div>
-                    </div>
-                </div>
-            {:else}
-                <div class="flex h-full items-center">
-                    <div
-                        class="w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
-                    >
-                        <CategoryIcon
-                            category="community"
-                            mode="hexagon"
-                            size={48}
-                        />
-                    </div>
-                    <div
-                        class="flex flex-col h-full items-start justify-center z-10"
-                    >
-                        <p
-                            class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
-                        >
-                            {totalReferrals}
-                        </p>
-                        <div class="flex items-center gap-3 mt-1">
-                            <span class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b]">
-                                Total Referrals
-                            </span>
-                            {#if builderReferralPoints > 0 || validatorReferralPoints > 0}
-                                <div class="flex items-center gap-2">
-                                    <div class="flex items-center gap-[3px]">
-                                        <CategoryIcon category="builder" mode="hexagon" size={14} />
-                                        <span class="text-[11px] font-medium text-[#999] leading-[14px]">{builderReferralPoints} pts</span>
-                                    </div>
-                                    <div class="flex items-center gap-[3px]">
-                                        <CategoryIcon category="validator" mode="hexagon" size={14} />
-                                        <span class="text-[11px] font-medium text-[#999] leading-[14px]">{validatorReferralPoints} pts</span>
-                                    </div>
-                                </div>
-                            {/if}
-                        </div>
-                    </div>
-                </div>
-            {/if}
-        </div>
     </div>
 
     <!-- Content Sections -->

--- a/frontend/src/components/profile/ReferralsView.svelte
+++ b/frontend/src/components/profile/ReferralsView.svelte
@@ -1,0 +1,386 @@
+<script>
+    import { push } from "svelte-spa-router";
+    import Avatar from "../Avatar.svelte";
+    import CategoryIcon from "../portal/CategoryIcon.svelte";
+    import { showSuccess } from "../../lib/toastStore";
+
+    let {
+        participant = null,
+        referralData = null,
+        referralPoints = { builder_points: 0, validator_points: 0 },
+        loading = false,
+        isOwnProfile = false,
+    } = $props();
+
+    let totalReferrals = $derived(referralData?.total_referrals ?? 0);
+    let builderReferralPoints = $derived(referralPoints?.builder_points ?? 0);
+    let validatorReferralPoints = $derived(referralPoints?.validator_points ?? 0);
+    let totalReferralPoints = $derived(builderReferralPoints + validatorReferralPoints);
+
+    let topReferrals = $derived(
+        (referralData?.referrals ?? [])
+            .slice()
+            .sort((a, b) => {
+                if (b.total_points !== a.total_points)
+                    return b.total_points - a.total_points;
+                return new Date(b.created_at) - new Date(a.created_at);
+            })
+            .slice(0, 5),
+    );
+
+    let hasReferrals = $derived(totalReferrals > 0);
+
+    function copyReferralLink() {
+        const referralLink = `https://portal.genlayer.foundation/?ref=${participant?.referral_code || ""}`;
+        navigator.clipboard.writeText(referralLink);
+        showSuccess("Referral link copied!");
+    }
+
+    function shortAddress(addr) {
+        if (!addr) return "";
+        return addr.slice(0, 6) + "..." + addr.slice(-4);
+    }
+
+    function referrerEarned(referral) {
+        const builder = Math.round((referral.builder_contribution_points || 0) * 0.1);
+        const validator = Math.round((referral.validator_contribution_points || 0) * 0.1);
+        return builder + validator;
+    }
+
+    function referralUserObj(referral) {
+        return {
+            name: referral.name,
+            address: referral.address,
+            profile_image_url: referral.profile_image_url,
+            builder: referral.is_builder,
+            validator: referral.is_validator,
+        };
+    }
+</script>
+
+<div class="w-full flex flex-col items-start mt-8">
+    <!-- Header -->
+    <div class="flex items-center justify-between w-full mb-4">
+        <div class="flex items-center gap-[10px]">
+            <div
+                class="relative flex-shrink-0"
+                style="width: 32px; height: 32px;"
+            >
+                <img
+                    src="/assets/icons/hexagon-genlayer.svg"
+                    alt=""
+                    class="w-full h-full"
+                />
+                <img
+                    src="/assets/icons/link-m.svg"
+                    alt=""
+                    class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 brightness-0 invert"
+                    style="width: 16px; height: 16px;"
+                />
+            </div>
+            <h2
+                class="text-[20px] font-semibold text-black"
+                style="letter-spacing: 0.4px;"
+            >
+                Referrals
+            </h2>
+        </div>
+        <button
+            onclick={() => push("/referral-program")}
+            class="flex items-center gap-[4px] text-[12px] font-medium text-black tracking-[0.24px] leading-[16px] hover:opacity-70 transition-opacity"
+        >
+            Referral Program
+            <img
+                src="/assets/icons/arrow-right-up-line.svg"
+                alt=""
+                class="w-4 h-4"
+            />
+        </button>
+    </div>
+
+    <!-- Invite & Earn Banner (own profile only) -->
+    {#if isOwnProfile}
+        <div
+            class="bg-[#1a1c1d] w-full rounded-[9px] shadow-[0px_4px_20px_0px_rgba(0,0,0,0.02)] p-[20px] mb-4"
+        >
+            <div
+                class="flex flex-col md:flex-row md:items-end md:justify-between gap-4"
+            >
+                <div class="flex flex-col gap-[4px]">
+                    <p
+                        class="font-['Switzer'] font-semibold text-[20px] text-white leading-[25px] tracking-[0.4px]"
+                    >
+                        Invite and earn, forever.
+                    </p>
+                    <p
+                        class="font-['Switzer'] text-[14px] text-[#b0b0b0] leading-[21px] tracking-[0.28px]"
+                    >
+                        For each builder or validator you refer who submits at
+                        least one contribution, you receive 10% of the points
+                        they earn permanently.
+                    </p>
+                </div>
+                <button
+                    onclick={copyReferralLink}
+                    class="bg-white flex gap-[8px] h-[40px] items-center justify-center px-[16px] rounded-[20px] hover:bg-[#f0f0f0] transition-colors shrink-0"
+                >
+                    <img
+                        src="/assets/icons/link-m.svg"
+                        alt=""
+                        class="w-4 h-4"
+                    />
+                    <span
+                        class="font-['Switzer'] font-medium text-[14px] text-[#1a1c1d] leading-[21px] tracking-[0.28px] whitespace-nowrap"
+                    >
+                        Copy Referral Link
+                    </span>
+                </button>
+            </div>
+        </div>
+    {/if}
+
+    {#if hasReferrals || loading}
+        <!-- Stat cards: Total Referrals + Total Referral Points -->
+        <div class="flex flex-col md:flex-row gap-4 w-full">
+            <!-- Total Referrals Card -->
+            <div
+                class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative"
+            >
+                {#if loading}
+                    <div class="flex h-full items-center animate-pulse">
+                        <div
+                            class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"
+                        ></div>
+                        <div class="flex flex-col gap-2">
+                            <div class="h-7 w-16 bg-gray-200 rounded"></div>
+                            <div class="h-3 w-24 bg-gray-100 rounded"></div>
+                        </div>
+                    </div>
+                {:else}
+                    <div class="flex h-full items-center">
+                        <div
+                            class="w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
+                        >
+                            <img
+                                src="/assets/icons/hexagon-genlayer.svg"
+                                alt=""
+                                class="w-full h-full"
+                            />
+                            <img
+                                src="/assets/icons/link-m.svg"
+                                alt=""
+                                class="absolute w-5 h-5 brightness-0 invert"
+                            />
+                        </div>
+                        <div
+                            class="flex flex-col h-full items-start justify-center whitespace-nowrap z-10"
+                        >
+                            <p
+                                class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
+                            >
+                                {totalReferrals}
+                            </p>
+                            <p
+                                class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
+                            >
+                                Total Referrals
+                            </p>
+                        </div>
+                    </div>
+                {/if}
+            </div>
+
+            <!-- Total Referral Points Card -->
+            <div
+                class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative"
+            >
+                {#if loading}
+                    <div class="flex h-full items-center animate-pulse">
+                        <div
+                            class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"
+                        ></div>
+                        <div class="flex flex-col gap-2">
+                            <div class="h-7 w-20 bg-gray-200 rounded"></div>
+                            <div class="h-3 w-32 bg-gray-100 rounded"></div>
+                        </div>
+                    </div>
+                {:else}
+                    <div class="flex h-full items-center">
+                        <div
+                            class="w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
+                        >
+                            <img
+                                src="/assets/icons/hexagon-genlayer.svg"
+                                alt=""
+                                class="w-full h-full"
+                            />
+                            <img
+                                src="/assets/icons/group-white.svg"
+                                alt=""
+                                class="absolute"
+                                style="width: 24px; height: 24px;"
+                            />
+                        </div>
+                        <div
+                            class="flex flex-col h-full items-start justify-center z-10"
+                        >
+                            <div class="flex items-center gap-2">
+                                <p
+                                    class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
+                                >
+                                    {totalReferralPoints}
+                                </p>
+                                <div class="relative group">
+                                    <svg
+                                        class="w-4 h-4 text-gray-400 hover:text-gray-600 cursor-help"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        viewBox="0 0 24 24"
+                                    >
+                                        <path
+                                            stroke-linecap="round"
+                                            stroke-linejoin="round"
+                                            stroke-width="2"
+                                            d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                                        ></path>
+                                    </svg>
+                                    <div
+                                        class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10 w-[240px] text-center"
+                                    >
+                                        10% of your referrals' eligible builder
+                                        and validator contributions.
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="flex items-center gap-3 mt-1">
+                                <span
+                                    class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b]"
+                                >
+                                    Total Referral Points
+                                </span>
+                                {#if builderReferralPoints > 0 || validatorReferralPoints > 0}
+                                    <div class="flex items-center gap-2">
+                                        <div class="flex items-center gap-[3px]">
+                                            <CategoryIcon
+                                                category="builder"
+                                                mode="hexagon"
+                                                size={14}
+                                            />
+                                            <span
+                                                class="text-[11px] font-medium text-[#999] leading-[14px]"
+                                                >{builderReferralPoints}</span
+                                            >
+                                        </div>
+                                        <div class="flex items-center gap-[3px]">
+                                            <CategoryIcon
+                                                category="validator"
+                                                mode="hexagon"
+                                                size={14}
+                                            />
+                                            <span
+                                                class="text-[11px] font-medium text-[#999] leading-[14px]"
+                                                >{validatorReferralPoints}</span
+                                            >
+                                        </div>
+                                    </div>
+                                {/if}
+                            </div>
+                        </div>
+                    </div>
+                {/if}
+            </div>
+        </div>
+
+        <!-- Top Referrals List -->
+        {#if hasReferrals}
+            <div class="w-full mt-6">
+                <div class="flex items-end justify-between mb-3">
+                    <div>
+                        <h3
+                            class="font-semibold text-[16px] text-black"
+                            style="letter-spacing: 0.32px;"
+                        >
+                            Top Referrals
+                        </h3>
+                        <p class="text-[13px] text-[#999] mt-1">
+                            Your highest earning referrals
+                        </p>
+                    </div>
+                    {#if isOwnProfile}
+                        <button
+                            onclick={() => push("/referrals")}
+                            class="flex items-center gap-[4px] text-[14px] text-[#6b6b6b] hover:text-black transition-colors"
+                            style="letter-spacing: 0.28px;"
+                        >
+                            View all referrals
+                            <img
+                                src="/assets/icons/arrow-right-line.svg"
+                                alt=""
+                                class="w-4 h-4"
+                            />
+                        </button>
+                    {/if}
+                </div>
+
+                <div
+                    class="bg-[#fcfcfc] border border-[#f0f0f0] rounded-[16px] p-[16px]"
+                >
+                    <div class="flex flex-col gap-[6px]">
+                        {#each topReferrals as referral}
+                            <button
+                                onclick={() =>
+                                    push(`/participant/${referral.address}`)}
+                                class="flex items-center justify-between rounded-[10px] bg-white hover:bg-[#f8f8f8] px-3 py-[10px] transition-colors w-full"
+                            >
+                                <div class="flex items-center gap-[10px] min-w-0">
+                                    <Avatar
+                                        user={referralUserObj(referral)}
+                                        size="sm"
+                                        clickable={false}
+                                    />
+                                    <div class="flex flex-col items-start min-w-0">
+                                        <span
+                                            class="text-[14px] font-medium text-black truncate max-w-[200px]"
+                                            style="letter-spacing: 0.2px;"
+                                        >
+                                            {referral.name || "Anonymous"}
+                                        </span>
+                                        <span
+                                            class="text-[12px] text-[#999] leading-[14px]"
+                                        >
+                                            {shortAddress(referral.address)}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="flex items-center gap-[6px]">
+                                    {#if referral.is_builder}
+                                        <CategoryIcon
+                                            category="builder"
+                                            mode="hexagon"
+                                            size={20}
+                                        />
+                                    {/if}
+                                    {#if referral.is_validator}
+                                        <CategoryIcon
+                                            category="validator"
+                                            mode="hexagon"
+                                            size={20}
+                                        />
+                                    {/if}
+                                    <div
+                                        class="flex items-center gap-[3px] text-[13px] font-medium text-[#7f52e1] ml-2"
+                                    >
+                                        <span>+{referrerEarned(referral)}</span>
+                                        <span class="text-[#999] font-normal"
+                                            >GP</span
+                                        >
+                                    </div>
+                                </div>
+                            </button>
+                        {/each}
+                    </div>
+                </div>
+            </div>
+        {/if}
+    {/if}
+</div>

--- a/frontend/src/routes/Profile.svelte
+++ b/frontend/src/routes/Profile.svelte
@@ -31,6 +31,7 @@
   import RoleView from "../components/profile/RoleView.svelte";
   import StewardView from "../components/profile/StewardView.svelte";
   import CommunityView from "../components/profile/CommunityView.svelte";
+  import ReferralsView from "../components/profile/ReferralsView.svelte";
   import CTABanner from "../components/shared/CTABanner.svelte";
   import CategoryIcon from "../components/portal/CategoryIcon.svelte";
 
@@ -126,9 +127,18 @@
   let overallPoints = $derived(
     (builderStats?.totalPoints || 0) +
       (validatorStats?.totalPoints || 0) +
+      (communityStats?.totalPoints || 0) +
       (referralPoints?.builder_points || 0) +
       (referralPoints?.validator_points || 0),
   );
+
+  let hasReferralData = $derived(
+    (referralData?.referrals?.length ?? 0) > 0 ||
+      (referralPoints?.builder_points ?? 0) > 0 ||
+      (referralPoints?.validator_points ?? 0) > 0,
+  );
+
+  let showReferralsSection = $derived(isOwnProfile || hasReferralData);
 
   $effect(() => {
     const currentParams = $params;
@@ -901,9 +911,6 @@
         <div id="community-journey-section" class="w-full mb-16 pt-10 border-t border-gray-100 mt-10">
           <CommunityView
             {participant}
-            {referralData}
-            {referralPoints}
-            loading={loadingReferrals}
             {isOwnProfile}
             communityStats={communityStats}
             communityStatsLoading={!communityStatsLoaded}
@@ -912,6 +919,19 @@
             onClaimDiscord={handleClaimDiscord}
             {isClaimingX}
             {isClaimingDiscord}
+          />
+        </div>
+      {/if}
+
+      <!-- Referrals Section -->
+      {#if showReferralsSection}
+        <div id="referrals-section" class="w-full mb-16 pt-10 border-t border-gray-100 mt-10">
+          <ReferralsView
+            {participant}
+            {referralData}
+            {referralPoints}
+            loading={isOwnProfile ? loadingReferrals : loading}
+            {isOwnProfile}
           />
         </div>
       {/if}

--- a/frontend/src/routes/Referrals.svelte
+++ b/frontend/src/routes/Referrals.svelte
@@ -2,31 +2,37 @@
   import { onMount } from 'svelte';
   import { push } from 'svelte-spa-router';
   import Avatar from '../components/Avatar.svelte';
+  import CategoryIcon from '../components/portal/CategoryIcon.svelte';
   import { usersAPI } from '../lib/api';
-  import Icons from '../components/Icons.svelte';
+  import { showSuccess } from '../lib/toastStore';
 
-  // State management
   let referralData = $state(null);
   let loading = $state(true);
   let error = $state(null);
   let searchQuery = $state('');
 
-  // Filter referrals based on search and sort by latest first
+  let totalReferrals = $derived(referralData?.total_referrals ?? 0);
+  let builderReferralPoints = $derived(referralData?.builder_points ?? 0);
+  let validatorReferralPoints = $derived(referralData?.validator_points ?? 0);
+  let totalReferralPoints = $derived(builderReferralPoints + validatorReferralPoints);
+
   let filteredReferrals = $derived(
     (() => {
-      const referrals = !searchQuery || !referralData?.referrals ? (referralData?.referrals || []) :
-        referralData.referrals.filter(entry => {
-          const query = searchQuery.toLowerCase();
-          const name = entry.name?.toLowerCase() || '';
-          const address = entry.address?.toLowerCase() || '';
-          return name.includes(query) || address.includes(query);
-        });
-      // Sort by created_at date from latest to oldest
-      return referrals.slice().sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+      const list = referralData?.referrals ?? [];
+      const q = searchQuery.trim().toLowerCase();
+      const filtered = !q
+        ? list
+        : list.filter((entry) => {
+            const name = entry.name?.toLowerCase() || '';
+            const address = entry.address?.toLowerCase() || '';
+            return name.includes(q) || address.includes(q);
+          });
+      return filtered
+        .slice()
+        .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
     })()
   );
 
-  // Fetch referral data
   async function fetchReferrals() {
     try {
       loading = true;
@@ -40,259 +46,362 @@
     }
   }
 
-  // Helper function to format date
   function formatDate(dateString) {
     if (!dateString) return 'N/A';
     return new Date(dateString).toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
-      year: 'numeric'
+      year: 'numeric',
     });
   }
 
-  // Helper to get badge type
-  function getBadgeType(referral) {
-    if (referral.is_validator) return 'Validator';
-    if (referral.is_builder) return 'Builder';
-    if (referral.is_steward) return 'Steward';
-    return 'Undetermined';
+  function shortAddress(addr) {
+    if (!addr) return '';
+    return addr.slice(0, 6) + '...' + addr.slice(-4);
   }
 
-  // Helper for badge styling
-  function getBadgeClass(referral) {
-    if (referral.is_validator) return 'bg-blue-100 text-blue-800';
-    if (referral.is_builder) return 'bg-orange-100 text-orange-800';
-    if (referral.is_steward) return 'bg-green-100 text-green-800';
-    return 'bg-gray-100 text-gray-800';
+  function referralUserObj(referral) {
+    return {
+      name: referral.name,
+      address: referral.address,
+      profile_image_url: referral.profile_image_url,
+      builder: referral.is_builder,
+      validator: referral.is_validator,
+    };
   }
 
-  // Fetch on mount
+  function builderEarned(referral) {
+    return Math.round((referral.builder_contribution_points || 0) * 0.1);
+  }
+
+  function validatorEarned(referral) {
+    return Math.round((referral.validator_contribution_points || 0) * 0.1);
+  }
+
   onMount(() => {
     fetchReferrals();
   });
 </script>
 
-<div class="space-y-6 sm:space-y-8 bg-purple-50 min-h-full relative w-screen md:w-[calc(100vw-16rem)] left-1/2 right-1/2 -ml-[50vw] md:-ml-[calc(50vw-8rem)] -mr-[50vw] md:-mr-[calc(50vw-8rem)] -my-4 md:-my-6 lg:-my-8 px-4 py-4 md:py-6 lg:py-8">
-  <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-    <div>
-      <h1 class="text-2xl font-bold text-gray-900">My Referrals</h1>
-      <p class="mt-1 text-sm text-gray-600">
-        People you've brought to the GenLayer ecosystem
-      </p>
-    </div>
-
-    {#if !loading && !error && referralData?.referrals?.length > 0}
-      <div class="w-full sm:w-64">
-        <label for="search" class="sr-only">Search referrals</label>
-        <div class="relative">
-          <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
-            </svg>
-          </div>
-          <input
-            id="search"
-            bind:value={searchQuery}
-            type="search"
-            class="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md leading-5 bg-white placeholder-gray-500 focus:outline-none focus:placeholder-gray-400 focus:ring-1 focus:ring-purple-500 focus:border-purple-500 sm:text-sm"
-            placeholder="Search by name or address"
-          />
-        </div>
+<div class="referrals-page">
+  <!-- Header -->
+  <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+    <div class="flex items-center gap-[10px]">
+      <div
+        class="relative flex-shrink-0"
+        style="width: 32px; height: 32px;"
+      >
+        <img
+          src="/assets/icons/hexagon-genlayer.svg"
+          alt=""
+          class="w-full h-full"
+        />
+        <img
+          src="/assets/icons/link-m.svg"
+          alt=""
+          class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 brightness-0 invert"
+          style="width: 16px; height: 16px;"
+        />
       </div>
-    {/if}
+      <div>
+        <h1
+          class="text-[24px] font-semibold text-black"
+          style="letter-spacing: 0.4px;"
+        >
+          My Referrals
+        </h1>
+        <p class="text-[13px] text-[#999] mt-1">
+          People you've brought to the GenLayer ecosystem
+        </p>
+      </div>
+    </div>
+    <button
+      onclick={() => push('/referral-program')}
+      class="flex items-center gap-[4px] text-[12px] font-medium text-black tracking-[0.24px] leading-[16px] hover:opacity-70 transition-opacity self-start sm:self-center"
+    >
+      Referral Program
+      <img
+        src="/assets/icons/arrow-right-up-line.svg"
+        alt=""
+        class="w-4 h-4"
+      />
+    </button>
   </div>
 
   {#if loading}
-    <div class="flex justify-center items-center p-12">
-      <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600"></div>
+    <!-- Stats skeleton -->
+    <div class="flex flex-col md:flex-row gap-4 w-full mb-6">
+      {#each [1, 2, 3] as _}
+        <div
+          class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full animate-pulse"
+        >
+          <div class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"></div>
+          <div class="flex flex-col gap-2">
+            <div class="h-7 w-16 bg-gray-200 rounded"></div>
+            <div class="h-3 w-24 bg-gray-100 rounded"></div>
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    <!-- List skeleton -->
+    <div class="bg-[#fcfcfc] border border-[#f0f0f0] rounded-[16px] p-[16px]">
+      <div class="flex flex-col gap-[6px]">
+        {#each [1, 2, 3, 4, 5] as _}
+          <div
+            class="flex items-center gap-[10px] rounded-[10px] bg-white px-3 py-[14px] animate-pulse"
+          >
+            <div class="w-8 h-8 rounded-full bg-gray-200"></div>
+            <div class="flex-1 h-4 bg-gray-200 rounded"></div>
+            <div class="w-20 h-4 bg-gray-100 rounded"></div>
+          </div>
+        {/each}
+      </div>
     </div>
   {:else if error}
-    <div class="bg-red-50 border-l-4 border-red-400 p-4">
-      <div class="flex">
-        <div class="flex-shrink-0">
-          <svg class="h-5 w-5 text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
-          </svg>
-        </div>
-        <div class="ml-3">
-          <h3 class="text-sm font-medium text-red-800">Error loading referrals</h3>
-          <p class="mt-1 text-sm text-red-700">{error}</p>
-        </div>
-      </div>
+    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-[12px]">
+      <p class="text-sm font-medium">Error loading referrals</p>
+      <p class="text-sm mt-1">{error}</p>
     </div>
   {:else if !referralData || referralData.referrals.length === 0}
-    <div class="bg-white shadow rounded-lg p-12 text-center">
-      <div class="mx-auto w-16 h-16 bg-purple-100 rounded-full flex items-center justify-center mb-4">
-        <svg class="w-8 h-8 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
-        </svg>
+    <!-- Empty State -->
+    <div
+      class="bg-[#1a1c1d] w-full rounded-[16px] p-[40px] flex flex-col items-center text-center"
+    >
+      <div
+        class="relative flex-shrink-0 mb-4"
+        style="width: 64px; height: 64px;"
+      >
+        <img
+          src="/assets/icons/hexagon-genlayer.svg"
+          alt=""
+          class="w-full h-full"
+        />
+        <img
+          src="/assets/icons/link-m.svg"
+          alt=""
+          class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 brightness-0 invert"
+          style="width: 32px; height: 32px;"
+        />
       </div>
-      <h3 class="text-lg font-semibold text-gray-900 mb-2">No Referrals Yet</h3>
-      <p class="text-gray-600">Start inviting people to the GenLayer ecosystem to see them here!</p>
+      <h2
+        class="font-['Switzer'] font-semibold text-[20px] text-white leading-[25px] tracking-[0.4px] mb-2"
+      >
+        No referrals yet
+      </h2>
+      <p
+        class="font-['Switzer'] text-[14px] text-[#b0b0b0] leading-[21px] tracking-[0.28px] max-w-[420px]"
+      >
+        Start inviting builders and validators. For each referred user who
+        submits at least one contribution, you receive 10% of the points they
+        earn permanently.
+      </p>
     </div>
   {:else}
-    <!-- Summary Cards -->
-    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
-      <div class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
-        <div class="flex items-center">
-          <div class="flex-shrink-0 p-2.5 rounded-lg bg-purple-100 text-purple-600 mr-3">
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
-            </svg>
+    <!-- Stats Cards -->
+    <div class="flex flex-col md:flex-row gap-4 w-full mb-6">
+      <!-- Total Referrals -->
+      <div
+        class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative"
+      >
+        <div class="flex h-full items-center">
+          <div
+            class="w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
+          >
+            <img
+              src="/assets/icons/hexagon-genlayer.svg"
+              alt=""
+              class="w-full h-full"
+            />
+            <img
+              src="/assets/icons/link-m.svg"
+              alt=""
+              class="absolute w-5 h-5 brightness-0 invert"
+            />
           </div>
-          <div class="flex-1">
-            <p class="text-sm text-gray-500">Total Referrals</p>
-            <p class="text-xl font-bold text-gray-900">{referralData.total_referrals}</p>
-          </div>
-        </div>
-      </div>
-
-      <div class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
-        <div class="flex items-center">
-          <div class="flex-shrink-0 p-2.5 rounded-lg bg-orange-100 mr-3">
-            <Icons name="builder" size="md" className="text-orange-600" />
-          </div>
-          <div class="flex-1">
-            <div class="flex items-center gap-1.5">
-              <p class="text-sm text-gray-500">Builder Referral Points</p>
-              <div class="relative group">
-                <svg class="w-4 h-4 text-gray-400 hover:text-gray-600 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                </svg>
-                <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10 w-[260px]">
-                  <div class="text-center">Points earned from referrals' builder contributions</div>
-                  <div class="absolute top-full left-1/2 transform -translate-x-1/2 -mt-1">
-                    <div class="border-4 border-transparent border-t-gray-900"></div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <p class="text-xl font-bold text-gray-900">{referralData.builder_points || 0}</p>
+          <div
+            class="flex flex-col h-full items-start justify-center whitespace-nowrap z-10"
+          >
+            <p
+              class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
+            >
+              {totalReferrals}
+            </p>
+            <p
+              class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
+            >
+              Total Referrals
+            </p>
           </div>
         </div>
       </div>
 
-      <div class="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
-        <div class="flex items-center">
-          <div class="flex-shrink-0 p-2.5 rounded-lg bg-blue-100 mr-3">
-            <Icons name="validator" size="md" className="text-blue-600" />
+      <!-- Builder Referral Points -->
+      <div
+        class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative"
+      >
+        <div class="flex h-full items-center">
+          <div
+            class="w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
+          >
+            <CategoryIcon category="builder" mode="hexagon" size={48} />
           </div>
-          <div class="flex-1">
-            <div class="flex items-center gap-1.5">
-              <p class="text-sm text-gray-500">Validator Referral Points</p>
-              <div class="relative group">
-                <svg class="w-4 h-4 text-gray-400 hover:text-gray-600 cursor-help" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                </svg>
-                <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10 w-[260px]">
-                  <div class="text-center">Points earned from referrals' validator contributions</div>
-                  <div class="absolute top-full left-1/2 transform -translate-x-1/2 -mt-1">
-                    <div class="border-4 border-transparent border-t-gray-900"></div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <p class="text-xl font-bold text-gray-900">{referralData.validator_points || 0}</p>
+          <div
+            class="flex flex-col h-full items-start justify-center whitespace-nowrap z-10"
+          >
+            <p
+              class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
+            >
+              {builderReferralPoints}
+            </p>
+            <p
+              class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
+            >
+              Builder Referral Points
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Validator Referral Points -->
+      <div
+        class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative"
+      >
+        <div class="flex h-full items-center">
+          <div
+            class="w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
+          >
+            <CategoryIcon category="validator" mode="hexagon" size={48} />
+          </div>
+          <div
+            class="flex flex-col h-full items-start justify-center whitespace-nowrap z-10"
+          >
+            <p
+              class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
+            >
+              {validatorReferralPoints}
+            </p>
+            <p
+              class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
+            >
+              Validator Referral Points
+            </p>
           </div>
         </div>
       </div>
     </div>
 
-    <!-- Referrals Table -->
-    <div class="bg-white shadow rounded-lg">
+    <!-- Search + Counter -->
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-3">
+      <p class="text-[13px] text-[#6b6b6b]">
+        Showing {searchQuery ? `${filteredReferrals.length} of ` : ''}{referralData.referrals.length} referrals
+      </p>
+      <div class="relative w-full sm:w-72">
+        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+          <img src="/assets/icons/search-line.svg" alt="" class="w-4 h-4 opacity-60" />
+        </div>
+        <input
+          bind:value={searchQuery}
+          type="search"
+          placeholder="Search by name or address"
+          class="block w-full pl-9 pr-3 py-2 text-[13px] bg-white border border-[#f0f0f0] rounded-[10px] placeholder-[#999] focus:outline-none focus:border-[#1a1c1d] transition-colors"
+        />
+      </div>
+    </div>
+
+    <!-- Referrals List -->
+    <div
+      class="bg-[#fcfcfc] border border-[#f0f0f0] rounded-[16px] p-[16px]"
+    >
       {#if searchQuery && filteredReferrals.length === 0}
-        <div class="p-6 text-center text-gray-500">
+        <div class="text-center py-8 text-[14px] text-[#999]">
           No referrals found matching "{searchQuery}"
         </div>
       {:else}
-        <div class="px-4 py-3 border-b border-gray-200">
-          <p class="text-sm text-gray-700">
-            Showing {searchQuery ? `${filteredReferrals.length} of` : ''} {referralData.referrals.length} referrals
-          </p>
-        </div>
+        <div class="flex flex-col gap-[6px]">
+          {#each filteredReferrals as referral}
+            <button
+              onclick={() => push(`/participant/${referral.address}`)}
+              class="flex flex-col sm:flex-row sm:items-center sm:justify-between rounded-[10px] bg-white hover:bg-[#f8f8f8] px-3 py-[14px] transition-colors w-full gap-3 text-left"
+            >
+              <!-- Participant -->
+              <div class="flex items-center gap-[10px] min-w-0 flex-1">
+                <Avatar
+                  user={referralUserObj(referral)}
+                  size="sm"
+                  clickable={false}
+                />
+                <div class="flex flex-col items-start min-w-0">
+                  <span
+                    class="text-[14px] font-medium text-black truncate max-w-[240px]"
+                    style="letter-spacing: 0.2px;"
+                  >
+                    {referral.name || 'Anonymous'}
+                  </span>
+                  <span class="text-[12px] text-[#999] leading-[14px]">
+                    {shortAddress(referral.address)}
+                  </span>
+                </div>
+              </div>
 
-        <div class="overflow-x-auto">
-          <table class="min-w-full divide-y divide-gray-200">
-            <thead class="bg-gray-50">
-              <tr>
-                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Participant
-                </th>
-                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Builder Points Earned
-                </th>
-                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Validator Points Earned
-                </th>
-                <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Joined Date
-                </th>
-              </tr>
-            </thead>
-            <tbody class="bg-white divide-y divide-gray-200">
-              {#each filteredReferrals as referral, i}
-                <tr class={i % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
-                  <td class="px-6 py-4 whitespace-nowrap">
-                    <div class="flex items-center">
-                      <div class="flex-shrink-0 mr-3">
-                        <Avatar
-                          user={referral}
-                          size="sm"
-                          clickable={true}
-                        />
-                      </div>
-                      <div>
-                        <button
-                          onclick={() => push(`/participant/${referral.address}`)}
-                          class="text-sm font-medium text-gray-900 hover:text-purple-600 transition-colors"
-                        >
-                          {referral.name || 'Anonymous'}
-                        </button>
-                        <div class="text-sm text-gray-500">
-                          {referral.address.slice(0, 6)}...{referral.address.slice(-4)}
-                        </div>
-                      </div>
+              <!-- Points earned breakdown -->
+              <div class="flex items-center gap-3 flex-shrink-0">
+                <div class="flex items-center gap-[6px] min-w-[120px]">
+                  <CategoryIcon category="builder" mode="hexagon" size={20} />
+                  {#if (referral.builder_contribution_points || 0) > 0}
+                    <div class="flex items-center gap-[4px] text-[12px]">
+                      <span class="text-[#6b6b6b]"
+                        >{(referral.builder_contribution_points || 0).toLocaleString()}</span
+                      >
+                      <span class="text-[#999]">→</span>
+                      <span class="font-medium text-[#ee8521]"
+                        >+{builderEarned(referral)}</span
+                      >
                     </div>
-                  </td>
-                  <td class="px-6 py-4 whitespace-nowrap">
-                    <div class="flex flex-col gap-1">
-                      {#if (referral.builder_contribution_points || 0) > 0}
-                        <div class="inline-flex items-center gap-1">
-                          <span class="text-sm text-gray-600">{(referral.builder_contribution_points || 0).toLocaleString()}</span>
-                          <span class="text-gray-400">→</span>
-                          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800">
-                            +{Math.round((referral.builder_contribution_points || 0) * 0.1)}
-                          </span>
-                        </div>
-                      {:else}
-                        <span class="text-sm text-gray-400">—</span>
-                      {/if}
+                  {:else}
+                    <span class="text-[12px] text-[#cfcfcf]">—</span>
+                  {/if}
+                </div>
+
+                <div class="flex items-center gap-[6px] min-w-[120px]">
+                  <CategoryIcon category="validator" mode="hexagon" size={20} />
+                  {#if (referral.validator_contribution_points || 0) > 0}
+                    <div class="flex items-center gap-[4px] text-[12px]">
+                      <span class="text-[#6b6b6b]"
+                        >{(referral.validator_contribution_points || 0).toLocaleString()}</span
+                      >
+                      <span class="text-[#999]">→</span>
+                      <span class="font-medium text-[#387de8]"
+                        >+{validatorEarned(referral)}</span
+                      >
                     </div>
-                  </td>
-                  <td class="px-6 py-4 whitespace-nowrap">
-                    <div class="flex flex-col gap-1">
-                      {#if (referral.validator_contribution_points || 0) > 0}
-                        <div class="inline-flex items-center gap-1">
-                          <span class="text-sm text-gray-600">{(referral.validator_contribution_points || 0).toLocaleString()}</span>
-                          <span class="text-gray-400">→</span>
-                          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                            +{Math.round((referral.validator_contribution_points || 0) * 0.1)}
-                          </span>
-                        </div>
-                      {:else}
-                        <span class="text-sm text-gray-400">—</span>
-                      {/if}
-                    </div>
-                  </td>
-                  <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {formatDate(referral.created_at)}
-                  </td>
-                </tr>
-              {/each}
-            </tbody>
-          </table>
+                  {:else}
+                    <span class="text-[12px] text-[#cfcfcf]">—</span>
+                  {/if}
+                </div>
+
+                <span
+                  class="text-[12px] text-[#999] leading-[14px] hidden md:block min-w-[100px] text-right"
+                >
+                  Joined {formatDate(referral.created_at)}
+                </span>
+              </div>
+            </button>
+          {/each}
         </div>
       {/if}
     </div>
   {/if}
 </div>
+
+<style>
+  .referrals-page,
+  .referrals-page :global(*) {
+    font-family:
+      "Switzer",
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  }
+</style>


### PR DESCRIPTION
## Summary

- New `ReferralsView` profile section with dedicated invite banner (own profile only), Total Referrals + Total Referral Points stat cards (with builder/validator breakdown tooltip), and a Top 5 referrals list sorted by points DESC.
- `Profile.svelte`: include `communityStats` in the `overallPoints` grand total (was missing) and gate the new section on `isOwnProfile || hasReferralData` — explicitly not gated on `creator` since the backend awards referral points to any referrer.
- `CommunityView.svelte`: strip referral concerns (banner + Total Referrals card), so Community now focuses purely on community contributions (X/Discord linking, x-posts).
- `Referrals` route rebrand: black hexagon icons, white cards, vertical list rows replacing the old purple-bg table.

## Test plan
- [ ] Own profile with referrals: section shows banner, two stat cards, and Top 5 list with View all link.
- [ ] Own profile with 0 referrals: only the banner shows.
- [ ] Non-own profile with referrals: section shows stats + list, no banner, no view-all.
- [ ] Non-own profile with no referrals: section hidden.
- [ ] /referrals page renders the rebranded layout with working search.
- [ ] All Points stat now includes community contribution points.