### PR TITLE
Preserve mission context after deadlines

### DIFF
--- a/.claude/skills/ai-review.md
+++ b/.claude/skills/ai-review.md
@@ -45,10 +45,10 @@ Use template text as the basis for `proposed_staff_reply` to keep responses cons
 curl -s -H "X-AI-Review-Key: $KEY" "$BASE_URL/api/v1/ai-review/?page_size=10"
 ```
 
-The list view returns lightweight data (no evidence or user history — just id, type, category, notes, state, created_at).
+The list view returns lightweight data (no evidence or user history — just id, type, category, mission, appeal fields, notes, state, created_at).
 Use it to identify which submissions to evaluate in detail.
 
-Common filters: `category=builder`, `exclude_empty_evidence=true`, `include_content=github`, `ordering=-created_at`.
+Common filters: `category=builder`, `mission={id}`, `mission=none`, `exclude_empty_evidence=true`, `include_content=github`, `ordering=-created_at`.
 
 ### Step 3: Get submission detail
 
@@ -58,8 +58,9 @@ For each submission to evaluate:
 curl -s -H "X-AI-Review-Key: $KEY" "$BASE_URL/api/v1/ai-review/{uuid}/"
 ```
 
-The detail view returns the full submission including `evidence_items` (URLs, descriptions) and
-`user_history` (accepted_count, rejected_count, pending_count). Use this data to make your evaluation.
+The detail view returns the full submission including `mission`, `has_appeal`, `appeal_reason`,
+`evidence_items` (URLs, descriptions), and `user_history` (accepted_count, rejected_count, pending_count).
+Use this data to make your evaluation.
 
 ### Step 4: Propose a review (POST = create, PUT = update)
 
@@ -119,9 +120,9 @@ Page through remaining submissions with `?page=2&page_size=10`.
 curl -s -H "X-AI-Review-Key: $KEY" "$BASE_URL/api/v1/ai-review/reviewed/?page_size=10"
 ```
 
-Returns submissions that were reviewed by stewards after having an AI proposal. Includes the final `state`, `staff_reply`, `evidence_items`, and all `internal_notes` (with proposal data). Use this to calibrate future proposals — check whether stewards agreed with your proposals or overrode them.
+Returns submissions that were reviewed by stewards after having an AI proposal. Includes the final `state`, `staff_reply`, `mission`, appeal fields, `evidence_items`, and all `internal_notes` (with proposal and final review data). Use this to calibrate future proposals — check whether stewards agreed with your proposals or overrode them.
 
-Filters: `state=accepted|rejected|more_info_needed`, `contribution_type={id}`, `category={slug}`.
+Filters: `state=accepted|rejected|more_info_needed`, `contribution_type={id}`, `category={slug}`, `mission={id}`, `mission=none`.
 
 ## Evaluation Guidelines
 

--- a/backend/contributions/ai_review/serializers.py
+++ b/backend/contributions/ai_review/serializers.py
@@ -11,6 +11,20 @@ class AIReviewEvidenceSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+class AIReviewMissionSerializer(serializers.Serializer):
+    """Minimal mission context for AI review payloads."""
+
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    start_date = serializers.DateTimeField(read_only=True)
+    end_date = serializers.DateTimeField(read_only=True)
+    contribution_type = serializers.PrimaryKeyRelatedField(read_only=True)
+    is_active = serializers.SerializerMethodField()
+
+    def get_is_active(self, obj):
+        return obj.is_active()
+
+
 class LightAIReviewSubmissionSerializer(serializers.ModelSerializer):
     """Light serializer for list views — no nested queries."""
 
@@ -19,6 +33,7 @@ class LightAIReviewSubmissionSerializer(serializers.ModelSerializer):
     )
     category_name = serializers.SerializerMethodField()
     has_proposal = serializers.SerializerMethodField()
+    mission = AIReviewMissionSerializer(read_only=True)
 
     class Meta:
         model = SubmittedContribution
@@ -30,6 +45,9 @@ class LightAIReviewSubmissionSerializer(serializers.ModelSerializer):
             'title',
             'notes',
             'state',
+            'mission',
+            'has_appeal',
+            'appeal_reason',
             'has_proposal',
             'created_at',
         ]
@@ -61,6 +79,7 @@ class AIReviewSubmissionSerializer(serializers.ModelSerializer):
         source='contribution_type.max_points', read_only=True,
     )
     evidence_items = AIReviewEvidenceSerializer(many=True, read_only=True)
+    mission = AIReviewMissionSerializer(read_only=True)
     user_history = serializers.SerializerMethodField()
     has_proposal = serializers.SerializerMethodField()
     proposed_by_name = serializers.SerializerMethodField()
@@ -78,6 +97,10 @@ class AIReviewSubmissionSerializer(serializers.ModelSerializer):
             'title',
             'notes',
             'state',
+            'staff_reply',
+            'mission',
+            'has_appeal',
+            'appeal_reason',
             'evidence_items',
             'user_history',
             'has_proposal',
@@ -140,6 +163,7 @@ class AIReviewReviewedSubmissionSerializer(serializers.ModelSerializer):
     category_name = serializers.SerializerMethodField()
     evidence_items = AIReviewEvidenceSerializer(many=True, read_only=True)
     internal_notes = AIReviewNoteSerializer(many=True, read_only=True)
+    mission = AIReviewMissionSerializer(read_only=True)
 
     class Meta:
         model = SubmittedContribution
@@ -152,6 +176,9 @@ class AIReviewReviewedSubmissionSerializer(serializers.ModelSerializer):
             'notes',
             'state',
             'staff_reply',
+            'mission',
+            'has_appeal',
+            'appeal_reason',
             'reviewed_at',
             'evidence_items',
             'internal_notes',

--- a/backend/contributions/ai_review/views.py
+++ b/backend/contributions/ai_review/views.py
@@ -49,6 +49,7 @@ class AIReviewFilterSet(FilterSet):
     min_accepted_contributions = NumberFilter(method='filter_min_accepted_contributions')
     has_proposal = BooleanFilter(method='filter_has_proposal')
     exclude_state = CharFilter(method='filter_exclude_state')
+    mission = CharFilter(method='filter_mission')
 
     class Meta:
         model = SubmittedContribution
@@ -173,6 +174,13 @@ class AIReviewFilterSet(FilterSet):
             return queryset.exclude(state=value)
         return queryset
 
+    def filter_mission(self, queryset, name, value):
+        if value in ('none', 'null'):
+            return queryset.filter(mission__isnull=True)
+        if value:
+            return queryset.filter(mission_id=value)
+        return queryset
+
 
 # ─── ViewSet ──────────────────────────────────────────────────────────────────
 
@@ -220,6 +228,7 @@ class AIReviewViewSet(
                 'contribution_type',
                 'contribution_type__category',
                 'user',
+                'mission',
                 'proposed_by',
             )
             .prefetch_related('evidence_items')
@@ -373,6 +382,7 @@ class AIReviewViewSet(
                 'contribution_type',
                 'contribution_type__category',
                 'user',
+                'mission',
                 'proposed_by',
             )
             .prefetch_related('evidence_items')
@@ -420,6 +430,7 @@ class AIReviewViewSet(
             .select_related(
                 'contribution_type',
                 'contribution_type__category',
+                'mission',
             )
             .prefetch_related('evidence_items', 'internal_notes')
             .order_by('-reviewed_at')
@@ -437,6 +448,12 @@ class AIReviewViewSet(
         category = request.query_params.get('category')
         if category:
             queryset = queryset.filter(contribution_type__category__slug=category)
+
+        mission = request.query_params.get('mission')
+        if mission in ('none', 'null'):
+            queryset = queryset.filter(mission__isnull=True)
+        elif mission:
+            queryset = queryset.filter(mission_id=mission)
 
         page = self.paginate_queryset(queryset)
         if page is not None:

--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -1800,17 +1800,25 @@ class MissionViewSet(viewsets.ReadOnlyModelViewSet):
         Return active missions by default.
         Supports filtering by contribution_type and category.
         """
-        from django.utils import timezone
-        from django.db import models
+        queryset = Mission.objects.all().select_related(
+            'contribution_type',
+            'contribution_type__category',
+        )
 
-        now = timezone.now()
+        include_inactive = (
+            self.request.query_params.get('include_inactive', '').lower()
+            in ['1', 'true', 'yes']
+        )
+        is_active = self.request.query_params.get('is_active')
 
-        # Get base queryset of active highlights (without slicing)
-        queryset = Mission.objects.filter(
-            models.Q(start_date__isnull=True) | models.Q(start_date__lte=now)
-        ).filter(
-            models.Q(end_date__isnull=True) | models.Q(end_date__gt=now)
-        ).select_related('contribution_type', 'contribution_type__category')
+        # Detail lookups must be able to resolve expired missions so historical
+        # submissions/contributions can keep their mission identity.
+        if self.action != 'retrieve' and not include_inactive:
+            active_q = self._active_mission_q()
+            if is_active is None or is_active.lower() in ['1', 'true', 'yes']:
+                queryset = queryset.filter(active_q)
+            elif is_active.lower() in ['0', 'false', 'no']:
+                queryset = queryset.exclude(active_q)
 
         # Filter by contribution type if specified
         contribution_type = self.request.query_params.get('contribution_type', None)
@@ -1823,6 +1831,17 @@ class MissionViewSet(viewsets.ReadOnlyModelViewSet):
             queryset = queryset.filter(contribution_type__category__slug=category)
 
         return queryset
+
+    @staticmethod
+    def _active_mission_q():
+        from django.utils import timezone
+        from django.db import models
+
+        now = timezone.now()
+        return (
+            (models.Q(start_date__isnull=True) | models.Q(start_date__lte=now))
+            & (models.Q(end_date__isnull=True) | models.Q(end_date__gt=now))
+        )
 
 
 class StartupRequestViewSet(viewsets.ReadOnlyModelViewSet):

--- a/frontend/src/lib/components/ContributionSelection.svelte
+++ b/frontend/src/lib/components/ContributionSelection.svelte
@@ -128,11 +128,10 @@
 	async function loadMissions() {
 		try {
 			// Use the missions store which caches and deduplicates requests
-			missions = await getMissions({
-				is_active: true,
-				// If we have a defaultMission, load all missions to find it regardless of category
-				category: defaultMission ? undefined : selectedCategory
-			});
+			const params = defaultMission
+				? { include_inactive: true }
+				: { is_active: true, category: selectedCategory };
+			missions = await getMissions(params);
 		} catch (error) {
 			missions = [];
 		}

--- a/frontend/src/routes/AllContributions.svelte
+++ b/frontend/src/routes/AllContributions.svelte
@@ -426,9 +426,13 @@
     }
     try {
       const res = await contributionsAPI.getMission(missionId);
-      activeMissionName = res.data?.name || '';
-      if (!typeId && res.data?.contribution_type) {
-        typeId = String(res.data.contribution_type);
+      const mission = res.data;
+      activeMissionName = mission?.name || '';
+      if (mission && !allMissions.some(m => String(m.id) === String(mission.id))) {
+        allMissions = [mission, ...allMissions];
+      }
+      if (!typeId && mission?.contribution_type) {
+        typeId = String(mission.contribution_type);
         resolveTypeName();
       }
     } catch {
@@ -441,7 +445,7 @@
     try {
       const [types, missions] = await Promise.all([
         getContributionTypes({ is_submittable: 'true' }),
-        getMissions({ is_active: true }),
+        getMissions(missionId ? { include_inactive: true } : { is_active: true }),
       ]);
       allTypes = Array.isArray(types) ? [...types].sort((a, b) => a.name.localeCompare(b.name)) : [];
       allMissions = Array.isArray(missions) ? missions : [];

--- a/frontend/src/routes/StewardSubmissions.svelte
+++ b/frontend/src/routes/StewardSubmissions.svelte
@@ -65,7 +65,7 @@
     prefetchMissions([
       { is_active: true, category: 'validator' },
       { is_active: true, category: 'builder' },
-      { is_active: true }  // Also prefetch all missions (for defaultMission lookups)
+      { include_inactive: true }  // Also prefetch all missions for defaultMission lookups
     ]);
 
     // Load permissions and templates in parallel with other data
@@ -122,7 +122,7 @@
 
   async function loadMissions() {
     try {
-      const response = await contributionsAPI.getMissions({ page_size: 100 });
+      const response = await contributionsAPI.getMissions({ include_inactive: true, page_size: 100 });
       missions = response.data.results || response.data || [];
     } catch (err) {
       // Error loading missions silently handled


### PR DESCRIPTION
Preserves mission identity for submissions and contributions after a mission deadline by allowing historical mission lookups while keeping default mission browsing active-only. Adds mission filtering plus mission and appeal context to the AI review API and updates the AI review instructions. Updates steward/contribution frontend mission lookup paths so expired missions remain resolvable in historical filters and review flows. Verification: ran Python compile checks, Django system check, and frontend build; Django test execution remains blocked by the existing test database seed-migration issue.