### PR TITLE
Fix Phantom sign-in and allow X intent URLs as evidence

### DIFF
--- a/backend/contributions/tests/test_url_utils.py
+++ b/backend/contributions/tests/test_url_utils.py
@@ -200,6 +200,16 @@ class ExtractHandleTests(TestCase):
         )
         self.assertEqual(handle, 'johndoe')
 
+    def test_x_intent_url_returns_none(self):
+        """X 'intent' URLs (e.g. /i/status/...) use 'i' as a reserved
+        segment rather than a real handle. extract_handle must return
+        None so ownership validation is skipped."""
+        url_type = EvidenceURLType.objects.get(slug='x-post')
+        handle = extract_handle(
+            'https://x.com/i/status/2020874480562659811', url_type,
+        )
+        self.assertIsNone(handle)
+
 
 class ValidateHandleOwnershipTests(TestCase):
     """Tests for handle ownership validation."""
@@ -286,6 +296,23 @@ class ValidateHandleOwnershipTests(TestCase):
         )
         self.assertIsNotNone(result)
         self.assertIn('otheruser', result)
+
+    def test_x_intent_url_bypasses_ownership_check(self):
+        """X intent URLs (/i/status/...) do not contain a real handle; the
+        user should be allowed to submit them even when their linked X
+        handle is different."""
+        from social_connections.models import TwitterConnection
+        TwitterConnection.objects.create(
+            user=self.user,
+            platform_user_id='12345',
+            platform_username='myhandle',
+            linked_at='2025-01-01T00:00:00Z',
+        )
+        url_type = EvidenceURLType.objects.get(slug='x-post')
+        result = validate_handle_ownership(
+            'https://x.com/i/status/2020874480562659811', url_type, self.user,
+        )
+        self.assertIsNone(result)
 
 
 class CheckDuplicateUrlTests(TestCase):

--- a/backend/contributions/url_utils.py
+++ b/backend/contributions/url_utils.py
@@ -117,7 +117,14 @@ def extract_handle(url, evidence_url_type):
     try:
         match = re.search(evidence_url_type.handle_extract_pattern, url, re.IGNORECASE)
         if match:
-            return match.group('handle').lower()
+            handle = match.group('handle').lower()
+            # X's intent URLs (e.g. https://x.com/i/status/123) use 'i' as a
+            # reserved segment, not a real handle. Returning None routes these
+            # through the "no handle, skip ownership check" path in
+            # validate_handle_ownership.
+            if handle == 'i' and evidence_url_type.slug == 'x-post':
+                return None
+            return handle
     except (re.error, IndexError):
         pass
     return None

--- a/backend/ethereum_auth/views.py
+++ b/backend/ethereum_auth/views.py
@@ -109,7 +109,7 @@ def login(request):
         # Verify the signature using eth_account
         message_hash = encode_defunct(text=message)
         recovered_address = Account.recover_message(message_hash, signature=signature)
-        
+
         if recovered_address.lower() != ethereum_address:
             return Response(
                 {'error': 'Invalid signature: address mismatch'},

--- a/frontend/src/components/WalletSelector.svelte
+++ b/frontend/src/components/WalletSelector.svelte
@@ -271,7 +271,7 @@
     try {
       // Get the provider (now async)
       const provider = await wallet.getProvider();
-      
+
       // Check if user aborted
       if (connectionAborted) {
         return;

--- a/frontend/src/lib/auth.js
+++ b/frontend/src/lib/auth.js
@@ -203,31 +203,48 @@ export async function getNonce() {
 export async function createAndSignMessage(address, nonce, provider = null) {
   const domain = window.location.host;
   const origin = window.location.origin;
-  
-  // Create a message string directly instead of using SiweMessage
+
+  // Use provided provider or default to window.ethereum
+  const ethereumProvider = provider || window.ethereum;
+
+  // Phantom rejects personal_sign when the SIWE Chain ID doesn't match the
+  // wallet's active chain. Reflect whatever the wallet reports; the backend
+  // doesn't validate chain id.
+  let chainId = 4221;
+  try {
+    const chainIdHex = await ethereumProvider.request({ method: 'eth_chainId' });
+    if (chainIdHex) {
+      chainId = parseInt(chainIdHex, 16);
+    }
+  } catch (chainIdError) {
+    // fall back to default
+  }
+
+  // EIP-4361 requires the address in the SIWE message body to use EIP-55
+  // checksum encoding. Phantom enforces this and rejects lowercase addresses.
+  let checksumAddress = address;
+  try {
+    checksumAddress = ethers.getAddress(address);
+  } catch (checksumError) {
+    // fall back to raw address
+  }
+
   const messageToSign = `${domain} wants you to sign in with your Ethereum account:
-${address}
+${checksumAddress}
 
 Sign in with Ethereum to GenLayer Testnet Contributions
 
 URI: ${origin}
 Version: 1
-Chain ID: 4221
+Chain ID: ${chainId}
 Nonce: ${nonce}
 Issued At: ${new Date().toISOString()}`;
-  
-  // Use provided provider or default to window.ethereum
-  const ethereumProvider = provider || window.ethereum;
-  
-  // Request signature from wallet
+
   const ethersProvider = new ethers.BrowserProvider(ethereumProvider);
   const signer = await ethersProvider.getSigner();
   const signature = await signer.signMessage(messageToSign);
-  
-  return {
-    message: messageToSign,
-    signature
-  };
+
+  return { message: messageToSign, signature };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix Phantom wallet sign-in (desktop + mobile) by reading the wallet's active chain via `eth_chainId` for the SIWE `Chain ID:` line and writing the address in EIP-55 checksum form, both of which Phantom enforces strictly while MetaMask/Trust/Coinbase tolerate either form.
- Allow X intent URLs like `https://x.com/i/status/123` as evidence by skipping ownership validation when the extracted handle is the reserved `i` segment, scoped to the `x-post` URL type.

## Test plan
- [ ] Sign in with Phantom on desktop while wallet is on Ethereum mainnet (chain 1) — should succeed.
- [ ] Sign in with Phantom mobile via the in-app browser deeplink — should succeed.
- [ ] Sign in with MetaMask — should still succeed; backend still lowercases both sides of address comparison.
- [ ] Submit an X intent URL (`https://x.com/i/status/<id>`) as evidence on an x-post-accepting type — should pass ownership validation.
- [ ] Submit a normal X post URL with a handle other than the user's linked X handle — should still be rejected.