### PR TITLE
Invert overview featured and winners sections

### DIFF
--- a/frontend/src/routes/Overview.svelte
+++ b/frontend/src/routes/Overview.svelte
@@ -14,8 +14,8 @@
   <HeroBanner />
   <LiveStats />
   <TrendingContributors />
-  <HackathonWinnersSlider />
   <FeaturedBuilds />
+  <HackathonWinnersSlider />
   <PortalHighlights />
   <NewestMembers />
   <MiniLeaderboard />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "quebec",
+  "name": "babylon",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary
- Move Featured Builds above Hackathon Winners on the overview page.
- Update the root package-lock name from quebec to babylon.

## Verification
- npm run build passes.
- npm run check was attempted earlier and still fails on existing repo-wide diagnostics unrelated to this change.