### PR TITLE
Show all highlights on the All Contributions page

### DIFF
--- a/backend/contributions/tests/test_highlights_api.py
+++ b/backend/contributions/tests/test_highlights_api.py
@@ -1,0 +1,71 @@
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from contributions.models import Category, Contribution, ContributionHighlight, ContributionType
+from leaderboard.models import GlobalLeaderboardMultiplier
+
+User = get_user_model()
+
+
+class ContributionHighlightsAPITest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.category = Category.objects.create(
+            name='Highlights Test',
+            slug='highlights-test',
+            description='Highlights test category',
+        )
+        self.contribution_type = ContributionType.objects.create(
+            name='Highlights Test Type',
+            slug='highlights-test-type',
+            description='Highlights test type',
+            category=self.category,
+            min_points=1,
+            max_points=100,
+        )
+        GlobalLeaderboardMultiplier.objects.create(
+            contribution_type=self.contribution_type,
+            multiplier_value=1,
+            valid_from=timezone.now() - timedelta(days=30),
+        )
+
+        for index in range(12):
+            user = User.objects.create_user(
+                email=f'highlight-user-{index}@test.com',
+                address=f'0x{index + 1:040x}',
+                password='testpass123',
+            )
+            contribution = Contribution.objects.create(
+                user=user,
+                contribution_type=self.contribution_type,
+                points=10,
+                contribution_date=timezone.now() - timedelta(days=index),
+                title=f'Contribution {index}',
+            )
+            ContributionHighlight.objects.create(
+                contribution=contribution,
+                title=f'Highlight {index}',
+                description='Highlighted contribution',
+            )
+
+    def test_highlights_default_limit_is_kept_for_summary_views(self):
+        response = self.client.get('/api/v1/contributions/highlights/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()), 10)
+
+    def test_highlights_limit_zero_returns_every_highlight(self):
+        response = self.client.get('/api/v1/contributions/highlights/?limit=0')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()), 12)
+
+    def test_highlights_rejects_negative_limit(self):
+        response = self.client.get('/api/v1/contributions/highlights/?limit=-1')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -272,7 +272,21 @@ class ContributionViewSet(viewsets.ReadOnlyModelViewSet):
         from contributions.models import Category, ContributionType
         from django.db.models import Q
         
-        limit = int(request.query_params.get('limit', 10))
+        limit_param = request.query_params.get('limit')
+        limit = 10
+        if limit_param is not None:
+            try:
+                limit = int(limit_param)
+            except (TypeError, ValueError):
+                return Response(
+                    {'detail': 'limit must be an integer.'},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+            if limit < 0:
+                return Response(
+                    {'detail': 'limit must be greater than or equal to 0.'},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
         category_slug = request.query_params.get('category')
         waitlist_only = request.query_params.get('waitlist_only', 'false').lower() == 'true'
         
@@ -336,7 +350,8 @@ class ContributionViewSet(viewsets.ReadOnlyModelViewSet):
                 # No validator type, just filter by waitlist users
                 queryset = queryset.filter(contribution__user_id__in=waitlist_users)
         
-        # Order by contribution date descending and apply limit
+        # Order by contribution date descending. `limit=0` is used by the
+        # all-contributions explorer so local filters can search every highlight.
         highlights = queryset.select_related(
             'contribution__user',
             'contribution__user__validator',
@@ -346,7 +361,10 @@ class ContributionViewSet(viewsets.ReadOnlyModelViewSet):
             'contribution__contribution_type__category'
         ).prefetch_related(
             'contribution__evidence_items'
-        ).order_by('-contribution__contribution_date')[:limit]
+        ).order_by('-contribution__contribution_date')
+
+        if limit > 0:
+            highlights = highlights[:limit]
         
         serializer = ContributionHighlightSerializer(highlights, many=True)
         return Response(serializer.data)

--- a/frontend/src/routes/AllContributions.svelte
+++ b/frontend/src/routes/AllContributions.svelte
@@ -326,7 +326,9 @@
     highlightsError = null;
     try {
       // Backend /highlights/ only honors `category` server-side; rest is client-side.
-      const params = category !== 'all' ? { category } : {};
+      // Request every highlight so user/type/mission filters are not limited to
+      // only the latest dashboard-sized batch.
+      const params = category !== 'all' ? { category, limit: 0 } : { limit: 0 };
       const response = await contributionsAPI.getAllHighlights(params);
       const all = Array.isArray(response.data) ? response.data : (response.data?.results || []);
       const sorted = sortHighlights(filterHighlightsClientSide(all));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "vienna-v3",
+  "name": "beijing-v1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary
- Treat `limit=0` on `/contributions/highlights/` as no cap and validate the param so the All Contributions explorer can filter across every highlight instead of only the latest dashboard batch.
- Update the frontend to request unlimited highlights when loading that page.
- Add API tests covering the default limit, unlimited (`limit=0`), and negative-limit rejection.

## Test plan
- [ ] `cd backend && source env/bin/activate && python manage.py test contributions.tests.test_highlights_api`
- [ ] Manually verify All Contributions filters surface highlights beyond the first 10 results