### PR TITLE
Fix validator display order save

### DIFF
--- a/backend/validators/node_version.py
+++ b/backend/validators/node_version.py
@@ -33,19 +33,32 @@ class NodeVersionMixin(models.Model):
     class Meta:
         abstract = True
 
+    def full_clean(self, exclude=None, validate_unique=True, validate_constraints=True):
+        self._node_version_validation_exclude = set(exclude or [])
+        try:
+            super().full_clean(
+                exclude=exclude,
+                validate_unique=validate_unique,
+                validate_constraints=validate_constraints,
+            )
+        finally:
+            if hasattr(self, '_node_version_validation_exclude'):
+                delattr(self, '_node_version_validation_exclude')
+
     def clean(self):
         """Validate the node version format for both networks."""
         super().clean()
 
         pattern = r'^\d+\.\d+\.\d+(-[a-zA-Z0-9\-\.]+)?(\+[a-zA-Z0-9\-\.]+)?$'
+        excluded_fields = getattr(self, '_node_version_validation_exclude', set())
 
-        if self.node_version_asimov:
+        if 'node_version_asimov' not in excluded_fields and self.node_version_asimov:
             if not re.match(pattern, self.node_version_asimov):
                 raise ValidationError({
                     'node_version_asimov': 'Node version must follow semantic versioning (e.g., 0.3.9, 1.2.3-beta.1)'
                 })
 
-        if self.node_version_bradbury:
+        if 'node_version_bradbury' not in excluded_fields and self.node_version_bradbury:
             if not re.match(pattern, self.node_version_bradbury):
                 raise ValidationError({
                     'node_version_bradbury': 'Node version must follow semantic versioning (e.g., 0.3.9, 1.2.3-beta.1)'

--- a/backend/validators/tests/test_node_version_tracking.py
+++ b/backend/validators/tests/test_node_version_tracking.py
@@ -5,6 +5,8 @@ from django.test import TestCase
 from django.utils import timezone
 from django.contrib.auth import get_user_model
 from datetime import timedelta
+from django.core.exceptions import ValidationError
+from django.forms import modelform_factory
 from validators.models import Validator
 from validators.node_version import calculate_early_upgrade_bonus
 from contributions.models import ContributionType, SubmittedContribution, Category
@@ -225,3 +227,32 @@ class NodeVersionTrackingTestCase(TestCase):
         self.assertFalse(NodeVersionMixin._compare_versions('1.0.0', '2.0.0'))
         self.assertFalse(NodeVersionMixin._compare_versions(None, '2.0.0'))
         self.assertFalse(NodeVersionMixin._compare_versions('2.0.0', None))
+
+    def test_full_clean_rejects_invalid_node_version(self):
+        """Test that full model validation still rejects invalid node versions."""
+        self.validator.node_version_asimov = 'version v0.5.5'
+
+        with self.assertRaises(ValidationError) as context:
+            self.validator.full_clean()
+
+        self.assertIn('node_version_asimov', context.exception.error_dict)
+
+    def test_display_order_form_ignores_excluded_invalid_node_version(self):
+        """Test list-editable display_order forms can save when stored versions are invalid."""
+        Validator.objects.filter(pk=self.validator.pk).update(
+            node_version_asimov='version v0.5.5'
+        )
+        self.validator.refresh_from_db()
+
+        DisplayOrderForm = modelform_factory(Validator, fields=('display_order',))
+        form = DisplayOrderForm(
+            data={'display_order': '7'},
+            instance=self.validator,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors.as_data())
+        form.save()
+
+        self.validator.refresh_from_db()
+        self.assertEqual(self.validator.display_order, 7)
+        self.assertEqual(self.validator.node_version_asimov, 'version v0.5.5')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "beijing-v1",
+  "name": "quebec",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Fixes the validator admin display-order save path when stored node version values are not valid semver strings. The node version mixin now skips validation for fields excluded by partial ModelForms, while full model validation still rejects invalid versions. Adds regression coverage for full validation and display_order-only forms. Also includes the current workspace package-lock name update from beijing-v1 to quebec.