### PR TITLE
Improve validators and leaderboard views

### DIFF
--- a/backend/leaderboard/views.py
+++ b/backend/leaderboard/views.py
@@ -2,11 +2,13 @@ from rest_framework import viewsets, permissions, filters, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from django.utils import timezone
-from django.db.models import Count, Q, Sum
+from django.db.models import Count, Exists, OuterRef, Q, Sum
 from django_filters.rest_framework import DjangoFilterBackend
 from .models import GlobalLeaderboardMultiplier, LeaderboardEntry, update_all_ranks, recalculate_all_leaderboards, LEADERBOARD_CONFIG
 from .serializers import GlobalLeaderboardMultiplierSerializer, LeaderboardEntrySerializer
 from contributions.models import Category, Contribution
+
+JOURNEY_AUTO_AWARD_SLUGS = ['builder-welcome', 'builder', 'validator-waitlist', 'validator']
 
 
 class GlobalLeaderboardMultiplierViewSet(viewsets.ReadOnlyModelViewSet):
@@ -102,6 +104,15 @@ class LeaderboardViewSet(viewsets.ReadOnlyModelViewSet):
                 # Default to validator leaderboard only when not filtering by user
                 queryset = queryset.filter(type='validator')
 
+            if leaderboard_type == 'builder':
+                eligible_builder_contributions = Contribution.objects.filter(
+                    user_id=OuterRef('user_id'),
+                    contribution_type__category__slug='builder',
+                ).exclude(
+                    contribution_type__slug__in=['builder-welcome', 'builder'],
+                )
+                queryset = queryset.filter(Exists(eligible_builder_contributions))
+
             # Handle network filtering for validators
             # Only include validators with active wallets on the specified network.
             network = self.request.query_params.get('network')
@@ -183,6 +194,65 @@ class LeaderboardViewSet(viewsets.ReadOnlyModelViewSet):
         top_entries = LeaderboardEntry.objects.filter(user__visible=True, type='validator').order_by('rank')[:10]
         serializer = self.get_serializer(top_entries, many=True)
         return Response(serializer.data)
+
+    @action(detail=False, methods=['get'])
+    def monthly(self, request):
+        """
+        Get top contributors for the current month, starting on day 1.
+        """
+        from users.models import User
+        from users.serializers import LightUserSerializer
+
+        leaderboard_type = request.query_params.get('type', 'validator')
+        if leaderboard_type not in LEADERBOARD_CONFIG:
+            return Response(
+                {'detail': f'Unknown leaderboard type: {leaderboard_type}'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            limit = int(request.query_params.get('limit', 10))
+        except (TypeError, ValueError):
+            limit = 10
+
+        now = timezone.localtime(timezone.now())
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+        monthly_totals = (
+            Contribution.objects
+            .filter(
+                user__visible=True,
+                user__leaderboard_entries__type=leaderboard_type,
+                contribution_type__category__slug=leaderboard_type,
+                contribution_date__gte=month_start,
+            )
+            .exclude(contribution_type__slug__in=JOURNEY_AUTO_AWARD_SLUGS)
+            .values('user_id')
+            .annotate(total_points=Sum('frozen_global_points'))
+            .order_by('-total_points', 'user__name')[:limit]
+        )
+
+        user_ids = [entry['user_id'] for entry in monthly_totals]
+        users_by_id = {
+            user.id: user
+            for user in User.objects.filter(id__in=user_ids)
+        }
+
+        result = []
+        for rank, entry in enumerate(monthly_totals, 1):
+            user = users_by_id.get(entry['user_id'])
+            if not user:
+                continue
+            result.append({
+                'id': f'monthly-{leaderboard_type}-{user.id}',
+                'user': user.id,
+                'user_details': LightUserSerializer(user).data,
+                'type': leaderboard_type,
+                'total_points': entry['total_points'] or 0,
+                'rank': rank,
+            })
+
+        return Response(result)
         
     @action(detail=False, methods=['get'])
     def stats(self, request):

--- a/backend/validators/views.py
+++ b/backend/validators/views.py
@@ -32,7 +32,7 @@ class ValidatorViewSet(viewsets.ModelViewSet):
         """
         Allow read-only access without authentication for public endpoints.
         """
-        if self.action in ['newest_validators']:
+        if self.action in ['all_validators', 'newest_validators']:
             return [AllowAny()]
         return [IsAuthenticated()]
     
@@ -59,6 +59,29 @@ class ValidatorViewSet(viewsets.ModelViewSet):
                 serializer.save()
                 return Response(serializer.data)
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=False, methods=['get'], url_path='all')
+    def all_validators(self, request):
+        """
+        Get all validator profile users for public ecosystem displays.
+        """
+        from users.serializers import LightUserSerializer
+
+        validators = (
+            Validator.objects
+            .select_related('user')
+            .filter(user__visible=True)
+            .order_by('display_order', '-created_at')
+        )
+
+        result = []
+        for validator in validators:
+            user_data = LightUserSerializer(validator.user).data
+            user_data['validator'] = True
+            user_data['validator_created_at'] = validator.created_at
+            result.append(user_data)
+
+        return Response(result)
     
     @action(detail=False, methods=['get'], url_path='newest')
     def newest_validators(self, request):

--- a/frontend/src/components/LeaderboardTable.svelte
+++ b/frontend/src/components/LeaderboardTable.svelte
@@ -11,15 +11,16 @@
     title = 'Leaderboard',
     subtitle = 'Top contributors ranked by points',
     compact = false,
-    hideAddress = false
+    hideAddress = false,
+    embedded = false
   } = $props();
 
   // Helper for rank styling
   function getRankClass(rank) {
-    if (rank === 1) return 'bg-amber-100 text-amber-800';
-    if (rank === 2) return 'bg-gray-100 text-gray-800';
-    if (rank === 3) return 'bg-amber-50 text-amber-700';
-    return 'bg-gray-50 text-gray-600';
+    if (rank === 1) return 'bg-[#f8b93d] text-white';
+    if (rank === 2) return 'bg-[#f1f3f7] text-[#333]';
+    if (rank === 3) return 'bg-[#c9956b] text-white';
+    return 'bg-[#f8fafc] text-[#506078]';
   }
 </script>
 
@@ -36,43 +37,43 @@
     <p class="text-gray-500">No entries found on the leaderboard yet.</p>
   </div>
 {:else}
-  <div class="bg-white shadow overflow-hidden rounded-lg">
+  <div class={embedded ? 'overflow-hidden' : 'overflow-hidden rounded-[8px] border border-[#e8ebf2] bg-white shadow-[0_8px_18px_rgba(31,42,68,0.07)]'}>
     {#if showHeader}
       <div class="px-4 py-5 sm:px-6">
-        <h3 class="text-lg leading-6 font-medium text-gray-900">
+        <h3 class="text-[18px] font-semibold leading-6 text-black">
           {title}
         </h3>
-        <p class="mt-1 max-w-2xl text-sm text-gray-500">
+        <p class="mt-1 max-w-2xl text-[14px] text-[#6b6b6b]">
           {subtitle}
         </p>
       </div>
     {/if}
     
     <div class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
+      <table class="min-w-full divide-y divide-[#eef1f6]">
+        <thead class="bg-[#f8fafc]">
           <tr>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <th scope="col" class="px-6 py-3 text-left text-[11px] font-semibold uppercase text-[#7b8798]" style="letter-spacing: 0.8px;">
               Rank
             </th>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <th scope="col" class="px-6 py-3 text-left text-[11px] font-semibold uppercase text-[#7b8798]" style="letter-spacing: 0.8px;">
               Participant
             </th>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <th scope="col" class="px-6 py-3 text-left text-[11px] font-semibold uppercase text-[#7b8798]" style="letter-spacing: 0.8px;">
               Points
             </th>
             {#if $currentCategory === 'validator'}
-              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              <th scope="col" class="px-6 py-3 text-left text-[11px] font-semibold uppercase text-[#7b8798]" style="letter-spacing: 0.8px;">
                 Active Validators
               </th>
             {/if}
           </tr>
         </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
+        <tbody class="divide-y divide-[#eef1f6] bg-white">
           {#each entries as entry, i}
-            <tr class={i % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+            <tr class="bg-white transition-colors hover:bg-[#fbfcff]">
               <td class="px-6 py-4 whitespace-nowrap">
-                <span class={`inline-flex items-center justify-center h-8 w-8 rounded-full ${getRankClass(entry.rank)}`}>
+                <span class={`inline-flex h-8 w-8 items-center justify-center rounded-full text-[13px] font-semibold ${getRankClass(entry.rank)}`}>
                   {entry.rank}
                 </span>
               </td>
@@ -90,12 +91,12 @@
                   <div>
                     <button
                       onclick={() => push(`/participant/${entry.user_details?.address || ''}`)}
-                      class="text-sm font-medium text-gray-900 hover:text-primary-600 transition-colors"
+                      class="text-[14px] font-semibold text-[#111827] transition-colors hover:text-black"
                     >
                       {entry.user_details?.name || 'N/A'}
                     </button>
                     {#if !hideAddress}
-                      <div class="text-sm text-gray-500">
+                      <div class="text-[13px] text-[#7b8798]">
                         {entry.user_details?.address || ''}
                       </div>
                     {/if}
@@ -103,19 +104,19 @@
                 </div>
               </td>
               <td class="px-6 py-4 whitespace-nowrap">
-                <div class="text-sm text-gray-900 font-medium">{entry.total_points}</div>
+                <div class="text-[14px] font-semibold text-[#111827]">{entry.total_points}</div>
               </td>
               {#if $currentCategory === 'validator'}
                 <td class="px-6 py-4 whitespace-nowrap">
                   {#if entry.active_validators_count === null}
-                    <span class="inline-block font-semibold rounded-full px-2.5 py-1.5 text-xs bg-gray-100 text-gray-500">
+                    <span class="inline-block rounded-full bg-[#f3f5f9] px-2.5 py-1.5 text-xs font-semibold text-[#7b8798]">
                       No validator
                     </span>
                   {:else}
                     <a
                       href="/validators/participants"
                       onclick={(e) => { e.preventDefault(); push('/validators/participants'); }}
-                      class="inline-block font-semibold rounded-full px-2.5 py-1.5 text-xs bg-blue-100 text-blue-800 hover:bg-blue-200 cursor-pointer transition-colors"
+                      class="inline-block cursor-pointer rounded-full bg-[#eef4ff] px-2.5 py-1.5 text-xs font-semibold text-[#387de8] transition-colors hover:bg-[#e0ebff]"
                     >
                       {entry.active_validators_count} active
                     </a>

--- a/frontend/src/components/ui/Podium.svelte
+++ b/frontend/src/components/ui/Podium.svelte
@@ -12,6 +12,10 @@
 
   // Color schemes per category
   const schemes = {
+    global: {
+      firstGradient: 'linear-gradient(135deg, #9d7cff 0%, #7f52e1 48%, #4d32a8 100%)',
+      glow: 'rgba(127, 82, 225, 0.25)',
+    },
     builder: {
       firstGradient: 'linear-gradient(to bottom, #f8b93d, #ee8d24)',
       glow: 'rgba(248, 185, 61, 0.25)',
@@ -19,6 +23,10 @@
     validator: {
       firstGradient: 'linear-gradient(135deg, #6da7f3 15%, #387de8 50%, #2159d2 85%)',
       glow: 'rgba(56, 125, 232, 0.25)',
+    },
+    steward: {
+      firstGradient: 'linear-gradient(135deg, #6bdc8a 0%, #3eb359 48%, #207b39 100%)',
+      glow: 'rgba(62, 179, 89, 0.25)',
     },
   };
 

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -112,6 +112,8 @@ export const leaderboardAPI = {
   getStats: () => api.get('/leaderboard/stats/'),
   getWaitlistStats: () => api.get('/leaderboard/validator-waitlist-stats/'),
   getWaitlistTop: (limit = 10) => api.get('/leaderboard/validator-waitlist/top/', { params: { limit } }),
+  getMonthlyLeaderboardByType: (type, limit = 10) =>
+    api.get('/leaderboard/monthly/', { params: { type, limit } }),
   getCommunity: (params = {}) => api.get('/leaderboard/community/', { params }),
   getTrending: (limit = 10) => api.get('/leaderboard/trending/', { params: { limit } }),
   getTypes: () => api.get('/leaderboard/types/'),
@@ -133,6 +135,7 @@ export const statsAPI = {
 // Validators API
 export const validatorsAPI = {
   getNewestValidators: (limit = 5) => api.get('/validators/newest/', { params: { limit } }),
+  getAllValidators: () => api.get('/validators/all/'),
   // Validator Wallets
   getAllValidatorWallets: (params = {}) => api.get('/validators/wallets/', { params }),
   getValidatorWalletsByOperator: (operatorAddress, network = null) => {

--- a/frontend/src/routes/Dashboard.svelte
+++ b/frontend/src/routes/Dashboard.svelte
@@ -76,8 +76,8 @@
         statsLoading = false;
       }).catch(() => { statsLoading = false; }),
 
-      // Leaderboard top 5
-      leaderboardAPI.getLeaderboardByType(cat, 'asc', { limit: 5 }).then(res => {
+      // Monthly leaderboard top 5, counted from day 1 of the current month.
+      leaderboardAPI.getMonthlyLeaderboardByType(cat, 5).then(res => {
         leaderboardEntries = Array.isArray(res.data) ? res.data : (res.data?.results ?? []);
         leaderboardLoading = false;
       }).catch(() => { leaderboardLoading = false; }),

--- a/frontend/src/routes/EcosystemPartners.svelte
+++ b/frontend/src/routes/EcosystemPartners.svelte
@@ -56,7 +56,7 @@
 
   function normalizeValidator(user) {
     return {
-      id: `validator-${user.address}`,
+      id: `validator-${user.address || user.id || user.name}`,
       name: user.name || 'Validator',
       logo_url: user.profile_image_url || '',
       href: user.address ? `#/participant/${user.address}` : '#',
@@ -86,9 +86,7 @@
   onMount(async () => {
     const [partnersRes, validatorsRes, buildsRes] = await Promise.allSettled([
       partnersAPI.list({ page_size: 200 }),
-      // `getNewestValidators` returns graduated validators only (users with the
-      // uptime contribution badge). Pull a wide page so we get the full list.
-      validatorsAPI.getNewestValidators(200),
+      validatorsAPI.getAllValidators(),
       featuredAPI.getBuilds(),
     ]);
 
@@ -100,7 +98,6 @@
     const validators =
       validatorsRes.status === 'fulfilled'
         ? asArray(validatorsRes.value?.data)
-            .filter((u) => u.address)
             .map(normalizeValidator)
         : [];
 

--- a/frontend/src/routes/Leaderboard.svelte
+++ b/frontend/src/routes/Leaderboard.svelte
@@ -1,183 +1,318 @@
 <script>
-  import { onMount } from 'svelte';
   import LeaderboardTable from '../components/LeaderboardTable.svelte';
+  import Podium from '../components/ui/Podium.svelte';
   import { leaderboardAPI } from '../lib/api';
-  import { currentCategory, categoryTheme } from '../stores/category.js';
+  import { currentCategory } from '../stores/category.js';
   
-  const PAGE_SIZE = 50;
+  const PAGE_SIZE = 10;
+  const PODIUM_SIZE = 3;
+  const REQUEST_SIZE = PAGE_SIZE + 1;
 
   // State management
   let leaderboard = $state([]);
   let loading = $state(true);
-  let loadingMore = $state(false);
+  let pageLoading = $state(false);
   let error = $state(null);
   let searchQuery = $state('');
-  let offset = $state(0);
-  let hasMore = $state(true);
+  let activeSearch = $state('');
+  let podiumEntries = $state([]);
+  let currentPage = $state(1);
+  let pendingPage = $state(null);
+  let hasNextPage = $state(false);
+  let activeCategory = $state(null);
+  let searchTimer;
+  let requestSequence = 0;
 
-  // Filter leaderboard based on search
-  let filteredLeaderboard = $derived(
-    !searchQuery ? leaderboard : leaderboard.filter(entry => {
-      const query = searchQuery.toLowerCase();
-      const name = entry.user_details?.name?.toLowerCase() || '';
-      const address = entry.user_details?.address?.toLowerCase() || '';
-      return name.includes(query) || address.includes(query);
-    })
-  );
+  const categoryConfig = {
+    global: {
+      title: 'Global Leaderboard',
+      label: 'participants',
+      description: 'All-time rankings across the GenLayer ecosystem.',
+      icon: '/assets/icons/group-white.svg',
+      iconClass: 'bg-black',
+      accentColor: '#7f52e1',
+      valueLabel: 'GP',
+      podiumCategory: 'global',
+    },
+    builder: {
+      title: 'Builders Leaderboard',
+      label: 'builders',
+      description: 'All-time Builder Points rankings.',
+      icon: '/assets/icons/terminal-fill-white.svg',
+      iconClass: 'bg-orange-500',
+      accentColor: '#ee8521',
+      valueLabel: 'BP',
+      podiumCategory: 'builder',
+    },
+    validator: {
+      title: 'Validators Leaderboard',
+      label: 'validators',
+      description: 'All-time Validator Points rankings.',
+      icon: '/assets/icons/shield-white.svg',
+      iconClass: 'bg-gradient-to-br from-[#8f7bff] to-[#6f8cff]',
+      accentColor: '#3a7ce7',
+      valueLabel: 'VP',
+      podiumCategory: 'validator',
+    },
+    steward: {
+      title: 'Stewards Leaderboard',
+      label: 'stewards',
+      description: 'All-time steward contribution rankings.',
+      icon: '/assets/icons/group-white.svg',
+      iconClass: 'bg-emerald-500',
+      accentColor: '#3eb359',
+      valueLabel: 'SP',
+      podiumCategory: 'steward',
+    },
+  };
 
-  // Fetch data based on category
-  async function fetchLeaderboard() {
+  let pageConfig = $derived(categoryConfig[$currentCategory] || categoryConfig.global);
+  let topEntries = $derived(podiumEntries);
+  let tableEntries = $derived(leaderboard);
+  let isSearching = $derived(searchQuery.trim().length > 0 || activeSearch.length > 0);
+  let selectedPage = $derived(pendingPage || currentPage);
+  let paginationPages = $derived((() => {
+    const pages = new Set([1, selectedPage]);
+    const start = Math.max(2, currentPage - 2);
+    const end = currentPage + (hasNextPage ? 1 : 0);
+
+    for (let page = start; page <= end; page += 1) {
+      pages.add(page);
+    }
+
+    return [...pages].filter(page => page >= 1).sort((a, b) => a - b);
+  })());
+
+  let filteredTableEntries = $derived(tableEntries);
+
+  function fetchEntries(category, options) {
+    const params = activeSearch ? { ...options, search: activeSearch } : options;
+
+    if (category === 'global') {
+      return leaderboardAPI.getLeaderboard(params);
+    }
+
+    return leaderboardAPI.getLeaderboardByType(category, 'asc', params);
+  }
+
+  async function fetchLeaderboard(page = 1, { reset = false } = {}) {
+    const category = $currentCategory || 'global';
+    const shouldShowFullLoader = reset || (podiumEntries.length === 0 && leaderboard.length === 0);
+    const requestId = ++requestSequence;
+
     try {
-      loading = true;
+      loading = shouldShowFullLoader;
+      pageLoading = !shouldShowFullLoader;
       error = null;
-      offset = 0;
 
-      let response;
-      if ($currentCategory === 'global') {
-        response = await leaderboardAPI.getLeaderboard({ limit: PAGE_SIZE, offset: 0 });
-      } else {
-        response = await leaderboardAPI.getLeaderboardByType($currentCategory, 'asc', { limit: PAGE_SIZE, offset: 0 });
-      }
+      const tableOffset = (activeSearch ? 0 : PODIUM_SIZE) + ((page - 1) * PAGE_SIZE);
+      const [podiumResponse, tableResponse] = await Promise.all([
+        fetchEntries(category, { limit: PODIUM_SIZE, offset: 0 }),
+        fetchEntries(category, { limit: REQUEST_SIZE, offset: tableOffset }),
+      ]);
 
-      const data = response.data || [];
-      leaderboard = data;
-      offset = data.length;
-      hasMore = data.length >= PAGE_SIZE;
+      if (requestId !== requestSequence) return;
+      if (category !== ($currentCategory || 'global')) return;
+
+      const tableData = tableResponse.data || [];
+      podiumEntries = podiumResponse.data || [];
+      leaderboard = tableData.slice(0, PAGE_SIZE);
+      currentPage = page;
+      hasNextPage = tableData.length > PAGE_SIZE;
     } catch (err) {
+      if (requestId !== requestSequence) return;
       error = err.message || 'Failed to load leaderboard';
     } finally {
-      loading = false;
-    }
-  }
-
-  async function loadMore() {
-    try {
-      loadingMore = true;
-
-      let response;
-      if ($currentCategory === 'global') {
-        response = await leaderboardAPI.getLeaderboard({ limit: PAGE_SIZE, offset });
-      } else {
-        response = await leaderboardAPI.getLeaderboardByType($currentCategory, 'asc', { limit: PAGE_SIZE, offset });
+      if (requestId === requestSequence) {
+        loading = false;
+        pageLoading = false;
+        pendingPage = null;
       }
-
-      const data = response.data || [];
-      leaderboard = [...leaderboard, ...data];
-      offset += data.length;
-      hasMore = data.length >= PAGE_SIZE;
-    } catch (err) {
-      console.error('Failed to load more entries:', err);
-    } finally {
-      loadingMore = false;
     }
   }
 
-  // Fetch on mount and when category changes
-  onMount(() => {
-    fetchLeaderboard();
-  });
+  function goToPage(page) {
+    if (page === currentPage || page < 1 || loading || pageLoading) return;
+    pendingPage = page;
+    fetchLeaderboard(page);
+  }
 
   // Re-fetch when category changes
   $effect(() => {
-    if ($currentCategory) {
-      fetchLeaderboard();
+    const category = $currentCategory || 'global';
+    if (category && category !== activeCategory) {
+      activeCategory = category;
+      searchQuery = '';
+      activeSearch = '';
+      pendingPage = null;
+      fetchLeaderboard(1, { reset: true });
     }
+  });
+
+  $effect(() => {
+    const query = searchQuery.trim();
+    clearTimeout(searchTimer);
+
+    searchTimer = setTimeout(() => {
+      if (query !== activeSearch) {
+        activeSearch = query;
+        pendingPage = null;
+        fetchLeaderboard(1);
+      }
+    }, 250);
+
+    return () => clearTimeout(searchTimer);
   });
 </script>
 
-<div class="space-y-6 sm:space-y-8">
-  <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-    <div>
-      <h1 class="text-2xl font-bold text-gray-900">
-        {$currentCategory === 'global' ? 'Global' :
-         $currentCategory === 'builder' ? 'Builders' :
-         $currentCategory === 'validator' ? 'Validators' :
-         $currentCategory === 'steward' ? 'Stewards' : 'Leaderboard'}
-      </h1>
-      <p class="mt-1 text-sm text-gray-500">
-        Complete rankings of {$currentCategory === 'global' ? 'all participants' :
-         $currentCategory === 'builder' ? 'builders' :
-         $currentCategory === 'validator' ? 'validators' :
-         $currentCategory === 'steward' ? 'stewards' : 'participants'}
-      </p>
-    </div>
-    
-    {#if !loading && !error && leaderboard.length > 0}
-      <div class="w-full sm:w-64">
-        <label for="search" class="sr-only">Search participants</label>
-        <div class="relative">
-          <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
-            </svg>
-          </div>
-          <input
-            id="search"
-            bind:value={searchQuery}
-            type="search"
-            class="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md leading-5 bg-white placeholder-gray-500 focus:outline-none focus:placeholder-gray-400 focus:ring-1 focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
-            placeholder="Search by name or address"
-          />
-        </div>
-      </div>
-    {/if}
+<div class="relative -mx-3 -my-3 overflow-hidden px-3 py-8 sm:px-5 sm:py-10 md:px-8 md:py-12">
+  <div
+    class="absolute inset-x-0 top-0 h-[320px] pointer-events-none overflow-hidden"
+    style="-webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 100%); mask-image: linear-gradient(to bottom, black 0%, transparent 100%);"
+  >
+    <img
+      src="/assets/illustrations/welcome-gradient.png"
+      alt=""
+      class="absolute inset-0 w-full h-full object-cover opacity-70"
+    />
+    <div class="absolute inset-0 bg-white/25"></div>
   </div>
-  
-  {#if loading}
-    <div class="flex justify-center items-center p-12">
-      <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
-    </div>
-  {:else if error}
-    <div class="bg-red-50 border-l-4 border-red-400 p-4">
-      <div class="flex">
-        <div class="flex-shrink-0">
-          <svg class="h-5 w-5 text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
-          </svg>
+
+  <div class="relative z-10 space-y-6">
+    <header class="flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
+      <div class="space-y-2">
+        <div class="flex items-center gap-3">
+          <div class="flex h-10 w-10 items-center justify-center rounded-[12px] {pageConfig.iconClass} shadow-[0_8px_18px_rgba(90,96,125,0.18)]">
+            <img src={pageConfig.icon} alt="" class="h-5 w-5" />
+          </div>
+          <h1
+            class="text-[34px] sm:text-[40px] md:text-[46px] font-semibold font-display text-black leading-none"
+            style="letter-spacing: -1px;"
+          >
+            {pageConfig.title}
+          </h1>
         </div>
-        <div class="ml-3">
-          <h3 class="text-sm font-medium text-red-800">Error loading leaderboard</h3>
-          <p class="mt-1 text-sm text-red-700">{error}</p>
-        </div>
+        <p class="max-w-2xl text-[14px] sm:text-[15px] text-[#3f4b5f]" style="letter-spacing: 0.2px;">
+          {pageConfig.description}
+        </p>
       </div>
-    </div>
-  {:else}
-    <div class="{$categoryTheme.bg === 'bg-white' ? 'bg-white' : 'bg-white/90'} shadow rounded-lg">
-      {#if searchQuery && filteredLeaderboard.length === 0}
-        <div class="p-6 text-center text-gray-500">
-          No participants found matching "{searchQuery}"
+
+      {#if !loading && !error && (leaderboard.length > 0 || podiumEntries.length > 0)}
+        <div class="w-full md:w-[320px]">
+          <label for="search" class="sr-only">Search participants</label>
+          <div class="relative">
+            <img
+              src="/assets/icons/search-line.svg"
+              alt=""
+              class="pointer-events-none absolute left-3 top-1/2 z-10 h-5 w-5 -translate-y-1/2 opacity-70"
+            />
+            <input
+              id="search"
+              bind:value={searchQuery}
+              type="search"
+              class="relative z-0 block h-[42px] w-full rounded-[8px] border border-white/70 bg-white/82 pl-11 pr-3 text-[14px] text-[#111827] shadow-[0_8px_22px_rgba(31,42,68,0.08)] outline-none backdrop-blur-md placeholder:text-[#7b8798] focus:border-black focus:ring-2 focus:ring-black/10"
+              placeholder="Search by name or address"
+            />
+          </div>
+        </div>
+      {/if}
+    </header>
+
+    <section class="rounded-[10px] border border-white/70 bg-white/78 p-5 sm:p-7 md:p-8 shadow-[0_18px_55px_rgba(38,48,75,0.15)] backdrop-blur-md">
+      {#if loading}
+        <div class="space-y-8">
+          <div>
+            <div class="mb-4 h-6 w-44 rounded-full bg-[#f2f3f7] animate-pulse"></div>
+            <Podium
+              entries={[]}
+              loading={true}
+              accentColor={pageConfig.accentColor}
+              valueLabel={pageConfig.valueLabel}
+              category={pageConfig.podiumCategory}
+            />
+          </div>
+          <div class="h-[320px] rounded-[8px] border border-[#e8ebf2] bg-white shadow-[0_8px_18px_rgba(31,42,68,0.07)] animate-pulse"></div>
+        </div>
+      {:else if error}
+        <div class="rounded-[8px] border border-red-100 bg-red-50 p-5">
+          <h3 class="text-[14px] font-semibold text-red-800">Error loading leaderboard</h3>
+          <p class="mt-1 text-[13px] text-red-700">{error}</p>
         </div>
       {:else}
-        <div class="px-4 py-3 border-b border-gray-200">
-          <p class="text-sm text-gray-700">
-            Showing {searchQuery ? `${filteredLeaderboard.length} of` : ''} {leaderboard.length} participants
-          </p>
-        </div>
-        <LeaderboardTable
-          entries={filteredLeaderboard}
-          loading={false}
-          error={null}
-          showHeader={false}
-        />
-      {/if}
-    </div>
-
-    {#if hasMore && !searchQuery}
-      <div class="flex justify-center py-4">
-        <button
-          onclick={loadMore}
-          disabled={loadingMore}
-          class="px-6 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
-        >
-          {#if loadingMore}
-            Loading...
-          {:else}
-            Load more
+        <div class="space-y-8 md:space-y-10">
+          {#if !isSearching}
+            <section>
+              <Podium
+                entries={topEntries}
+                loading={false}
+                accentColor={pageConfig.accentColor}
+                valueLabel={pageConfig.valueLabel}
+                category={pageConfig.podiumCategory}
+              />
+            </section>
           {/if}
-        </button>
-      </div>
-    {/if}
-  {/if}
+
+          <section class={!isSearching ? 'border-t border-[#e9ecf3] pt-6 md:pt-8' : ''}>
+            <div class={`overflow-hidden rounded-[8px] border border-[#e8ebf2] bg-white shadow-[0_8px_18px_rgba(31,42,68,0.07)] transition-opacity duration-200 ${pageLoading ? 'opacity-60' : 'opacity-100'}`}>
+              {#if searchQuery && filteredTableEntries.length === 0}
+                <div class="p-8 text-center text-[14px] text-[#6b6b6b]">
+                  No participants found matching "{searchQuery.trim()}"
+                </div>
+              {:else}
+                <LeaderboardTable
+                  entries={filteredTableEntries}
+                  loading={false}
+                  error={null}
+                  showHeader={false}
+                  embedded={true}
+                />
+              {/if}
+            </div>
+          </section>
+        </div>
+
+        {#if currentPage > 1 || hasNextPage}
+          <div class="mt-6 flex flex-wrap items-center justify-center gap-2">
+            <button
+              onclick={() => goToPage(currentPage - 1)}
+              disabled={currentPage === 1 || loading || pageLoading}
+              class="inline-flex h-10 items-center justify-center rounded-[8px] border border-[#dfe4ee] bg-white px-4 text-[13px] font-semibold text-[#111827] shadow-[0_8px_18px_rgba(31,42,68,0.07)] transition hover:-translate-y-0.5 hover:shadow-[0_14px_26px_rgba(31,42,68,0.12)] disabled:translate-y-0 disabled:opacity-45 disabled:shadow-none"
+            >
+              Previous
+            </button>
+
+            {#if paginationPages[1] && paginationPages[1] > 2}
+              <span class="inline-flex h-10 min-w-10 items-center justify-center text-[13px] font-semibold text-[#7b8798]">...</span>
+            {/if}
+
+            {#each paginationPages as page}
+              <button
+                onclick={() => goToPage(page)}
+                disabled={page === selectedPage || loading || pageLoading}
+                class={`inline-flex h-10 min-w-10 items-center justify-center rounded-[8px] border px-3 text-[13px] font-semibold shadow-[0_8px_18px_rgba(31,42,68,0.06)] transition ${
+                  page === selectedPage
+                    ? 'text-white'
+                    : 'border-[#dfe4ee] bg-white text-[#111827] hover:-translate-y-0.5 hover:shadow-[0_14px_26px_rgba(31,42,68,0.12)]'
+                } disabled:translate-y-0 disabled:shadow-none`}
+                style={page === selectedPage ? `background-color: ${pageConfig.accentColor}; border-color: ${pageConfig.accentColor};` : ''}
+                aria-current={page === selectedPage ? 'page' : undefined}
+              >
+                {page}
+              </button>
+            {/each}
+
+            <button
+              onclick={() => goToPage(currentPage + 1)}
+              disabled={!hasNextPage || loading || pageLoading}
+              class="inline-flex h-10 items-center justify-center rounded-[8px] border border-[#dfe4ee] bg-white px-4 text-[13px] font-semibold text-[#111827] shadow-[0_8px_18px_rgba(31,42,68,0.07)] transition hover:-translate-y-0.5 hover:shadow-[0_14px_26px_rgba(31,42,68,0.12)] disabled:translate-y-0 disabled:opacity-45 disabled:shadow-none"
+            >
+              Next
+            </button>
+          </div>
+        {/if}
+      {/if}
+    </section>
+  </div>
 </div>
 
 <style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "quebec",
+  "name": "mumbai",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Fetch all visible validators for Ecosystem Partners through a new public validators endpoint. Add a monthly leaderboard endpoint for Dashboard top contributors that starts from day 1 of the month and excludes journey auto-awards. Refresh the Leaderboard UI with the rebranded podium/table styling, server-backed search, compact pagination, and category-colored selected pages. Restrict builder leaderboard rows to builders with real builder-category contributions and add proper podium palettes for global and steward tabs.