### PR TITLE
Fix steward submission state carryover

### DIFF
--- a/frontend/src/routes/StewardSubmissions.svelte
+++ b/frontend/src/routes/StewardSubmissions.svelte
@@ -661,7 +661,7 @@
     {/if}
 
     <div class="space-y-4">
-      {#each submissions as submission}
+      {#each submissions as submission (submission.id)}
         <div>
           {#if submission.state === 'pending' || submission.state === 'more_info_needed'}
             <div class="mb-2 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white px-4 py-2 shadow-sm">


### PR DESCRIPTION
## Summary
- Key the steward submissions list by submission id so Svelte remounts each review card when a processed submission is removed.
- Prevent review form metadata such as reject text, selected user, and contribution type from carrying over to the next submission.

## Testing
- npm run build