### PR TITLE
Fix Pending review metric collapsing to zero under filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable user-facing changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Metrics dashboard Pending review tile no longer collapses to zero when filters are applied; it now shows submissions created in the selected range that are still awaiting a decision (97dc404)
 - Stewards can now mark submissions as internally interesting from a header checkbox on the submission card and filter the steward queue by that flag with `is:interesting` / `not:interesting` in the search bar; the flag is never exposed to submitters. Requesting more information on a submission also records the staff reply as a quoted block in the submission's internal CRM note next to the action summary (6dfeb10)
 - Metrics dashboard now reports the same Builder and Validator counts as the role dashboards (visible users with a category-matched contribution) and drops the "Unique participants" tile from the Portal Participation strip (b46195c)
 - Profile Ranking widget hides the Community tab and shows community points that match the Community section, the bottom CTA banner skips users tied with the viewer when computing the next rank and greets rank-1 users with a category-aware message, and the Profile Edit banner drops the purple gradient overlay once a banner image is uploaded (d74f7fd)

--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -1296,6 +1296,10 @@ class StewardSubmissionViewSet(viewsets.ModelViewSet):
         - rejected: Submissions rejected
         - more_info_requested: Submissions requesting more info
         - points_awarded: Total points from accepted contributions
+
+        The `totals` block also includes `pending_review`: submissions created
+        in the date range that are still in the pending state, respecting the
+        category and contribution_type filters.
         """
         from datetime import datetime, timedelta
         from django.db.models import Min, Max
@@ -1465,13 +1469,25 @@ class StewardSubmissionViewSet(viewsets.ModelViewSet):
                 else:
                     current_date = current_date.replace(month=current_date.month + 1)
 
+        # Pending review counts submissions created in the range that are still
+        # in pending state. We can't derive it from `ingress - reviewed` because
+        # ingress is bucketed by created_at while review outcomes are bucketed
+        # by reviewed_at, so the two measure disjoint cohorts and the
+        # subtraction produces nonsense (often clamped to 0) under filters.
+        pending_review = base_qs.filter(
+            state='pending',
+            created_at__date__gte=start_date,
+            created_at__date__lte=end_date
+        ).count()
+
         # Calculate totals for the period
         totals = {
             'ingress': sum(d['ingress'] for d in data),
             'accepted': sum(d['accepted'] for d in data),
             'rejected': sum(d['rejected'] for d in data),
             'more_info_requested': sum(d['more_info_requested'] for d in data),
-            'points_awarded': sum(d['points_awarded'] for d in data)
+            'points_awarded': sum(d['points_awarded'] for d in data),
+            'pending_review': pending_review
         }
 
         return Response({

--- a/frontend/src/routes/Metrics.svelte
+++ b/frontend/src/routes/Metrics.svelte
@@ -252,7 +252,11 @@
     const moreInfoRequested = Number(totals.more_info_requested || 0);
     const pointsAwarded = Number(totals.points_awarded || 0);
     const reviewed = accepted + rejected + moreInfoRequested;
-    const pendingReview = Math.max(0, ingress - reviewed);
+    // Pending review comes from the backend: submissions created in the
+    // selected range that are still in pending state. We can't derive it from
+    // ingress - reviewed because ingress is bucketed by created_at and reviews
+    // by reviewed_at, so they measure disjoint cohorts under any filter.
+    const pendingReview = Number(totals.pending_review || 0);
 
     return {
       accepted,
@@ -1456,7 +1460,7 @@
             <p class="mt-3 text-3xl font-semibold {reviewPalette.pending.text}">
               {formatNumber(submissionsSummary.pendingReview)}
             </p>
-            <p class="mt-2 text-xs leading-5 text-slate-500">Remaining submissions awaiting a decision.</p>
+            <p class="mt-2 text-xs leading-5 text-slate-500">Submissions in this range still awaiting a decision.</p>
           </div>
 
           <div class="rounded-[24px] border border-slate-200 bg-gradient-to-br {reviewPalette.accepted.surface} p-5">


### PR DESCRIPTION
## Summary
The Metrics dashboard Pending review tile dropped to zero whenever a category, contribution-type, or date-range filter was applied. It was derived in the frontend as `ingress - reviewed`, but those totals are bucketed on different timestamps (`created_at` vs `reviewed_at`), so under any filter the reviewed cohort routinely overtakes the ingress cohort and the tile clamped to zero. The steward submissions `daily-metrics` endpoint now returns a real `pending_review` count of submissions created in the selected range that are still in the pending state, respecting the active category and type filters, and the dashboard reads it directly. Tile subtitle updated to describe the new semantics.

## Test plan
- [ ] Open Metrics → Portal tab and confirm the Pending review tile shows a sensible value with no filters
- [ ] Apply a category filter (e.g. Builder) and confirm the count updates without going to zero
- [ ] Apply a contribution-type filter and confirm the count updates
- [ ] Narrow the date range to a recent week and confirm the count reflects only submissions created in that window that are still pending