### PR TITLE
Allow users to refresh GitHub username

### DIFF
--- a/backend/social_connections/github_oauth.py
+++ b/backend/social_connections/github_oauth.py
@@ -2,6 +2,7 @@
 
 from urllib.parse import urlencode
 
+import requests
 from django.conf import settings
 from django.shortcuts import redirect
 from django.views.decorators.csrf import csrf_exempt
@@ -13,6 +14,7 @@ from rest_framework import status
 from tally.middleware.logging_utils import get_app_logger
 
 from .oauth_service import GitHubOAuthService
+from .serializers import GitHubConnectionSerializer
 
 logger = get_app_logger('github_oauth')
 service = GitHubOAuthService()
@@ -58,6 +60,54 @@ def disconnect_github(request):
         pass
 
     return Response({'message': 'GitHub account disconnected successfully'}, status=status.HTTP_200_OK)
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def refresh_github_username(request):
+    """Refresh the linked GitHub username from GitHub's current user API."""
+    from .models import GitHubConnection
+
+    try:
+        connection = request.user.githubconnection
+    except GitHubConnection.DoesNotExist:
+        return Response({
+            'error': 'GitHub account not linked',
+        }, status=status.HTTP_400_BAD_REQUEST)
+
+    try:
+        connection, changed = service.refresh_connection_username(connection)
+    except ValueError as e:
+        error_code = str(e)
+        if error_code in ('missing_access_token', 'invalid_access_token'):
+            return Response({
+                'error': 'GitHub authorization is no longer valid. Please reconnect GitHub.',
+                'code': error_code,
+            }, status=status.HTTP_400_BAD_REQUEST)
+        if error_code == 'account_mismatch':
+            logger.warning(
+                "GitHub refresh returned a different account for user %s",
+                request.user.id,
+            )
+            return Response({
+                'error': 'GitHub account mismatch. Please reconnect GitHub.',
+                'code': error_code,
+            }, status=status.HTTP_409_CONFLICT)
+        logger.error(f"Failed to refresh GitHub username: {e}")
+        return Response({
+            'error': 'Failed to refresh GitHub username',
+        }, status=status.HTTP_400_BAD_REQUEST)
+    except requests.RequestException as e:
+        logger.error(f"GitHub API request failed while refreshing username: {e}")
+        return Response({
+            'error': 'Failed to reach GitHub. Please try again.',
+        }, status=status.HTTP_502_BAD_GATEWAY)
+
+    return Response({
+        'message': 'GitHub username refreshed successfully',
+        'changed': changed,
+        'github_connection': GitHubConnectionSerializer(connection).data,
+    }, status=status.HTTP_200_OK)
 
 
 @api_view(['GET'])

--- a/backend/social_connections/oauth_service.py
+++ b/backend/social_connections/oauth_service.py
@@ -6,6 +6,7 @@ import base64
 from urllib.parse import urlencode, urlparse, urlunparse
 
 import requests
+from cryptography.fernet import InvalidToken
 from django.conf import settings
 from django.core import signing
 from django.http import HttpResponseRedirect
@@ -370,6 +371,31 @@ class GitHubOAuthService(OAuthService):
             'platform_user_id': str(data['id']),
             'platform_username': data['login'],
         }
+
+    def refresh_connection_username(self, connection):
+        """Refresh a linked GitHub username using the stored OAuth token."""
+        if not connection.access_token:
+            raise ValueError('missing_access_token')
+
+        try:
+            access_token = decrypt_token(connection.access_token)
+        except InvalidToken as exc:
+            raise ValueError('invalid_access_token') from exc
+
+        user_info = self.fetch_user_info(access_token)
+        platform_user_id = str(user_info.get('platform_user_id', ''))
+        platform_username = str(user_info.get('platform_username', ''))[:100]
+
+        if platform_user_id != str(connection.platform_user_id):
+            raise ValueError('account_mismatch')
+
+        changed = platform_username != connection.platform_username
+        if changed:
+            connection.platform_username = platform_username
+            connection.updated_at = timezone.now()
+            connection.save(update_fields=['platform_username', 'updated_at'])
+
+        return connection, changed
 
     def check_repo_star(self, connection):
         """Check if user has starred the configured repository."""

--- a/backend/social_connections/tests/test_github_oauth.py
+++ b/backend/social_connections/tests/test_github_oauth.py
@@ -6,7 +6,12 @@ from rest_framework.test import force_authenticate
 
 from users.models import User
 from social_connections.models import GitHubConnection
-from social_connections.github_oauth import github_oauth_initiate, disconnect_github, check_repo_star
+from social_connections.github_oauth import (
+    github_oauth_initiate,
+    disconnect_github,
+    check_repo_star,
+    refresh_github_username,
+)
 from social_connections.oauth_service import GitHubOAuthService
 
 TEST_ENCRYPTION_KEY = 'dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdGtleXQ='
@@ -73,6 +78,55 @@ class GitHubOAuthTest(TestCase):
         response = check_repo_star(request)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.data['has_starred'])
+
+    @patch('social_connections.oauth_service.decrypt_token', return_value='test_token')
+    @patch('social_connections.oauth_service.requests')
+    def test_refresh_github_username_updates_existing_connection(self, mock_requests, mock_decrypt_token):
+        GitHubConnection.objects.create(
+            user=self.user,
+            platform_user_id='12345',
+            platform_username='old-name',
+            access_token='encrypted-token',
+            linked_at=timezone.now(),
+        )
+
+        mock_user_response = MagicMock()
+        mock_user_response.raise_for_status = MagicMock()
+        mock_user_response.json.return_value = {'id': 12345, 'login': 'new-name'}
+        mock_requests.get.return_value = mock_user_response
+
+        request = self.factory.post('/api/v1/users/github/refresh/')
+        force_authenticate(request, user=self.user)
+        response = refresh_github_username(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data['changed'])
+        self.assertEqual(response.data['github_connection']['platform_username'], 'new-name')
+        self.assertEqual(self.user.githubconnection.platform_username, 'new-name')
+
+    @patch('social_connections.oauth_service.decrypt_token', return_value='test_token')
+    @patch('social_connections.oauth_service.requests')
+    def test_refresh_github_username_rejects_account_mismatch(self, mock_requests, mock_decrypt_token):
+        GitHubConnection.objects.create(
+            user=self.user,
+            platform_user_id='12345',
+            platform_username='old-name',
+            access_token='encrypted-token',
+            linked_at=timezone.now(),
+        )
+
+        mock_user_response = MagicMock()
+        mock_user_response.raise_for_status = MagicMock()
+        mock_user_response.json.return_value = {'id': 99999, 'login': 'other-name'}
+        mock_requests.get.return_value = mock_user_response
+
+        request = self.factory.post('/api/v1/users/github/refresh/')
+        force_authenticate(request, user=self.user)
+        response = refresh_github_username(request)
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.data['code'], 'account_mismatch')
+        self.assertEqual(self.user.githubconnection.platform_username, 'old-name')
 
     @patch('social_connections.oauth_service.requests')
     def test_callback_full_flow(self, mock_requests):

--- a/backend/social_connections/urls.py
+++ b/backend/social_connections/urls.py
@@ -1,6 +1,11 @@
 from django.urls import path
 
-from .github_oauth import github_oauth_initiate, github_oauth_callback, check_repo_star
+from .github_oauth import (
+    github_oauth_initiate,
+    github_oauth_callback,
+    check_repo_star,
+    refresh_github_username,
+)
 from .twitter_oauth import twitter_oauth_initiate, twitter_oauth_callback
 from .discord_oauth import discord_oauth_initiate, discord_oauth_callback, check_discord_guild
 
@@ -8,6 +13,7 @@ urlpatterns = [
     # GitHub OAuth
     path('api/auth/github/', github_oauth_initiate, name='github_oauth'),
     path('api/auth/github/callback/', github_oauth_callback, name='github_callback'),
+    path('api/v1/users/github/refresh/', refresh_github_username, name='github_refresh_username'),
     path('api/v1/users/github/check-star/', check_repo_star, name='github_check_star'),
 
     # Twitter OAuth

--- a/frontend/src/components/SocialLink.svelte
+++ b/frontend/src/components/SocialLink.svelte
@@ -2,7 +2,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { authState } from '../lib/auth';
   import { API_BASE_URL } from '../lib/config.js';
-  import { getCurrentUser } from '../lib/api';
+  import { getCurrentUser, socialAPI } from '../lib/api';
   import { showSuccess, showError } from '../lib/toastStore';
 
   let {
@@ -15,6 +15,7 @@
   } = $props();
 
   let isLinking = $state(false);
+  let isRefreshing = $state(false);
   let handledOAuthResult = $state(false);
 
   // Imperative bookkeeping — plain let, NOT $state, to avoid Svelte 5
@@ -255,6 +256,31 @@
       }
     }, 500);
   }
+
+  async function refreshAccount() {
+    if (!$authState.isAuthenticated || platform !== 'github' || !connection || isRefreshing) {
+      return;
+    }
+
+    isRefreshing = true;
+    try {
+      const response = await socialAPI.refreshGitHubUsername();
+      const updatedUser = await getCurrentUser();
+      const updatedConnection = response.data?.github_connection;
+      const username = updatedConnection?.platform_username || connection.platform_username;
+      showSuccess(
+        response.data?.changed
+          ? `GitHub username updated to @${username}`
+          : 'GitHub username is already up to date'
+      );
+      onLinked(updatedUser);
+    } catch (error) {
+      const message = error?.response?.data?.error || 'Could not refresh GitHub username. Please try again.';
+      showError(message);
+    } finally {
+      isRefreshing = false;
+    }
+  }
 </script>
 
 {#if compact}
@@ -300,11 +326,37 @@
   <!-- Full mode: for ProfileEdit -->
   {#if connection}
     <div
-      class="px-4 py-3 rounded-[8px] text-white flex items-center gap-2.5"
+      class="social-connected-row"
       style="background-color: {config.color};"
     >
-      <span class="flex-shrink-0 opacity-90">{@html config.icon}</span>
-      <span class="font-medium text-sm">{connection.platform_username}</span>
+      <div class="social-connected-identity">
+        <span class="flex-shrink-0 opacity-90">{@html config.icon}</span>
+        <span class="font-medium text-sm">{connection.platform_username}</span>
+      </div>
+      {#if platform === 'github'}
+        <button
+          type="button"
+          class="social-refresh-btn"
+          onclick={refreshAccount}
+          disabled={isRefreshing}
+          title="Refresh GitHub username"
+          aria-label="Refresh GitHub username"
+        >
+          {#if isRefreshing}
+            <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+          {:else}
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M21 12a9 9 0 0 0-15-6.7L3 8"></path>
+              <path d="M3 3v5h5"></path>
+              <path d="M3 12a9 9 0 0 0 15 6.7l3-2.7"></path>
+              <path d="M21 21v-5h-5"></path>
+            </svg>
+          {/if}
+        </button>
+      {/if}
     </div>
     {#if connection.linked_at}
       <p class="text-xs text-gray-400 mt-1">
@@ -357,6 +409,57 @@
 
   .social-connect-btn:disabled {
     opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .social-connected-row {
+    width: 100%;
+    min-height: 44px;
+    padding: 0.625rem 0.75rem 0.625rem 1rem;
+    border-radius: 8px;
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .social-connected-identity {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+  }
+
+  .social-connected-identity span:last-child {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .social-refresh-btn {
+    width: 30px;
+    height: 30px;
+    flex: 0 0 30px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;
+    border: 1px solid rgba(255, 255, 255, 0.26);
+    background: rgba(255, 255, 255, 0.12);
+    color: white;
+    cursor: pointer;
+    transition: background-color 0.15s, border-color 0.15s, opacity 0.15s;
+  }
+
+  .social-refresh-btn:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.2);
+    border-color: rgba(255, 255, 255, 0.42);
+  }
+
+  .social-refresh-btn:disabled {
+    opacity: 0.65;
     cursor: not-allowed;
   }
 

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -180,6 +180,7 @@ export const githubAPI = {
 
 // Social connections API
 export const socialAPI = {
+  refreshGitHubUsername: () => api.post('/users/github/refresh/'),
   checkDiscordGuild: () => api.get('/users/discord/check-guild/'),
 };
 


### PR DESCRIPTION
Adds an authenticated GitHub username refresh endpoint that re-fetches the linked account with the stored OAuth token and verifies the GitHub account id before updating. Adds a refresh action to the connected GitHub account UI with single-flight request handling. Includes focused backend coverage for successful username updates and account mismatch rejection.