### PR TITLE
Fix Gen TV stream image refresh

### DIFF
--- a/backend/gen_tv/migrations/0003_upsert_fud_markets_stream.py
+++ b/backend/gen_tv/migrations/0003_upsert_fud_markets_stream.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timedelta, timezone
+
+from django.db import migrations
+
+
+FUD_STREAM = {
+    "slug": "fud-markets-testnet-launch",
+    "title": "FUD Markets Testnet Launch Livestream",
+    "description": (
+        "@raskovsky and @theboymarc0x's deep dive on the recently launched app FUD "
+        "Markets that uses GenLayer's technology, their Testnet and Mainnet phases.\n\n"
+        "Speakers: @raskovsky, @theboymarc0x"
+    ),
+    "url": "https://x.com/GenLayer/status/2054659264912687394",
+    "image_url": "https://res.cloudinary.com/dfqmoeawa/image/upload/gen_tv/fud-markets-testnet-launch.png",
+    "starts_at": datetime(2026, 5, 15, 15, 0, tzinfo=timezone.utc),
+    "category": "internal",
+    "is_active": True,
+}
+
+
+def upsert_fud_markets_stream(apps, schema_editor):
+    Stream = apps.get_model("gen_tv", "Stream")
+    starts_at = FUD_STREAM["starts_at"]
+    defaults = {
+        key: value
+        for key, value in FUD_STREAM.items()
+        if key != "slug"
+    }
+    defaults["ends_at"] = starts_at + timedelta(minutes=30)
+
+    stream = Stream.objects.filter(url=FUD_STREAM["url"]).order_by("id").first()
+    if stream is None:
+        stream = Stream.objects.filter(slug=FUD_STREAM["slug"]).first()
+
+    if stream is None:
+        Stream.objects.create(slug=FUD_STREAM["slug"], **defaults)
+        return
+
+    for field, value in defaults.items():
+        setattr(stream, field, value)
+    stream.save(update_fields=[*defaults.keys(), "updated_at"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("gen_tv", "0002_seed_streams"),
+    ]
+
+    operations = [
+        migrations.RunPython(upsert_fud_markets_stream, migrations.RunPython.noop),
+    ]

--- a/backend/gen_tv/serializers.py
+++ b/backend/gen_tv/serializers.py
@@ -21,6 +21,7 @@ class LightStreamSerializer(serializers.ModelSerializer):
             'ends_at',
             'category',
             'status',
+            'updated_at',
         ]
         read_only_fields = fields
 

--- a/frontend/src/components/portal/gen-tv/LiveStreamHero.svelte
+++ b/frontend/src/components/portal/gen-tv/LiveStreamHero.svelte
@@ -17,6 +17,21 @@
     }
   }
 
+  function withImageCacheKey(url, key) {
+    if (!url || !key) return url || '';
+    try {
+      const imageUrl = new URL(url);
+      imageUrl.searchParams.set('v', key);
+      return imageUrl.toString();
+    } catch {
+      return `${url}${url.includes('?') ? '&' : '?'}v=${encodeURIComponent(key)}`;
+    }
+  }
+
+  function imageSrc(item) {
+    return withImageCacheKey(item.image_url, item.updated_at || item.id);
+  }
+
   function selectStream(index) {
     currentIndex = index;
     startAutoAdvance();
@@ -66,9 +81,9 @@
         style="opacity: {i === currentIndex ? 1 : 0};"
       >
         <div class="absolute inset-0 bg-gradient-to-br from-[#202020] via-[#111] to-black"></div>
-        {#if item.image_url}
+        {#if imageSrc(item)}
           <img
-            src={item.image_url}
+            src={imageSrc(item)}
             alt=""
             class="absolute inset-0 h-full w-full scale-110 object-cover opacity-45 blur-2xl"
             loading={i === 0 ? 'eager' : 'lazy'}
@@ -77,7 +92,7 @@
             }}
           />
           <img
-            src={item.image_url}
+            src={imageSrc(item)}
             alt=""
             class="absolute inset-0 h-full w-full object-cover sm:object-contain"
             loading={i === 0 ? 'eager' : 'lazy'}

--- a/frontend/src/components/portal/gen-tv/StreamCard.svelte
+++ b/frontend/src/components/portal/gen-tv/StreamCard.svelte
@@ -46,6 +46,17 @@
     return !url || url.includes('/default-banner.');
   }
 
+  function withImageCacheKey(url, key) {
+    if (!url || !key) return url || '';
+    try {
+      const imageUrl = new URL(url);
+      imageUrl.searchParams.set('v', key);
+      return imageUrl.toString();
+    } catch {
+      return `${url}${url.includes('?') ? '&' : '?'}v=${encodeURIComponent(key)}`;
+    }
+  }
+
   let imageFailed = $state(false);
   let isLive = $derived(variant === 'live');
   let isUpcoming = $derived(variant === 'upcoming');
@@ -54,7 +65,14 @@
   let duration = $derived(formatDuration(stream.starts_at, stream.ends_at));
   let dateTime = $derived(formatDateTime(stream.starts_at));
   let description = $derived(descriptionPreview(stream.description));
+  let imageSrc = $derived(withImageCacheKey(stream.image_url, stream.updated_at || stream.id));
   let showDefaultInfo = $derived(isDefaultImage(stream.image_url) || imageFailed);
+
+  $effect(() => {
+    stream.image_url;
+    stream.updated_at;
+    imageFailed = false;
+  });
 </script>
 
 <a
@@ -66,9 +84,9 @@
 >
   <div class="relative w-full aspect-[16/9]">
     <div class="absolute inset-0 bg-gradient-to-br from-[#202020] via-[#111] to-black"></div>
-    {#if stream.image_url}
+    {#if imageSrc}
       <img
-        src={stream.image_url}
+        src={imageSrc}
         alt=""
         class="absolute inset-0 w-full h-full object-cover"
         loading="lazy"


### PR DESCRIPTION
## Summary
- add a follow-up Gen TV data migration that updates the FUD Markets stream by URL, so manually-created/admin rows are not duplicated
- include `updated_at` in Gen TV list payloads
- append an image cache key in Gen TV cards and live hero images so admin image updates do not keep showing a stale blank/fallback card

## Validation
- `npm run build` passes with existing app-wide Svelte accessibility/chunk warnings
- `env/bin/python manage.py migrate gen_tv --plan` shows `gen_tv.0003_upsert_fud_markets_stream`
- direct browser check loads the Cloudinary FUD image at 1920x1080

Note: left the unrelated local `package-lock.json` workspace-name change uncommitted.