### PR TITLE
Add canceled submission state

### DIFF
--- a/backend/contributions/admin.py
+++ b/backend/contributions/admin.py
@@ -665,7 +665,11 @@ class MissionAdmin(admin.ModelAdmin):
         }),
         ('Submission Limit', {
             'fields': ('max_submissions', 'max_submissions_per_user'),
-            'description': 'Optional: Limit total non-rejected submissions and per-user non-rejected submissions for this mission.'
+            'description': (
+                'Optional: Limit total non-rejected, non-canceled submissions '
+                'and per-user non-rejected, non-canceled submissions for '
+                'this mission.'
+            )
         }),
         ('Metadata', {
             'fields': ('created_at', 'updated_at'),

--- a/backend/contributions/migrations/0059_add_canceled_submission_state.py
+++ b/backend/contributions/migrations/0059_add_canceled_submission_state.py
@@ -1,0 +1,91 @@
+from django.db import migrations, models
+from django.db.models import Q
+
+
+def forwards(apps, schema_editor):
+    SubmittedContribution = apps.get_model(
+        'contributions', 'SubmittedContribution'
+    )
+    cancellation_note = (
+        Q(staff_reply__iexact='Cancelled by user')
+        | Q(staff_reply__iexact='Canceled by user')
+        | Q(notes__iexact='Cancelled by user')
+        | Q(notes__iexact='Canceled by user')
+    )
+    SubmittedContribution.objects.filter(state='rejected').filter(
+        cancellation_note
+    ).update(state='canceled')
+
+
+def backwards(apps, schema_editor):
+    SubmittedContribution = apps.get_model(
+        'contributions', 'SubmittedContribution'
+    )
+    SubmittedContribution.objects.filter(state='canceled').update(
+        state='rejected'
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contributions', '0058_mission_max_submissions_per_user'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contributiontype',
+            name='max_submissions',
+            field=models.PositiveIntegerField(
+                blank=True,
+                help_text=(
+                    'Maximum number of non-rejected, non-canceled '
+                    'submissions allowed for this contribution type. Leave '
+                    'blank for unlimited.'
+                ),
+                null=True,
+            ),
+        ),
+        migrations.AlterField(
+            model_name='submittedcontribution',
+            name='state',
+            field=models.CharField(
+                choices=[
+                    ('pending', 'Pending Review'),
+                    ('accepted', 'Accepted'),
+                    ('rejected', 'Rejected'),
+                    ('canceled', 'Canceled'),
+                    ('more_info_needed', 'More Information Needed'),
+                ],
+                default='pending',
+                max_length=20,
+            ),
+        ),
+        migrations.AlterField(
+            model_name='mission',
+            name='max_submissions',
+            field=models.PositiveIntegerField(
+                blank=True,
+                help_text=(
+                    'Maximum number of non-rejected, non-canceled '
+                    'submissions allowed for this mission. Leave blank for '
+                    'unlimited.'
+                ),
+                null=True,
+            ),
+        ),
+        migrations.AlterField(
+            model_name='mission',
+            name='max_submissions_per_user',
+            field=models.PositiveIntegerField(
+                blank=True,
+                help_text=(
+                    'Maximum number of non-rejected, non-canceled '
+                    'submissions allowed per user for this mission. Leave '
+                    'blank for unlimited.'
+                ),
+                null=True,
+            ),
+        ),
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/backend/contributions/models.py
+++ b/backend/contributions/models.py
@@ -87,8 +87,8 @@ class ContributionType(BaseModel):
         null=True,
         blank=True,
         help_text=(
-            "Maximum number of non-rejected submissions allowed for this "
-            "contribution type. Leave blank for unlimited."
+            "Maximum number of non-rejected, non-canceled submissions allowed "
+            "for this contribution type. Leave blank for unlimited."
         ),
     )
     show_in_contributions = models.BooleanField(
@@ -138,7 +138,9 @@ class ContributionType(BaseModel):
         annotated_count = getattr(self, 'submission_count', None)
         if annotated_count is not None:
             return annotated_count
-        return self.submitted_contributions.exclude(state='rejected').count()
+        return self.submitted_contributions.exclude(
+            state__in=['rejected', 'canceled']
+        ).count()
 
     def submissions_remaining(self):
         if self.max_submissions is None:
@@ -327,6 +329,7 @@ class SubmittedContribution(BaseModel):
         ('pending', 'Pending Review'),
         ('accepted', 'Accepted'),
         ('rejected', 'Rejected'),
+        ('canceled', 'Canceled'),
         ('more_info_needed', 'More Information Needed')
     ]
     state = models.CharField(
@@ -696,16 +699,16 @@ class Mission(BaseModel):
         null=True,
         blank=True,
         help_text=(
-            "Maximum number of non-rejected submissions allowed for this "
-            "mission. Leave blank for unlimited."
+            "Maximum number of non-rejected, non-canceled submissions allowed "
+            "for this mission. Leave blank for unlimited."
         ),
     )
     max_submissions_per_user = models.PositiveIntegerField(
         null=True,
         blank=True,
         help_text=(
-            "Maximum number of non-rejected submissions allowed per user for "
-            "this mission. Leave blank for unlimited."
+            "Maximum number of non-rejected, non-canceled submissions allowed "
+            "per user for this mission. Leave blank for unlimited."
         ),
     )
 
@@ -735,13 +738,15 @@ class Mission(BaseModel):
         """
         Count submissions that consume mission capacity.
 
-        Rejected submissions do not consume capacity so a bad or withdrawn
-        submission can reopen a slot.
+        Rejected and canceled submissions do not consume capacity so a bad or
+        withdrawn submission can reopen a slot.
         """
         annotated_count = getattr(self, 'submission_count', None)
         if annotated_count is not None:
             return annotated_count
-        return self.submissions.exclude(state='rejected').count()
+        return self.submissions.exclude(
+            state__in=['rejected', 'canceled']
+        ).count()
 
     def submissions_remaining(self):
         if self.max_submissions is None:
@@ -760,7 +765,9 @@ class Mission(BaseModel):
         """
         if not user or not getattr(user, 'is_authenticated', False):
             return None
-        return self.submissions.filter(user=user).exclude(state='rejected').count()
+        return self.submissions.filter(user=user).exclude(
+            state__in=['rejected', 'canceled']
+        ).count()
 
     def user_submissions_remaining(self, user):
         if self.max_submissions_per_user is None:

--- a/backend/contributions/templates/contributions/staff/submission_list.html
+++ b/backend/contributions/templates/contributions/staff/submission_list.html
@@ -59,7 +59,7 @@
                         <td>{{ submission.contribution_type.name }}</td>
                         <td>{{ submission.contribution_date|date:"Y-m-d H:i" }}</td>
                         <td>
-                            <span class="badge badge-{% if submission.state == 'pending' %}warning{% elif submission.state == 'accepted' %}success{% elif submission.state == 'rejected' %}danger{% else %}info{% endif %}">
+                            <span class="badge badge-{% if submission.state == 'pending' %}warning{% elif submission.state == 'accepted' %}success{% elif submission.state == 'rejected' %}danger{% elif submission.state == 'canceled' %}secondary{% else %}info{% endif %}">
                                 {{ submission.get_state_display }}
                             </span>
                         </td>

--- a/backend/contributions/templates/contributions/staff/submission_review.html
+++ b/backend/contributions/templates/contributions/staff/submission_review.html
@@ -169,7 +169,7 @@
                                     
                                     <dt>Current State:</dt>
                                     <dd>
-                                        <span class="badge badge-{% if submission.state == 'pending' %}warning{% elif submission.state == 'accepted' %}success{% elif submission.state == 'rejected' %}danger{% else %}info{% endif %}">
+                                        <span class="badge badge-{% if submission.state == 'pending' %}warning{% elif submission.state == 'accepted' %}success{% elif submission.state == 'rejected' %}danger{% elif submission.state == 'canceled' %}secondary{% else %}info{% endif %}">
                                             {{ submission.get_state_display }}
                                         </span>
                                     </dd>

--- a/backend/contributions/tests/test_appeal.py
+++ b/backend/contributions/tests/test_appeal.py
@@ -268,6 +268,24 @@ class AppealEndpointTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         submission.refresh_from_db()
-        self.assertEqual(submission.state, 'rejected')
+        self.assertEqual(submission.state, 'canceled')
         # Original staff_reply is preserved on cancel because it was appealed
         self.assertEqual(submission.staff_reply, 'Original rejection reason')
+
+    def test_cancelling_pending_submission_marks_canceled(self):
+        submission = self._make_submission(state='pending')
+        submission.staff_reply = ''
+        submission.reviewed_by = None
+        submission.reviewed_at = None
+        submission.save(
+            update_fields=['staff_reply', 'reviewed_by', 'reviewed_at']
+        )
+        self.client.force_authenticate(user=self.owner)
+
+        response = self.client.delete(f'/api/v1/submissions/{submission.id}/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        submission.refresh_from_db()
+        self.assertEqual(submission.state, 'canceled')
+        self.assertEqual(submission.staff_reply, 'Canceled by user')
+        self.assertIsNotNone(submission.reviewed_at)

--- a/backend/contributions/tests/test_canceled_submissions.py
+++ b/backend/contributions/tests/test_canceled_submissions.py
@@ -1,0 +1,69 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from contributions.models import Category, ContributionType, SubmittedContribution
+
+User = get_user_model()
+
+
+class CanceledSubmissionMetricsTest(TestCase):
+    def setUp(self):
+        self.category = Category.objects.create(
+            name='Test', slug='test', description='Test',
+        )
+        self.contribution_type = ContributionType.objects.create(
+            name='Test Type',
+            slug='test-type',
+            description='Test type',
+            category=self.category,
+            min_points=1,
+            max_points=10,
+        )
+        self.user = User.objects.create_user(
+            email='user@test.com',
+            address='0x1234567890123456789012345678901234567890',
+            password='testpass123',
+        )
+        self.client = APIClient()
+
+    def _create_submission(self, state, staff_reply=''):
+        return SubmittedContribution.objects.create(
+            user=self.user,
+            contribution_type=self.contribution_type,
+            contribution_date=timezone.now(),
+            notes='Test submission',
+            state=state,
+            staff_reply=staff_reply,
+            reviewed_at=timezone.now(),
+        )
+
+    def test_canceled_submissions_are_not_counted_as_rejected(self):
+        self._create_submission(state='rejected', staff_reply='Not valid')
+        self._create_submission(state='canceled', staff_reply='Canceled by user')
+
+        today = timezone.now().date().isoformat()
+        response = self.client.get(
+            '/api/v1/steward-submissions/daily-metrics/',
+            {
+                'group_by': 'day',
+                'start_date': today,
+                'end_date': today,
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['totals']['rejected'], 1)
+        self.assertEqual(response.data['totals']['canceled'], 1)
+
+    def test_canceled_submissions_are_not_reviewed_decisions(self):
+        self._create_submission(state='rejected', staff_reply='Not valid')
+        self._create_submission(state='canceled', staff_reply='Canceled by user')
+
+        response = self.client.get('/api/v1/steward-submissions/stats/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['total_reviewed'], 1)
+        self.assertEqual(response.data['total_rejected'], 1)

--- a/backend/contributions/tests/test_submission_limits.py
+++ b/backend/contributions/tests/test_submission_limits.py
@@ -92,6 +92,15 @@ class SubmissionLimitTest(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    def test_canceled_submissions_do_not_consume_type_capacity(self):
+        self.contribution_type.max_submissions = 1
+        self.contribution_type.save(update_fields=['max_submissions'])
+        self._create_submission(state='canceled')
+
+        response = self._post_submission()
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
     def test_mission_limit_blocks_new_submissions(self):
         mission = Mission.objects.create(
             name='Limited Mission',
@@ -115,6 +124,19 @@ class SubmissionLimitTest(TestCase):
             max_submissions=1,
         )
         self._create_submission(state='rejected', mission=mission)
+
+        response = self._post_submission(mission=mission)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_canceled_submissions_do_not_consume_mission_capacity(self):
+        mission = Mission.objects.create(
+            name='Limited Mission',
+            description='Test mission',
+            contribution_type=self.contribution_type,
+            max_submissions=1,
+        )
+        self._create_submission(state='canceled', mission=mission)
 
         response = self._post_submission(mission=mission)
 
@@ -156,6 +178,19 @@ class SubmissionLimitTest(TestCase):
             max_submissions_per_user=1,
         )
         self._create_submission(state='rejected', mission=mission, user=self.user)
+
+        response = self._post_submission(mission=mission)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_canceled_submissions_do_not_consume_mission_per_user_capacity(self):
+        mission = Mission.objects.create(
+            name='Per User Limited Mission',
+            description='Test mission',
+            contribution_type=self.contribution_type,
+            max_submissions_per_user=1,
+        )
+        self._create_submission(state='canceled', mission=mission, user=self.user)
 
         response = self._post_submission(mission=mission)
 

--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -43,7 +43,9 @@ class ContributionTypeViewSet(viewsets.ReadOnlyModelViewSet):
         queryset = ContributionType.objects.all().annotate(
             submission_count=Count(
                 'submitted_contributions',
-                filter=~Q(submitted_contributions__state='rejected'),
+                filter=~Q(
+                    submitted_contributions__state__in=['rejected', 'canceled']
+                ),
                 distinct=True,
             )
         )
@@ -704,26 +706,33 @@ class SubmittedContributionViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
     def destroy(self, request, *args, **kwargs):
-        """Soft delete submission by marking as rejected (only allowed for pending or more_info_needed states)."""
+        """
+        Soft delete submission by marking as canceled.
+
+        Only pending or more_info_needed submissions can be canceled.
+        """
         instance = self.get_object()
 
         # Check if cancellation is allowed
         if instance.state not in ['pending', 'more_info_needed']:
             return Response(
-                {'error': 'Only pending or unreviewed submissions can be cancelled.'},
+                {'error': 'Only pending or unreviewed submissions can be canceled.'},
                 status=status.HTTP_403_FORBIDDEN
             )
 
-        # Soft delete - mark as rejected with cancellation note
-        instance.state = 'rejected'
+        # Soft delete - mark as canceled with cancellation note
+        instance.state = 'canceled'
         # Preserve the original rejection reason if this submission was appealed;
         # otherwise record the cancellation in staff_reply.
         if not instance.has_appeal:
-            instance.staff_reply = 'Cancelled by user'
+            instance.staff_reply = 'Canceled by user'
         instance.reviewed_at = timezone.now()
         instance.save()
 
-        return Response({'message': 'Submission cancelled successfully'}, status=status.HTTP_200_OK)
+        return Response(
+            {'message': 'Submission canceled successfully'},
+            status=status.HTTP_200_OK,
+        )
     
     @action(detail=False, methods=['get'], url_path='my')
     def my_submissions(self, request):
@@ -1293,21 +1302,18 @@ class StewardSubmissionViewSet(viewsets.ModelViewSet):
         
         # Stats specific to authenticated steward (if logged in)
         if request.user and request.user.is_authenticated:
-            total_reviewed = SubmittedContribution.objects.filter(
+            reviewed_qs = SubmittedContribution.objects.filter(
                 reviewed_by=request.user
-            ).count()
+            ).exclude(state='canceled')
+            total_reviewed = reviewed_qs.count()
             
             # Get last review time
-            last_review = SubmittedContribution.objects.filter(
-                reviewed_by=request.user
-            ).order_by('-reviewed_at').first()
+            last_review = reviewed_qs.order_by('-reviewed_at').first()
             
             last_review_time = last_review.reviewed_at if last_review else None
             
             # Get acceptance rate
-            user_reviews = SubmittedContribution.objects.filter(
-                reviewed_by=request.user
-            ).exclude(state='pending')
+            user_reviews = reviewed_qs.exclude(state='pending')
             
             total_decisions = user_reviews.count()
             accepted = user_reviews.filter(state='accepted').count()
@@ -1316,17 +1322,21 @@ class StewardSubmissionViewSet(viewsets.ModelViewSet):
             acceptance_rate = (accepted / total_decisions * 100) if total_decisions > 0 else 0
         else:
             # Public stats - show overall system stats
-            total_reviewed = SubmittedContribution.objects.exclude(state='pending').count()
+            total_reviewed = SubmittedContribution.objects.exclude(
+                state__in=['pending', 'canceled']
+            ).count()
             
             # Get last review time (system-wide)
             last_review = SubmittedContribution.objects.exclude(
                 reviewed_at__isnull=True
-            ).order_by('-reviewed_at').first()
+            ).exclude(state='canceled').order_by('-reviewed_at').first()
             
             last_review_time = last_review.reviewed_at if last_review else None
             
             # Get overall acceptance rate
-            all_reviews = SubmittedContribution.objects.exclude(state='pending')
+            all_reviews = SubmittedContribution.objects.exclude(
+                state__in=['pending', 'canceled']
+            )
             total_decisions = all_reviews.count()
             accepted = all_reviews.filter(state='accepted').count()
             total_rejected = all_reviews.filter(state='rejected').count()
@@ -1467,6 +1477,15 @@ class StewardSubmissionViewSet(viewsets.ModelViewSet):
             .order_by('period')
         )
 
+        canceled = (
+            reviews_base
+            .filter(state='canceled')
+            .annotate(period=trunc_func('reviewed_at'))
+            .values('period')
+            .annotate(count=Count('id'))
+            .order_by('period')
+        )
+
         # Get points awarded (from converted contributions)
         points_qs = Contribution.objects.filter(
             created_at__date__gte=start_date,
@@ -1498,6 +1517,7 @@ class StewardSubmissionViewSet(viewsets.ModelViewSet):
         accepted_dict = {to_date(item['period']): item['count'] for item in accepted}
         rejected_dict = {to_date(item['period']): item['count'] for item in rejected}
         more_info_dict = {to_date(item['period']): item['count'] for item in more_info}
+        canceled_dict = {to_date(item['period']): item['count'] for item in canceled}
         points_dict = {to_date(item['period']): item['total_points'] for item in points}
 
         # Build response with all periods in range
@@ -1519,6 +1539,7 @@ class StewardSubmissionViewSet(viewsets.ModelViewSet):
                 'accepted': accepted_dict.get(current_date, 0),
                 'rejected': rejected_dict.get(current_date, 0),
                 'more_info_requested': more_info_dict.get(current_date, 0),
+                'canceled': canceled_dict.get(current_date, 0),
                 'points_awarded': points_dict.get(current_date, 0) or 0
             })
 
@@ -1551,6 +1572,7 @@ class StewardSubmissionViewSet(viewsets.ModelViewSet):
             'accepted': sum(d['accepted'] for d in data),
             'rejected': sum(d['rejected'] for d in data),
             'more_info_requested': sum(d['more_info_requested'] for d in data),
+            'canceled': sum(d['canceled'] for d in data),
             'points_awarded': sum(d['points_awarded'] for d in data),
             'pending_review': pending_review
         }
@@ -1889,12 +1911,19 @@ class MissionViewSet(viewsets.ReadOnlyModelViewSet):
         ).annotate(
             submission_count=Count(
                 'submissions',
-                filter=~Q(submissions__state='rejected'),
+                filter=~Q(
+                    submissions__state__in=['rejected', 'canceled']
+                ),
                 distinct=True,
             ),
             contribution_type_submission_count=Count(
                 'contribution_type__submitted_contributions',
-                filter=~Q(contribution_type__submitted_contributions__state='rejected'),
+                filter=~Q(
+                    contribution_type__submitted_contributions__state__in=[
+                        'rejected',
+                        'canceled',
+                    ]
+                ),
                 distinct=True,
             )
         )

--- a/frontend/src/components/StewardSearchBar.svelte
+++ b/frontend/src/components/StewardSearchBar.svelte
@@ -20,6 +20,11 @@
   let lastSearchedValue = $state('');
 
   const TAGS = [
+    {
+      name: 'status',
+      description: 'Filter by review status',
+      values: () => ['pending', 'accepted', 'rejected', 'canceled', 'more_info_needed']
+    },
     { name: 'type', description: 'Filter by contribution type', values: () => contributionTypes.map(t => t.name.toLowerCase().replace(/\s+/g, '-')) },
     { name: 'category', description: 'Filter by category', values: () => [...new Set(contributionTypes.map(t => t.category).filter(Boolean))] },
     { name: 'from', description: 'Search by user name/email/address', values: () => [] },
@@ -226,6 +231,7 @@
       <div class="help-content">
         <div class="help-section">
           <div class="help-row"><code>type:blog-post</code><span>Filter by contribution type</span></div>
+          <div class="help-row"><code>status:canceled</code><span>Filter by review status</span></div>
           <div class="help-row"><code>category:builder</code><span>Filter by category (builder, validator)</span></div>
           <div class="help-row"><code>from:username</code><span>Search by user name/email/address</span></div>
           <div class="help-row"><code>assigned:me</code><span>Filter by assignment (me, unassigned, name)</span></div>

--- a/frontend/src/components/SubmissionCard.svelte
+++ b/frontend/src/components/SubmissionCard.svelte
@@ -321,6 +321,8 @@
         return 'bg-green-100 text-green-800';
       case 'rejected':
         return 'bg-red-100 text-red-800';
+      case 'canceled':
+        return 'bg-gray-100 text-gray-700';
       case 'more_info_needed':
         return 'bg-blue-100 text-blue-800';
       default:
@@ -336,6 +338,8 @@
         return 'border-l-green-400';
       case 'rejected':
         return 'border-l-red-400';
+      case 'canceled':
+        return 'border-l-gray-400';
       case 'more_info_needed':
         return 'border-l-blue-400';
       default:
@@ -351,6 +355,8 @@
         return 'bg-green-50';
       case 'rejected':
         return 'bg-red-50';
+      case 'canceled':
+        return 'bg-gray-50';
       case 'more_info_needed':
         return 'bg-blue-50';
       default:
@@ -695,7 +701,7 @@
           </div>
         {/if}
 
-        {#if submission.staff_reply && submission.state !== 'rejected'}
+        {#if submission.staff_reply && submission.state !== 'rejected' && submission.state !== 'canceled'}
           <div class="bg-gray-50 p-3 rounded">
             <h4 class="text-sm font-medium text-gray-700 mb-1">Staff Response</h4>
             <div class="markdown-content text-sm text-gray-600">{@html parseMarkdown(submission.staff_reply)}</div>
@@ -1117,6 +1123,11 @@
               </div>
             {/if}
           {/if}
+        {:else if submission.state === 'canceled'}
+          <div class="border border-gray-200 rounded-lg p-4 bg-gray-50">
+            <h4 class="text-sm font-medium text-gray-900 mb-2">Canceled</h4>
+            <p class="text-sm text-gray-700">Canceled by user</p>
+          </div>
         {:else if isOwnSubmission && submission.state === 'pending' && submission.has_appeal}
           <div class="border border-orange-200 rounded-lg p-3 bg-orange-50">
             <h4 class="text-sm font-medium text-orange-900 mb-1">Your appeal is under review</h4>

--- a/frontend/src/lib/searchParser.js
+++ b/frontend/src/lib/searchParser.js
@@ -2,7 +2,7 @@
  * Parse a GitHub-style search query into structured filters.
  *
  * Supported tags:
- * - status:pending|accepted|rejected|more_info
+ * - status:pending|accepted|rejected|canceled|more_info
  * - type:contribution-type-name
  * - from:username
  * - assigned:me|unassigned|steward-name

--- a/frontend/src/lib/searchToParams.js
+++ b/frontend/src/lib/searchToParams.js
@@ -24,10 +24,18 @@ export function searchToParams(parsed, options = {}) {
 
   // status → state (handle negation as exclude_state)
   if (filters.status) {
+    const statusMap = {
+      more_info: 'more_info_needed',
+      'more-info': 'more_info_needed',
+      info: 'more_info_needed',
+      canceled: 'canceled',
+      cancelled: 'canceled',
+    };
+    const state = statusMap[filters.status.value.toLowerCase()] || filters.status.value;
     if (filters.status.negated) {
-      params.exclude_state = filters.status.value;
+      params.exclude_state = state;
     } else {
-      params.state = filters.status.value;
+      params.state = state;
     }
   }
 

--- a/frontend/src/routes/EditSubmission.svelte
+++ b/frontend/src/routes/EditSubmission.svelte
@@ -869,7 +869,7 @@
 <ConfirmDialog
   isOpen={showDeleteDialog}
   title="Remove Submission"
-  message="Are you sure you want to remove this submission? It will be marked as rejected."
+  message="Are you sure you want to remove this submission? It will be marked as canceled."
   confirmText="Remove"
   cancelText="Cancel"
   onConfirm={confirmDelete}

--- a/frontend/src/routes/Metrics.svelte
+++ b/frontend/src/routes/Metrics.svelte
@@ -974,13 +974,18 @@
     let cumAccepted = 0;
     let cumRejected = 0;
     let cumMoreInfo = 0;
+    let cumCanceled = 0;
 
     return submissionsData.data.map((point) => {
       cumIngress += Number(point.ingress || 0);
       cumAccepted += Number(point.accepted || 0);
       cumRejected += Number(point.rejected || 0);
       cumMoreInfo += Number(point.more_info_requested || 0);
-      const pending = Math.max(0, cumIngress - cumAccepted - cumRejected - cumMoreInfo);
+      cumCanceled += Number(point.canceled || 0);
+      const pending = Math.max(
+        0,
+        cumIngress - cumAccepted - cumRejected - cumMoreInfo - cumCanceled
+      );
       return { pending, accepted: cumAccepted, rejected: cumRejected, moreInfo: cumMoreInfo };
     });
   }

--- a/frontend/src/routes/MySubmissions.svelte
+++ b/frontend/src/routes/MySubmissions.svelte
@@ -134,6 +134,7 @@
       <option value="pending">Pending Review</option>
       <option value="accepted">Accepted</option>
       <option value="rejected">Rejected</option>
+      <option value="canceled">Canceled</option>
       <option value="more_info_needed">More Info Needed</option>
     </select>
   </div>

--- a/frontend/src/routes/StewardSubmissions.svelte
+++ b/frontend/src/routes/StewardSubmissions.svelte
@@ -524,6 +524,7 @@
           <option value="pending">Pending Review</option>
           <option value="accepted">Accepted</option>
           <option value="rejected">Rejected</option>
+          <option value="canceled">Canceled</option>
           <option value="more_info_needed">More Info Needed</option>
         </select>
       </div>


### PR DESCRIPTION
Adds a Canceled submission state and migration that moves rejected submissions with "Cancelled/Canceled by user" notes into the new state.
Updates cancellation flow, metrics, submission capacity counts including per-user mission caps, and frontend/staff status displays so canceled submissions do not inflate rejected metrics.
Adds focused backend coverage for cancellation, metrics, and capacity behavior.
Validation: `makemigrations --check --dry-run`, `manage.py check`, and `npm run build` passed; focused Django tests are blocked by existing migration `0037_seed_featured_content` requiring `albert@genlayer.foundation`.