### PR TITLE
Add social account refresh actions

### DIFF
--- a/backend/social_connections/discord_oauth.py
+++ b/backend/social_connections/discord_oauth.py
@@ -2,6 +2,7 @@
 
 from urllib.parse import urlencode
 
+import requests
 from django.conf import settings
 from django.shortcuts import redirect
 from django.views.decorators.csrf import csrf_exempt
@@ -14,6 +15,7 @@ from tally.middleware.logging_utils import get_app_logger
 
 from .encryption import decrypt_token
 from .oauth_service import DiscordOAuthService
+from .serializers import DiscordConnectionSerializer
 
 logger = get_app_logger('discord_oauth')
 service = DiscordOAuthService()
@@ -59,6 +61,61 @@ def disconnect_discord(request):
         pass
 
     return Response({'message': 'Discord account disconnected successfully'}, status=status.HTTP_200_OK)
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def refresh_discord_username(request):
+    """Refresh the linked Discord username from Discord's current user API."""
+    from .models import DiscordConnection
+
+    try:
+        connection = request.user.discordconnection
+    except DiscordConnection.DoesNotExist:
+        return Response({
+            'error': 'Discord account not linked',
+        }, status=status.HTTP_400_BAD_REQUEST)
+
+    try:
+        connection, changed = service.refresh_connection_username(connection)
+    except ValueError as e:
+        error_code = str(e)
+        if error_code in (
+            'missing_access_token',
+            'invalid_access_token',
+            'missing_refresh_token',
+            'invalid_refresh_token',
+            'refresh_not_supported',
+            'no_access_token',
+        ):
+            return Response({
+                'error': 'Discord authorization is no longer valid. Please reconnect Discord.',
+                'code': error_code,
+            }, status=status.HTTP_400_BAD_REQUEST)
+        if error_code == 'account_mismatch':
+            logger.warning(
+                "Discord refresh returned a different account for user %s",
+                request.user.id,
+            )
+            return Response({
+                'error': 'Discord account mismatch. Please reconnect Discord.',
+                'code': error_code,
+            }, status=status.HTTP_409_CONFLICT)
+        logger.error(f"Failed to refresh Discord username: {e}")
+        return Response({
+            'error': 'Failed to refresh Discord username',
+        }, status=status.HTTP_400_BAD_REQUEST)
+    except requests.RequestException as e:
+        logger.error(f"Discord API request failed while refreshing username: {e}")
+        return Response({
+            'error': 'Failed to reach Discord. Please try again.',
+        }, status=status.HTTP_502_BAD_GATEWAY)
+
+    return Response({
+        'message': 'Discord username refreshed successfully',
+        'changed': changed,
+        'discord_connection': DiscordConnectionSerializer(connection).data,
+    }, status=status.HTTP_200_OK)
 
 
 @api_view(['GET'])

--- a/backend/social_connections/github_oauth.py
+++ b/backend/social_connections/github_oauth.py
@@ -79,7 +79,14 @@ def refresh_github_username(request):
         connection, changed = service.refresh_connection_username(connection)
     except ValueError as e:
         error_code = str(e)
-        if error_code in ('missing_access_token', 'invalid_access_token'):
+        if error_code in (
+            'missing_access_token',
+            'invalid_access_token',
+            'missing_refresh_token',
+            'invalid_refresh_token',
+            'refresh_not_supported',
+            'no_access_token',
+        ):
             return Response({
                 'error': 'GitHub authorization is no longer valid. Please reconnect GitHub.',
                 'code': error_code,

--- a/backend/social_connections/oauth_service.py
+++ b/backend/social_connections/oauth_service.py
@@ -6,6 +6,7 @@ import base64
 from urllib.parse import urlencode, urlparse, urlunparse
 
 import requests
+from requests import HTTPError
 from cryptography.fernet import InvalidToken
 from django.conf import settings
 from django.core import signing
@@ -138,6 +139,96 @@ class OAuthService:
     def fetch_user_info(self, access_token):
         """Fetch and normalize user info. Returns dict with 'platform_user_id', 'platform_username', and any extras."""
         raise NotImplementedError
+
+    def refresh_access_token(self, refresh_token):
+        """Refresh an OAuth access token. Override for providers that support it."""
+        raise ValueError('refresh_not_supported')
+
+    def refresh_stored_access_token(self, connection):
+        """Rotate a stored OAuth access token using the stored refresh token."""
+        if not connection.refresh_token:
+            raise ValueError('missing_refresh_token')
+
+        try:
+            refresh_token = decrypt_token(connection.refresh_token)
+        except InvalidToken as exc:
+            raise ValueError('invalid_refresh_token') from exc
+
+        try:
+            token_data = self.refresh_access_token(refresh_token)
+        except HTTPError as exc:
+            response = getattr(exc, 'response', None)
+            status_code = getattr(response, 'status_code', None)
+            if status_code is not None and 400 <= status_code < 500:
+                raise ValueError('invalid_refresh_token') from exc
+            raise
+        except ValueError as exc:
+            raise ValueError('invalid_refresh_token') from exc
+
+        access_token = token_data.get('access_token')
+        if not access_token:
+            raise ValueError('no_access_token')
+
+        update_fields = ['access_token', 'updated_at']
+        connection.access_token = encrypt_token(access_token)
+
+        new_refresh_token = token_data.get('refresh_token')
+        if new_refresh_token:
+            connection.refresh_token = encrypt_token(new_refresh_token)
+            update_fields.append('refresh_token')
+
+        connection.updated_at = timezone.now()
+        connection.save(update_fields=update_fields)
+        return access_token
+
+    def refresh_connection_username(self, connection):
+        """Refresh linked account details using the provider's current user API."""
+        if not connection.access_token:
+            raise ValueError('missing_access_token')
+
+        try:
+            access_token = decrypt_token(connection.access_token)
+        except InvalidToken as exc:
+            raise ValueError('invalid_access_token') from exc
+
+        try:
+            user_info = self.fetch_user_info(access_token)
+        except HTTPError as exc:
+            response = getattr(exc, 'response', None)
+            if response is None or response.status_code != 401:
+                raise
+            access_token = self.refresh_stored_access_token(connection)
+            user_info = self.fetch_user_info(access_token)
+
+        platform_user_id = str(user_info.get('platform_user_id', ''))
+        platform_username = str(user_info.get('platform_username', ''))[:100]
+
+        if platform_user_id != str(connection.platform_user_id):
+            raise ValueError('account_mismatch')
+
+        update_fields = []
+        changed = False
+
+        if platform_username != connection.platform_username:
+            connection.platform_username = platform_username
+            update_fields.append('platform_username')
+            changed = True
+
+        extra_fields = user_info.get('extra_fields', {})
+        for field_name, field_value in extra_fields.items():
+            if not hasattr(connection, field_name):
+                continue
+            if getattr(connection, field_name) != field_value:
+                setattr(connection, field_name, field_value)
+                update_fields.append(field_name)
+                changed = True
+
+        if changed:
+            connection.updated_at = timezone.now()
+            update_fields.append('updated_at')
+            connection.save(update_fields=update_fields)
+
+        return connection, changed
 
     # --- Template rendering ---
 
@@ -372,31 +463,6 @@ class GitHubOAuthService(OAuthService):
             'platform_username': data['login'],
         }
 
-    def refresh_connection_username(self, connection):
-        """Refresh a linked GitHub username using the stored OAuth token."""
-        if not connection.access_token:
-            raise ValueError('missing_access_token')
-
-        try:
-            access_token = decrypt_token(connection.access_token)
-        except InvalidToken as exc:
-            raise ValueError('invalid_access_token') from exc
-
-        user_info = self.fetch_user_info(access_token)
-        platform_user_id = str(user_info.get('platform_user_id', ''))
-        platform_username = str(user_info.get('platform_username', ''))[:100]
-
-        if platform_user_id != str(connection.platform_user_id):
-            raise ValueError('account_mismatch')
-
-        changed = platform_username != connection.platform_username
-        if changed:
-            connection.platform_username = platform_username
-            connection.updated_at = timezone.now()
-            connection.save(update_fields=['platform_username', 'updated_at'])
-
-        return connection, changed
-
     def check_repo_star(self, connection):
         """Check if user has starred the configured repository."""
         from .encryption import decrypt_token
@@ -439,7 +505,7 @@ class TwitterOAuthService(OAuthService):
     authorize_url = 'https://x.com/i/oauth2/authorize'
     token_url = 'https://api.x.com/2/oauth2/token'
     user_info_url = 'https://api.x.com/2/users/me'
-    scopes = ['tweet.read', 'users.read']
+    scopes = ['tweet.read', 'users.read', 'offline.access']
     uses_pkce = True
 
     def get_connection_model(self):
@@ -469,6 +535,27 @@ class TwitterOAuthService(OAuthService):
                 'grant_type': 'authorization_code',
                 'redirect_uri': self.get_redirect_uri(),
                 'code_verifier': code_verifier,
+            }, headers={
+                'Authorization': f'Basic {auth_string}',
+                'Content-Type': 'application/x-www-form-urlencoded',
+            })
+            response.raise_for_status()
+            data = response.json()
+
+        if 'error' in data:
+            raise ValueError(data.get('error', 'unknown error'))
+        return data
+
+    def refresh_access_token(self, refresh_token):
+        auth_string = base64.b64encode(
+            f"{self.get_client_id()}:{self.get_client_secret()}".encode()
+        ).decode()
+
+        with trace_external('twitter', 'token_refresh'):
+            response = requests.post(self.token_url, data={
+                'grant_type': 'refresh_token',
+                'refresh_token': refresh_token,
+                'client_id': self.get_client_id(),
             }, headers={
                 'Authorization': f'Basic {auth_string}',
                 'Content-Type': 'application/x-www-form-urlencoded',
@@ -536,6 +623,23 @@ class DiscordOAuthService(OAuthService):
             raise ValueError(data.get('error', 'unknown error'))
         return data
 
+    def refresh_access_token(self, refresh_token):
+        with trace_external('discord', 'token_refresh'):
+            response = requests.post(self.token_url, data={
+                'client_id': self.get_client_id(),
+                'client_secret': self.get_client_secret(),
+                'grant_type': 'refresh_token',
+                'refresh_token': refresh_token,
+            }, headers={
+                'Content-Type': 'application/x-www-form-urlencoded',
+            })
+            response.raise_for_status()
+            data = response.json()
+
+        if 'error' in data:
+            raise ValueError(data.get('error', 'unknown error'))
+        return data
+
     def fetch_user_info(self, access_token):
         with trace_external('discord', 'get_user'):
             response = requests.get(self.user_info_url, headers={
@@ -547,11 +651,10 @@ class DiscordOAuthService(OAuthService):
         if not data.get('id') or not data.get('username'):
             raise ValueError("Missing id or username in Discord user response")
 
-        extra_fields = {}
-        if data.get('discriminator'):
-            extra_fields['discriminator'] = str(data['discriminator'])[:10]
-        if data.get('avatar'):
-            extra_fields['avatar_hash'] = str(data['avatar'])[:100]
+        extra_fields = {
+            'discriminator': str(data.get('discriminator') or '')[:10],
+            'avatar_hash': str(data.get('avatar') or '')[:100],
+        }
 
         return {
             'platform_user_id': str(data['id']),

--- a/backend/social_connections/tests/test_discord_oauth.py
+++ b/backend/social_connections/tests/test_discord_oauth.py
@@ -1,13 +1,18 @@
 from unittest.mock import patch, MagicMock
 
+import requests
 from django.test import TestCase, RequestFactory, override_settings
 from django.utils import timezone
 from rest_framework.test import force_authenticate
 
 from users.models import User
+from social_connections.encryption import encrypt_token
 from social_connections.models import DiscordConnection
 from social_connections.discord_oauth import (
-    discord_oauth_initiate, disconnect_discord, check_discord_guild,
+    discord_oauth_initiate,
+    disconnect_discord,
+    check_discord_guild,
+    refresh_discord_username,
 )
 from social_connections.oauth_service import DiscordOAuthService
 
@@ -66,6 +71,141 @@ class DiscordOAuthTest(TestCase):
         force_authenticate(request, user=self.user)
         response = disconnect_discord(request)
         self.assertEqual(response.status_code, 200)
+
+    @patch('social_connections.oauth_service.decrypt_token', return_value='test_token')
+    @patch('social_connections.oauth_service.requests')
+    def test_refresh_discord_username_updates_existing_connection(self, mock_requests, mock_decrypt_token):
+        DiscordConnection.objects.create(
+            user=self.user,
+            platform_user_id='11111',
+            platform_username='old-discord-name',
+            access_token='encrypted-token',
+            avatar_hash='old-avatar',
+            linked_at=timezone.now(),
+        )
+
+        mock_user_response = MagicMock()
+        mock_user_response.raise_for_status = MagicMock()
+        mock_user_response.json.return_value = {
+            'id': '11111',
+            'username': 'new-discord-name',
+            'discriminator': '0',
+            'avatar': 'new-avatar',
+        }
+        mock_requests.get.return_value = mock_user_response
+
+        request = self.factory.post('/api/v1/users/discord/refresh/')
+        force_authenticate(request, user=self.user)
+        response = refresh_discord_username(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data['changed'])
+        self.assertEqual(response.data['discord_connection']['platform_username'], 'new-discord-name')
+        self.assertEqual(self.user.discordconnection.platform_username, 'new-discord-name')
+        self.assertEqual(self.user.discordconnection.avatar_hash, 'new-avatar')
+
+    @patch('social_connections.oauth_service.requests')
+    def test_refresh_discord_username_uses_refresh_token_when_access_token_expired(self, mock_requests):
+        DiscordConnection.objects.create(
+            user=self.user,
+            platform_user_id='11111',
+            platform_username='old-discord-name',
+            access_token=encrypt_token('expired-token'),
+            refresh_token=encrypt_token('refresh-token'),
+            linked_at=timezone.now(),
+        )
+
+        expired_response = MagicMock()
+        expired_response.status_code = 401
+        expired_error = requests.HTTPError(response=expired_response)
+        first_user_response = MagicMock()
+        first_user_response.raise_for_status.side_effect = expired_error
+
+        refresh_response = MagicMock()
+        refresh_response.raise_for_status = MagicMock()
+        refresh_response.json.return_value = {
+            'access_token': 'fresh-token',
+            'refresh_token': 'new-refresh-token',
+        }
+
+        second_user_response = MagicMock()
+        second_user_response.raise_for_status = MagicMock()
+        second_user_response.json.return_value = {
+            'id': '11111',
+            'username': 'new-discord-name',
+        }
+
+        mock_requests.get.side_effect = [first_user_response, second_user_response]
+        mock_requests.post.return_value = refresh_response
+
+        request = self.factory.post('/api/v1/users/discord/refresh/')
+        force_authenticate(request, user=self.user)
+        response = refresh_discord_username(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data['changed'])
+        self.assertEqual(self.user.discordconnection.platform_username, 'new-discord-name')
+
+    @patch('social_connections.oauth_service.requests')
+    def test_refresh_discord_username_reconnects_when_refresh_token_rejected(self, mock_requests):
+        DiscordConnection.objects.create(
+            user=self.user,
+            platform_user_id='11111',
+            platform_username='old-discord-name',
+            access_token=encrypt_token('expired-token'),
+            refresh_token=encrypt_token('revoked-refresh-token'),
+            linked_at=timezone.now(),
+        )
+
+        expired_response = MagicMock()
+        expired_response.status_code = 401
+        expired_error = requests.HTTPError(response=expired_response)
+        first_user_response = MagicMock()
+        first_user_response.raise_for_status.side_effect = expired_error
+
+        rejected_refresh_response = MagicMock()
+        rejected_refresh_response.status_code = 400
+        rejected_refresh_response.raise_for_status.side_effect = requests.HTTPError(
+            response=rejected_refresh_response,
+        )
+
+        mock_requests.get.return_value = first_user_response
+        mock_requests.post.return_value = rejected_refresh_response
+
+        request = self.factory.post('/api/v1/users/discord/refresh/')
+        force_authenticate(request, user=self.user)
+        response = refresh_discord_username(request)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data['code'], 'invalid_refresh_token')
+        self.assertIn('Please reconnect Discord', response.data['error'])
+
+    @patch('social_connections.oauth_service.decrypt_token', return_value='test_token')
+    @patch('social_connections.oauth_service.requests')
+    def test_refresh_discord_username_rejects_account_mismatch(self, mock_requests, mock_decrypt_token):
+        DiscordConnection.objects.create(
+            user=self.user,
+            platform_user_id='11111',
+            platform_username='old-discord-name',
+            access_token='encrypted-token',
+            linked_at=timezone.now(),
+        )
+
+        mock_user_response = MagicMock()
+        mock_user_response.raise_for_status = MagicMock()
+        mock_user_response.json.return_value = {
+            'id': '22222',
+            'username': 'other-discord-name',
+        }
+        mock_requests.get.return_value = mock_user_response
+
+        request = self.factory.post('/api/v1/users/discord/refresh/')
+        force_authenticate(request, user=self.user)
+        response = refresh_discord_username(request)
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.data['code'], 'account_mismatch')
+        self.assertEqual(self.user.discordconnection.platform_username, 'old-discord-name')
 
     @patch('social_connections.oauth_service.requests')
     def test_callback_full_flow(self, mock_requests):
@@ -199,7 +339,6 @@ class DiscordOAuthTest(TestCase):
     @patch('social_connections.discord_oauth.service.check_guild_membership')
     def test_check_guild_is_member(self, mock_check):
         """Test guild check when user is a member."""
-        from social_connections.encryption import encrypt_token
         DiscordConnection.objects.create(
             user=self.user,
             platform_user_id='11111',
@@ -223,7 +362,6 @@ class DiscordOAuthTest(TestCase):
     @patch('social_connections.discord_oauth.service.check_guild_membership')
     def test_check_guild_not_member(self, mock_check):
         """Test guild check when user is not a member."""
-        from social_connections.encryption import encrypt_token
         DiscordConnection.objects.create(
             user=self.user,
             platform_user_id='11111',

--- a/backend/social_connections/tests/test_twitter_oauth.py
+++ b/backend/social_connections/tests/test_twitter_oauth.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, MagicMock
 from urllib.parse import parse_qs, urlparse
 
+import requests
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import TestCase, RequestFactory, override_settings
 from django.utils import timezone
@@ -8,7 +9,12 @@ from rest_framework.test import force_authenticate
 
 from users.models import User
 from social_connections.models import TwitterConnection
-from social_connections.twitter_oauth import twitter_oauth_initiate, disconnect_twitter
+from social_connections.encryption import encrypt_token
+from social_connections.twitter_oauth import (
+    twitter_oauth_initiate,
+    disconnect_twitter,
+    refresh_twitter_username,
+)
 from social_connections.oauth_service import TwitterOAuthService
 
 TEST_ENCRYPTION_KEY = 'dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdGtleXQ='
@@ -57,16 +63,17 @@ class TwitterOAuthTest(TestCase):
         self.assertIn('x.com/i/oauth2/authorize', response.url)
         self.assertEqual(query['client_id'][0], 'test_twitter_id')
         self.assertEqual(query['response_type'][0], 'code')
-        self.assertEqual(query['scope'][0], 'tweet.read users.read')
+        self.assertEqual(query['scope'][0], 'tweet.read users.read offline.access')
         self.assertIn('code_challenge', query)
         self.assertEqual(query['code_challenge_method'][0], 'S256')
         self.assertLessEqual(len(query['state'][0]), 500)
-        self.assertIn('scope=tweet.read%20users.read', response.url)
+        self.assertIn('scope=tweet.read%20users.read%20offline.access', response.url)
         self.assertNotIn('scope=tweet.read+users.read', response.url)
-        self.assertTrue(request.session['twitter_oauth_code_verifier'])
-        self.assertEqual(request.session['twitter_oauth_redirect_url'], 'http://localhost:5173')
+        state_data = self.service.validate_state(query['state'][0])
+        self.assertTrue(state_data['code_verifier'])
+        self.assertEqual(state_data['redirect_url'], 'http://localhost:5173')
 
-    def test_initiate_validates_redirect_before_storing_in_session(self):
+    def test_initiate_validates_redirect_before_storing_in_state(self):
         request = self.factory.get('/api/auth/twitter/', {
             'redirect': 'https://evil.example/profile',
         })
@@ -75,8 +82,11 @@ class TwitterOAuthTest(TestCase):
 
         response = twitter_oauth_initiate(request)
 
+        query = parse_qs(urlparse(response.url).query)
+        state_data = self.service.validate_state(query['state'][0])
+
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(request.session['twitter_oauth_redirect_url'], 'http://localhost:5173')
+        self.assertEqual(state_data['redirect_url'], 'http://localhost:5173')
 
     def test_disconnect_deletes_connection(self):
         TwitterConnection.objects.create(
@@ -101,7 +111,10 @@ class TwitterOAuthTest(TestCase):
     def test_callback_full_flow(self, mock_requests):
         """Test the full Twitter OAuth callback flow with PKCE."""
         code_verifier = self.service.generate_code_verifier()
-        state = self.service.generate_state(self.user.id)
+        state = self.service.generate_state(self.user.id, extra_data={
+            'code_verifier': code_verifier,
+            'redirect_url': 'http://localhost:5173',
+        })
 
         mock_token_response = MagicMock()
         mock_token_response.raise_for_status = MagicMock()
@@ -121,10 +134,6 @@ class TwitterOAuthTest(TestCase):
             'code': 'twitter_code_123',
             'state': state,
         })
-        self.attach_session(request)
-        request.session['twitter_oauth_code_verifier'] = code_verifier
-        request.session['twitter_oauth_redirect_url'] = 'http://localhost:5173'
-        request.session.save()
         response = twitter_oauth_callback(request)
         self.assertEqual(response.status_code, 302)
         self.assertIn('oauth_platform=twitter', response.url)
@@ -148,10 +157,6 @@ class TwitterOAuthTest(TestCase):
             'code': 'dup_twitter_code',
             'state': state,
         })
-        self.attach_session(request)
-        request.session['twitter_oauth_code_verifier'] = 'dummy_verifier'
-        request.session['twitter_oauth_redirect_url'] = 'http://localhost:5173'
-        request.session.save()
         response = twitter_oauth_callback(request)
         self.assertEqual(response.status_code, 302)
         self.assertIn('oauth_platform=twitter', response.url)
@@ -172,7 +177,10 @@ class TwitterOAuthTest(TestCase):
         )
 
         code_verifier = self.service.generate_code_verifier()
-        state = self.service.generate_state(self.user.id)
+        state = self.service.generate_state(self.user.id, extra_data={
+            'code_verifier': code_verifier,
+            'redirect_url': 'http://localhost:5173',
+        })
 
         mock_token_response = MagicMock()
         mock_token_response.raise_for_status = MagicMock()
@@ -192,12 +200,136 @@ class TwitterOAuthTest(TestCase):
             'code': 'new_twitter_code_456',
             'state': state,
         })
-        self.attach_session(request)
-        request.session['twitter_oauth_code_verifier'] = code_verifier
-        request.session['twitter_oauth_redirect_url'] = 'http://localhost:5173'
-        request.session.save()
         response = twitter_oauth_callback(request)
         self.assertEqual(response.status_code, 302)
         self.assertIn('oauth_platform=twitter', response.url)
         self.assertIn('oauth_verified=false', response.url)
         self.assertIn('oauth_error=already_linked', response.url)
+
+    @patch('social_connections.oauth_service.decrypt_token', return_value='test_token')
+    @patch('social_connections.oauth_service.requests')
+    def test_refresh_twitter_username_updates_existing_connection(self, mock_requests, mock_decrypt_token):
+        TwitterConnection.objects.create(
+            user=self.user,
+            platform_user_id='99999',
+            platform_username='old_x_name',
+            access_token='encrypted-token',
+            linked_at=timezone.now(),
+        )
+
+        mock_user_response = MagicMock()
+        mock_user_response.raise_for_status = MagicMock()
+        mock_user_response.json.return_value = {
+            'data': {'id': '99999', 'username': 'new_x_name'},
+        }
+        mock_requests.get.return_value = mock_user_response
+
+        request = self.factory.post('/api/v1/users/twitter/refresh/')
+        force_authenticate(request, user=self.user)
+        response = refresh_twitter_username(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data['changed'])
+        self.assertEqual(response.data['twitter_connection']['platform_username'], 'new_x_name')
+        self.assertEqual(self.user.twitterconnection.platform_username, 'new_x_name')
+
+    @patch('social_connections.oauth_service.requests')
+    def test_refresh_twitter_username_uses_refresh_token_when_access_token_expired(self, mock_requests):
+        TwitterConnection.objects.create(
+            user=self.user,
+            platform_user_id='99999',
+            platform_username='old_x_name',
+            access_token=encrypt_token('expired-token'),
+            refresh_token=encrypt_token('refresh-token'),
+            linked_at=timezone.now(),
+        )
+
+        expired_response = MagicMock()
+        expired_response.status_code = 401
+        expired_error = requests.HTTPError(response=expired_response)
+        first_user_response = MagicMock()
+        first_user_response.raise_for_status.side_effect = expired_error
+
+        refresh_response = MagicMock()
+        refresh_response.raise_for_status = MagicMock()
+        refresh_response.json.return_value = {
+            'access_token': 'fresh-token',
+            'refresh_token': 'new-refresh-token',
+        }
+
+        second_user_response = MagicMock()
+        second_user_response.raise_for_status = MagicMock()
+        second_user_response.json.return_value = {
+            'data': {'id': '99999', 'username': 'new_x_name'},
+        }
+
+        mock_requests.get.side_effect = [first_user_response, second_user_response]
+        mock_requests.post.return_value = refresh_response
+
+        request = self.factory.post('/api/v1/users/twitter/refresh/')
+        force_authenticate(request, user=self.user)
+        response = refresh_twitter_username(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data['changed'])
+        self.assertEqual(self.user.twitterconnection.platform_username, 'new_x_name')
+
+    @patch('social_connections.oauth_service.requests')
+    def test_refresh_twitter_username_reconnects_when_refresh_token_rejected(self, mock_requests):
+        TwitterConnection.objects.create(
+            user=self.user,
+            platform_user_id='99999',
+            platform_username='old_x_name',
+            access_token=encrypt_token('expired-token'),
+            refresh_token=encrypt_token('revoked-refresh-token'),
+            linked_at=timezone.now(),
+        )
+
+        expired_response = MagicMock()
+        expired_response.status_code = 401
+        expired_error = requests.HTTPError(response=expired_response)
+        first_user_response = MagicMock()
+        first_user_response.raise_for_status.side_effect = expired_error
+
+        rejected_refresh_response = MagicMock()
+        rejected_refresh_response.status_code = 400
+        rejected_refresh_response.raise_for_status.side_effect = requests.HTTPError(
+            response=rejected_refresh_response,
+        )
+
+        mock_requests.get.return_value = first_user_response
+        mock_requests.post.return_value = rejected_refresh_response
+
+        request = self.factory.post('/api/v1/users/twitter/refresh/')
+        force_authenticate(request, user=self.user)
+        response = refresh_twitter_username(request)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data['code'], 'invalid_refresh_token')
+        self.assertIn('Please reconnect X', response.data['error'])
+
+    @patch('social_connections.oauth_service.decrypt_token', return_value='test_token')
+    @patch('social_connections.oauth_service.requests')
+    def test_refresh_twitter_username_rejects_account_mismatch(self, mock_requests, mock_decrypt_token):
+        TwitterConnection.objects.create(
+            user=self.user,
+            platform_user_id='99999',
+            platform_username='old_x_name',
+            access_token='encrypted-token',
+            linked_at=timezone.now(),
+        )
+
+        mock_user_response = MagicMock()
+        mock_user_response.raise_for_status = MagicMock()
+        mock_user_response.json.return_value = {
+            'data': {'id': '12345', 'username': 'other_x_name'},
+        }
+        mock_requests.get.return_value = mock_user_response
+
+        request = self.factory.post('/api/v1/users/twitter/refresh/')
+        force_authenticate(request, user=self.user)
+        response = refresh_twitter_username(request)
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.data['code'], 'account_mismatch')
+        self.assertEqual(self.user.twitterconnection.platform_username, 'old_x_name')

--- a/backend/social_connections/twitter_oauth.py
+++ b/backend/social_connections/twitter_oauth.py
@@ -2,6 +2,7 @@
 
 from urllib.parse import quote, urlencode
 
+import requests
 from django.conf import settings
 from django.shortcuts import redirect
 from django.views.decorators.csrf import csrf_exempt
@@ -12,6 +13,7 @@ from rest_framework import status
 
 from tally.middleware.logging_utils import get_app_logger
 
+from .serializers import TwitterConnectionSerializer
 from .oauth_service import TwitterOAuthService
 
 logger = get_app_logger('twitter_oauth')
@@ -69,3 +71,58 @@ def disconnect_twitter(request):
         pass
 
     return Response({'message': 'Twitter account disconnected successfully'}, status=status.HTTP_200_OK)
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def refresh_twitter_username(request):
+    """Refresh the linked X username from X's current user API."""
+    from .models import TwitterConnection
+
+    try:
+        connection = request.user.twitterconnection
+    except TwitterConnection.DoesNotExist:
+        return Response({
+            'error': 'X account not linked',
+        }, status=status.HTTP_400_BAD_REQUEST)
+
+    try:
+        connection, changed = service.refresh_connection_username(connection)
+    except ValueError as e:
+        error_code = str(e)
+        if error_code in (
+            'missing_access_token',
+            'invalid_access_token',
+            'missing_refresh_token',
+            'invalid_refresh_token',
+            'refresh_not_supported',
+            'no_access_token',
+        ):
+            return Response({
+                'error': 'X authorization is no longer valid. Please reconnect X.',
+                'code': error_code,
+            }, status=status.HTTP_400_BAD_REQUEST)
+        if error_code == 'account_mismatch':
+            logger.warning(
+                "X refresh returned a different account for user %s",
+                request.user.id,
+            )
+            return Response({
+                'error': 'X account mismatch. Please reconnect X.',
+                'code': error_code,
+            }, status=status.HTTP_409_CONFLICT)
+        logger.error(f"Failed to refresh X username: {e}")
+        return Response({
+            'error': 'Failed to refresh X username',
+        }, status=status.HTTP_400_BAD_REQUEST)
+    except requests.RequestException as e:
+        logger.error(f"X API request failed while refreshing username: {e}")
+        return Response({
+            'error': 'Failed to reach X. Please try again.',
+        }, status=status.HTTP_502_BAD_GATEWAY)
+
+    return Response({
+        'message': 'X username refreshed successfully',
+        'changed': changed,
+        'twitter_connection': TwitterConnectionSerializer(connection).data,
+    }, status=status.HTTP_200_OK)

--- a/backend/social_connections/urls.py
+++ b/backend/social_connections/urls.py
@@ -6,8 +6,13 @@ from .github_oauth import (
     check_repo_star,
     refresh_github_username,
 )
-from .twitter_oauth import twitter_oauth_initiate, twitter_oauth_callback
-from .discord_oauth import discord_oauth_initiate, discord_oauth_callback, check_discord_guild
+from .twitter_oauth import twitter_oauth_initiate, twitter_oauth_callback, refresh_twitter_username
+from .discord_oauth import (
+    discord_oauth_initiate,
+    discord_oauth_callback,
+    check_discord_guild,
+    refresh_discord_username,
+)
 
 urlpatterns = [
     # GitHub OAuth
@@ -19,9 +24,11 @@ urlpatterns = [
     # Twitter OAuth
     path('api/auth/twitter/', twitter_oauth_initiate, name='twitter_oauth'),
     path('api/auth/twitter/callback/', twitter_oauth_callback, name='twitter_callback'),
+    path('api/v1/users/twitter/refresh/', refresh_twitter_username, name='twitter_refresh_username'),
 
     # Discord OAuth
     path('api/auth/discord/', discord_oauth_initiate, name='discord_oauth'),
     path('api/auth/discord/callback/', discord_oauth_callback, name='discord_callback'),
+    path('api/v1/users/discord/refresh/', refresh_discord_username, name='discord_refresh_username'),
     path('api/v1/users/discord/check-guild/', check_discord_guild, name='discord_check_guild'),
 ]

--- a/frontend/src/components/SocialLink.svelte
+++ b/frontend/src/components/SocialLink.svelte
@@ -194,6 +194,12 @@
   };
 
   let config = $derived(platformConfig[platform] || platformConfig.github);
+  const refreshHandlers = {
+    github: socialAPI.refreshGitHubUsername,
+    twitter: socialAPI.refreshTwitterUsername,
+    discord: socialAPI.refreshDiscordUsername,
+  };
+  let canRefresh = $derived(!!refreshHandlers[platform]);
 
   function isMobileBrowser() {
     const userAgent = navigator.userAgent || navigator.vendor || window.opera || '';
@@ -258,24 +264,24 @@
   }
 
   async function refreshAccount() {
-    if (!$authState.isAuthenticated || platform !== 'github' || !connection || isRefreshing) {
+    if (!$authState.isAuthenticated || !canRefresh || !connection || isRefreshing) {
       return;
     }
 
     isRefreshing = true;
     try {
-      const response = await socialAPI.refreshGitHubUsername();
+      const response = await refreshHandlers[platform]();
       const updatedUser = await getCurrentUser();
-      const updatedConnection = response.data?.github_connection;
+      const updatedConnection = response.data?.[`${platform}_connection`];
       const username = updatedConnection?.platform_username || connection.platform_username;
       showSuccess(
         response.data?.changed
-          ? `GitHub username updated to @${username}`
-          : 'GitHub username is already up to date'
+          ? `${platformLabel} username updated to ${username}`
+          : `${platformLabel} username is already up to date`
       );
       onLinked(updatedUser);
     } catch (error) {
-      const message = error?.response?.data?.error || 'Could not refresh GitHub username. Please try again.';
+      const message = error?.response?.data?.error || `Could not refresh ${platformLabel} username. Please try again.`;
       showError(message);
     } finally {
       isRefreshing = false;
@@ -333,14 +339,14 @@
         <span class="flex-shrink-0 opacity-90">{@html config.icon}</span>
         <span class="font-medium text-sm">{connection.platform_username}</span>
       </div>
-      {#if platform === 'github'}
+      {#if canRefresh}
         <button
           type="button"
           class="social-refresh-btn"
           onclick={refreshAccount}
           disabled={isRefreshing}
-          title="Refresh GitHub username"
-          aria-label="Refresh GitHub username"
+          title="Refresh {platformLabel} username"
+          aria-label="Refresh {platformLabel} username"
         >
           {#if isRefreshing}
             <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -181,6 +181,8 @@ export const githubAPI = {
 // Social connections API
 export const socialAPI = {
   refreshGitHubUsername: () => api.post('/users/github/refresh/'),
+  refreshTwitterUsername: () => api.post('/users/twitter/refresh/'),
+  refreshDiscordUsername: () => api.post('/users/discord/refresh/'),
   checkDiscordGuild: () => api.get('/users/discord/check-guild/'),
 };
 


### PR DESCRIPTION
Adds user-triggered refresh actions for GitHub, Discord, and X linked accounts.
The shared OAuth service now verifies account IDs, updates usernames and Discord avatar metadata, and rotates Discord/X access tokens on 401 when refresh tokens are available.
X OAuth now requests offline.access for newly linked accounts so user-initiated refresh can continue after short-lived access tokens expire.
Validation: Django system check, backend py_compile for touched OAuth files/tests, and frontend production build passed; targeted Django tests are blocked by an existing test migration requiring albert@genlayer.foundation.
