### PR TITLE
Mark interesting submissions and capture more-info replies in notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable user-facing changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Stewards can now mark submissions as internally interesting from a header checkbox on the submission card and filter the steward queue by that flag with `is:interesting` / `not:interesting` in the search bar; the flag is never exposed to submitters. Requesting more information on a submission also records the staff reply as a quoted block in the submission's internal CRM note next to the action summary (6dfeb10)
 - Metrics dashboard now reports the same Builder and Validator counts as the role dashboards (visible users with a category-matched contribution) and drops the "Unique participants" tile from the Portal Participation strip (b46195c)
 - Profile Ranking widget hides the Community tab and shows community points that match the Community section, the bottom CTA banner skips users tied with the viewer when computing the next rank and greets rank-1 users with a category-aware message, and the Profile Edit banner drops the purple gradient overlay once a banner image is uploaded (d74f7fd)
 - Overview hero banner card now clamps the project title to one line and the description to two lines, with ellipsis on overflow (4368281)

--- a/backend/contributions/migrations/0054_submittedcontribution_is_interesting.py
+++ b/backend/contributions/migrations/0054_submittedcontribution_is_interesting.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contributions', '0053_add_show_in_contributions'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='submittedcontribution',
+            name='is_interesting',
+            field=models.BooleanField(
+                default=False,
+                db_index=True,
+                help_text='Internal-only flag stewards can toggle to mark a submission as interesting.',
+            ),
+        ),
+    ]

--- a/backend/contributions/models.py
+++ b/backend/contributions/models.py
@@ -416,7 +416,15 @@ class SubmittedContribution(BaseModel):
         on_delete=models.SET_NULL,
         related_name='source_submission'
     )
-    
+
+    # Internal flag for stewards to mark submissions worth revisiting.
+    # Not exposed to submitters; used only for steward filtering.
+    is_interesting = models.BooleanField(
+        default=False,
+        db_index=True,
+        help_text="Internal-only flag stewards can toggle to mark a submission as interesting."
+    )
+
     # Edit tracking
     last_edited_at = models.DateTimeField(null=True, blank=True)
     

--- a/backend/contributions/serializers.py
+++ b/backend/contributions/serializers.py
@@ -883,10 +883,10 @@ class StewardSubmissionSerializer(serializers.ModelSerializer):
                   'proposed_highlight_title', 'proposed_highlight_description',
                   'proposed_by', 'proposed_at', 'proposed_by_details', 'has_proposal',
                   'proposed_confidence', 'proposed_template', 'proposed_template_name',
-                  'notes_count',
+                  'notes_count', 'is_interesting',
                   'created_at', 'updated_at', 'last_edited_at', 'converted_contribution', 'contribution',
                   'mission']
-        read_only_fields = ['id', 'created_at', 'updated_at', 'proposed_points']
+        read_only_fields = ['id', 'created_at', 'updated_at', 'proposed_points', 'is_interesting']
 
     def get_user_details(self, obj):
         use_light = self.context.get('use_light_serializers', False)

--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets, permissions, filters, status
+from rest_framework import viewsets, permissions, filters, status, serializers
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from django_filters.rest_framework import DjangoFilterBackend
@@ -827,6 +827,7 @@ class StewardSubmissionFilterSet(FilterSet):
     proposed_action = CharFilter(method='filter_proposed_action')
     proposed_confidence = CharFilter(method='filter_proposed_confidence')
     proposed_template = NumberFilter(method='filter_proposed_template')
+    is_interesting = BooleanFilter(field_name='is_interesting')
     search = CharFilter(method='filter_search')
     category = CharFilter(method='filter_category')
     exclude_category = CharFilter(method='filter_exclude_category')
@@ -1200,15 +1201,17 @@ class StewardSubmissionViewSet(viewsets.ModelViewSet):
         from .models import SubmissionNote
         reviewer_name = request.user.name or request.user.address[:10] + '...'
         pts_str = f" with **{serializer.validated_data.get('points', '')} points**" if action_name == 'accept' else ''
+        reply_text = serializer.validated_data.get('staff_reply', '') or ''
+        reply_str = f"\n\n> {reply_text}" if reply_text and action_name in ('reject', 'more_info') else ''
         SubmissionNote.objects.create(
             submitted_contribution=submission,
             user=request.user,
-            message=f"Reviewed: **{action_name}**{pts_str} by {reviewer_name}",
+            message=f"Reviewed: **{action_name}**{pts_str} by {reviewer_name}{reply_str}",
             is_proposal=False,
             data={
                 'action': action_name,
                 'points': serializer.validated_data.get('points'),
-                'staff_reply': serializer.validated_data.get('staff_reply', ''),
+                'staff_reply': reply_text,
                 'template_id': serializer.validated_data['template_id'].id if serializer.validated_data.get('template_id') else None,
             },
         )
@@ -1529,6 +1532,28 @@ class StewardSubmissionViewSet(viewsets.ModelViewSet):
 
         submission.assigned_to = steward_user
         submission.save()
+
+        serializer = self.get_serializer(submission)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=['post'], url_path='toggle-interesting', permission_classes=[IsSteward])
+    def toggle_interesting(self, request, pk=None):
+        """Toggle (or set) the internal `is_interesting` flag on a submission."""
+        submission = self.get_object()
+
+        if 'is_interesting' in request.data:
+            field = serializers.BooleanField()
+            try:
+                submission.is_interesting = field.run_validation(request.data.get('is_interesting'))
+            except serializers.ValidationError as exc:
+                return Response(
+                    {'is_interesting': exc.detail},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+        else:
+            submission.is_interesting = not submission.is_interesting
+
+        submission.save(update_fields=['is_interesting', 'updated_at'])
 
         serializer = self.get_serializer(submission)
         return Response(serializer.data)

--- a/frontend/src/components/StewardSearchBar.svelte
+++ b/frontend/src/components/StewardSearchBar.svelte
@@ -28,6 +28,8 @@
     { name: 'include', description: 'Only show submissions containing text', values: () => [] },
     { name: 'has', description: 'Filter by presence', values: () => ['url', 'evidence', 'proposal'] },
     { name: 'no', description: 'Filter by absence', values: () => ['url', 'evidence', 'proposal'] },
+    { name: 'is', description: 'Filter by internal flag', values: () => ['interesting'] },
+    { name: 'not', description: 'Exclude by internal flag', values: () => ['interesting'] },
     { name: 'proposal', description: 'Filter by proposed action', values: () => ['accept', 'reject', 'more-info'] },
     { name: 'confidence', description: 'Filter by proposal confidence', values: () => ['high', 'medium', 'low'] },
     { name: 'template', description: 'Filter by review template', values: () => templates.map(t => t.label.toLowerCase().replace(/\s+/g, '-')) },
@@ -232,6 +234,8 @@
           <div class="help-row"><code>has:url</code><span>Only submissions with URLs</span></div>
           <div class="help-row"><code>has:proposal</code><span>Only submissions with a proposal</span></div>
           <div class="help-row"><code>no:url</code><span>Only submissions without URLs</span></div>
+          <div class="help-row"><code>is:interesting</code><span>Only submissions flagged as interesting</span></div>
+          <div class="help-row"><code>not:interesting</code><span>Exclude submissions flagged as interesting</span></div>
           <div class="help-row"><code>proposal:reject</code><span>Filter by proposed action (accept, reject, more-info)</span></div>
           <div class="help-row"><code>confidence:high</code><span>Filter by proposal confidence (high, medium, low)</span></div>
           <div class="help-row"><code>mission:name</code><span>Filter by mission (or "none")</span></div>

--- a/frontend/src/components/SubmissionCard.svelte
+++ b/frontend/src/components/SubmissionCard.svelte
@@ -26,8 +26,27 @@
     templates = [],
     notes = [],
     notesLoading = false,
-    onAddNote = null
+    onAddNote = null,
+    onToggleInteresting = null
   } = $props();
+
+  let togglingInteresting = $state(false);
+
+  async function handleToggleInteresting(event) {
+    if (!onToggleInteresting) return;
+    const checkbox = event.target;
+    const next = checkbox.checked;
+    togglingInteresting = true;
+    try {
+      await onToggleInteresting(submission.id, next);
+    } catch {
+      // Parent failed to persist; the prop hasn't changed, so resync the DOM
+      // back to the underlying value to undo the browser's optimistic flip.
+      checkbox.checked = submission.is_interesting;
+    } finally {
+      togglingInteresting = false;
+    }
+  }
 
   // Determine which actions this steward can take on this submission
   let canAccept = $derived(
@@ -295,6 +314,21 @@
         </p>
       </div>
       <div class="flex items-center gap-2">
+        {#if !isOwnSubmission && onToggleInteresting}
+          <label
+            class="flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium cursor-pointer select-none transition-colors {submission.is_interesting ? 'bg-purple-100 text-purple-800 hover:bg-purple-200' : 'bg-gray-50 text-gray-500 hover:bg-gray-100'}"
+            title="Mark this submission as internally interesting"
+          >
+            <input
+              type="checkbox"
+              checked={submission.is_interesting}
+              disabled={togglingInteresting}
+              onchange={handleToggleInteresting}
+              class="w-3.5 h-3.5 rounded border-gray-300 text-purple-600 focus:ring-purple-500 cursor-pointer"
+            />
+            <span>{submission.is_interesting ? 'Interesting' : 'Mark interesting'}</span>
+          </label>
+        {/if}
         {#if submission.has_proposal}
           <span class="px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
             Proposal

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -201,6 +201,10 @@ export const stewardAPI = {
   // Assign submission to a steward
   assignSubmission: (id, data) => api.post(`/steward-submissions/${id}/assign/`, data),
 
+  // Toggle the internal "interesting" flag on a submission
+  toggleInteresting: (id, isInteresting) =>
+    api.post(`/steward-submissions/${id}/toggle-interesting/`, { is_interesting: isInteresting }),
+
   // Bulk reject multiple submissions
   bulkRejectSubmissions: (submissionIds, staffReply) =>
     api.post('/steward-submissions/bulk-reject/', { submission_ids: submissionIds, staff_reply: staffReply }),

--- a/frontend/src/lib/searchParser.js
+++ b/frontend/src/lib/searchParser.js
@@ -18,7 +18,7 @@
  */
 
 const SINGLE_VALUE_TAGS = ['status', 'type', 'category', 'from', 'assigned', 'sort', 'confidence', 'template', 'proposal', 'mission'];
-const MULTI_VALUE_TAGS = ['exclude', 'include', 'has', 'no'];
+const MULTI_VALUE_TAGS = ['exclude', 'include', 'has', 'no', 'is', 'not'];
 const NUMERIC_TAGS = ['min-contributions'];
 
 /**
@@ -114,6 +114,8 @@ export function parseSearch(query) {
     include: [],
     has: [],
     no: [],
+    is: [],
+    not: [],
     minContributions: null,
     sort: null,
     freeText: []

--- a/frontend/src/lib/searchToParams.js
+++ b/frontend/src/lib/searchToParams.js
@@ -120,6 +120,13 @@ export function searchToParams(parsed, options = {}) {
     params.has_proposal = false;
   }
 
+  // is:interesting / not:interesting → is_interesting filter
+  if (filters.is && filters.is.includes('interesting')) {
+    params.is_interesting = true;
+  } else if (filters.not && filters.not.includes('interesting')) {
+    params.is_interesting = false;
+  }
+
   // min-contributions
   if (filters.minContributions !== null && filters.minContributions > 0) {
     params.min_accepted_contributions = filters.minContributions;

--- a/frontend/src/routes/StewardSubmissions.svelte
+++ b/frontend/src/routes/StewardSubmissions.svelte
@@ -288,6 +288,20 @@
     }
   }
 
+  async function handleToggleInteresting(submissionId, isInteresting) {
+    try {
+      const response = await stewardAPI.toggleInteresting(submissionId, isInteresting);
+      const idx = submissions.findIndex(s => s.id === submissionId);
+      if (idx !== -1) {
+        submissions[idx] = response.data;
+        submissions = [...submissions];
+      }
+    } catch (err) {
+      showError('Failed to update flag: ' + (err.response?.data?.detail || err.message));
+      throw err;
+    }
+  }
+
   async function handleAddNote(submissionId, message) {
     try {
       await stewardAPI.addNote(submissionId, message);
@@ -679,6 +693,7 @@
               notes={submissionNotes[submission.id] || []}
               notesLoading={notesLoading[submission.id] || false}
               onAddNote={handleAddNote}
+              onToggleInteresting={handleToggleInteresting}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Adds an internal-only `is_interesting` flag on submissions, with a header checkbox on the steward submission card and `is:interesting` / `not:interesting` filters in the steward search bar. The flag is never exposed to submitters, and is parsed via DRF's BooleanField so values like `false` are coerced safely.
- Embeds the steward's staff reply as a quoted block in the auto-generated CRM note when a submission goes to `more_info_needed` (and on rejection), so the wording is preserved next to the action summary in the submission's internal notes.

## Test plan

- [ ] Run `python manage.py migrate` and verify migration `0054_submittedcontribution_is_interesting` applies cleanly.
- [ ] As a steward, toggle the "Mark interesting" pill on submissions across `pending`, `more_info_needed`, `accepted`, and `rejected`; confirm the value persists and the visual rolls back when the API errors.
- [ ] Filter the steward queue with `is:interesting` and `not:interesting`, alone and combined with `status:` filters; confirm results match.
- [ ] Submit a `Request Information` review with a non-empty reply; open the submission's CRM notes and verify the reply appears as a blockquote inside the action summary note.
- [ ] Confirm `is_interesting` is not exposed in the submitter-facing submission endpoints (`/api/v1/submitted-contributions/...`).