### PR TITLE
Match Metrics builder/validator counts to Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable user-facing changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Metrics dashboard now reports the same Builder and Validator counts as the role dashboards (visible users with a category-matched contribution) and drops the "Unique participants" tile from the Portal Participation strip (b46195c)
 - Profile Ranking widget hides the Community tab and shows community points that match the Community section, the bottom CTA banner skips users tied with the viewer when computing the next rank and greets rank-1 users with a category-aware message, and the Profile Edit banner drops the purple gradient overlay once a banner image is uploaded (d74f7fd)
 - Overview hero banner card now clamps the project title to one line and the description to two lines, with ellipsis on overflow (4368281)
 - Overview hero banner is more compact on desktop and no longer leaves a large empty gap inside the text card when the description is short or the View Project button is missing; titles and descriptions now ellipsize cleanly when they overflow (2e75620)

--- a/backend/api/metrics_views.py
+++ b/backend/api/metrics_views.py
@@ -163,9 +163,12 @@ class ParticipantsGrowthView(APIView):
     Totals are deduplicated across cohorts so users present in multiple roles
     are only counted once in the overall participant total.
 
-    A "builder" is counted from the date of their first non-welcome accepted
-    contribution. Users with a Builder profile but no real contribution yet
-    are excluded so the metric reflects active builder participation.
+    A "builder" is counted from the date of their first accepted contribution
+    in the `builder` category (excluding the welcome auto-award). The
+    "validator" rule is the parallel: first accepted contribution in the
+    `validator` category, excluding the waitlist auto-award. Both cohorts
+    require `user.visible=True`, matching the Dashboard `/leaderboard/stats/`
+    definitions so the time series and the live counts agree.
     """
 
     EXCLUDED_BUILDER_SLUGS = ('builder-welcome', 'builder')
@@ -178,16 +181,18 @@ class ParticipantsGrowthView(APIView):
         from validators.models import Validator
         from builders.models import Builder
 
-        # Validators are users with a Validator profile AND at least one accepted
-        # contribution that is not a journey/waitlist auto-award. Mirrors the
-        # builder rule so the validator line counts active validators rather
-        # than waitlist participants who got promoted later.
+        # Validators are users with a visible Validator profile AND at least
+        # one accepted contribution in the `validator` category (excluding the
+        # waitlist/auto-award). Mirrors the Dashboard `?type=validator` rule.
         validators_by_date = defaultdict(set)
-        validator_user_ids = set(Validator.objects.values_list('user_id', flat=True))
+        validator_user_ids = set(
+            Validator.objects.filter(user__visible=True).values_list('user_id', flat=True)
+        )
         if validator_user_ids:
             qualifying_validator_contributions = (
                 Contribution.objects
                 .filter(user_id__in=validator_user_ids)
+                .filter(contribution_type__category__slug='validator')
                 .exclude(contribution_type__slug__in=self.EXCLUDED_VALIDATOR_SLUGS)
                 .values('user_id')
                 .annotate(first_contribution=Min('contribution_date'))
@@ -212,16 +217,19 @@ class ParticipantsGrowthView(APIView):
         except ContributionType.DoesNotExist:
             pass
 
-        # Builders are users with a Builder profile AND at least one accepted
-        # contribution that is not a welcome/waitlist auto-award. We use the
-        # first qualifying contribution date so historical points reflect when
-        # the user actually became an active builder.
+        # Builders are users with a visible Builder profile AND at least one
+        # accepted contribution in the `builder` category (excluding the
+        # welcome/auto-award). Mirrors the Dashboard `?type=builder` rule so
+        # this time series matches the live builder count.
         builders_by_date = defaultdict(set)
-        builder_user_ids = set(Builder.objects.values_list('user_id', flat=True))
+        builder_user_ids = set(
+            Builder.objects.filter(user__visible=True).values_list('user_id', flat=True)
+        )
         if builder_user_ids:
             qualifying_contributions = (
                 Contribution.objects
                 .filter(user_id__in=builder_user_ids)
+                .filter(contribution_type__category__slug='builder')
                 .exclude(contribution_type__slug__in=self.EXCLUDED_BUILDER_SLUGS)
                 .values('user_id')
                 .annotate(first_contribution=Min('contribution_date'))

--- a/frontend/src/routes/Metrics.svelte
+++ b/frontend/src/routes/Metrics.svelte
@@ -1277,9 +1277,9 @@
         <h2 class="text-2xl font-semibold tracking-tight text-slate-900">Validators and active builders</h2>
       </div>
 
-      <div class="mb-6 grid gap-4 md:grid-cols-3">
+      <div class="mb-6 grid gap-4 md:grid-cols-2">
         {#if loading}
-          {#each [0, 1, 2] as _, i (i)}
+          {#each [0, 1] as _, i (i)}
             <div class="h-[110px] animate-pulse rounded-[24px] border border-slate-200 bg-slate-50"></div>
           {/each}
         {:else}
@@ -1289,10 +1289,7 @@
               <p class="text-3xl font-semibold {participantPalette.validators.text}">
                 {formatNumber(latestParticipantsSnapshot.validators)}
               </p>
-              <p class="text-xs font-medium text-slate-500">
-                {formatPercent((latestParticipantsSnapshot.validators / (latestParticipantsSnapshot.total || 1)) * 100)}
-                of unique participants
-              </p>
+              <p class="text-xs font-medium text-slate-500">Network operators</p>
             </div>
           </div>
 
@@ -1302,17 +1299,7 @@
               <p class="text-3xl font-semibold {participantPalette.builders.text}">
                 {formatNumber(latestParticipantsSnapshot.builders)}
               </p>
-              <p class="text-xs font-medium text-slate-500">
-                Contributors
-              </p>
-            </div>
-          </div>
-
-          <div class="rounded-[24px] border border-slate-200 bg-gradient-to-br from-slate-50 via-white to-slate-50/40 p-5">
-            <p class="text-sm font-medium text-slate-500">Unique participants</p>
-            <div class="mt-3 flex items-end justify-between gap-4">
-              <p class="text-3xl font-semibold text-slate-900">{formatNumber(latestParticipantsSnapshot.total)}</p>
-              <p class="text-xs font-medium text-slate-500">Deduplicated across roles</p>
+              <p class="text-xs font-medium text-slate-500">Contributors</p>
             </div>
           </div>
         {/if}


### PR DESCRIPTION
## Summary

The Portal Participation tab on `/metrics` now uses the same role definitions as the builder and validator dashboards: a builder is a visible user with a Builder profile and at least one accepted contribution in the `builder` category (excluding the welcome auto-award), and the validator rule is the parallel. The latest snapshot from `participants-growth` therefore matches `/leaderboard/stats/?type=<role>`. The "Unique participants" tile is removed so the strip focuses on the two role-specific KPIs that align with the rest of the portal.

## Test plan

- [ ] Open `/metrics` and confirm the Builders and Validators counts match the values shown on `/builders` and `/validators` dashboards.
- [ ] Confirm the Portal Participation tab now shows two tiles (Validators, Builders) instead of three.
- [ ] Confirm the participants growth chart still renders.