### PR TITLE
Fix mission loading and submission admin performance

### DIFF
--- a/backend/contributions/admin.py
+++ b/backend/contributions/admin.py
@@ -7,7 +7,7 @@ from django.shortcuts import render, redirect
 from django.utils import timezone
 from django.utils.html import format_html
 from django.db import transaction
-from django.db.models import Count
+from django.db.models import Count, Q
 from django.core.exceptions import ValidationError
 from django.contrib.auth import get_user_model
 from datetime import datetime
@@ -50,6 +50,18 @@ class ContributionTypeAdmin(admin.ModelAdmin):
     prepopulated_fields = { 'slug': ('name',) }
     filter_horizontal = ('accepted_evidence_url_types', 'required_evidence_url_types')
     inlines = [GlobalLeaderboardMultiplierInline]
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related('category').annotate(
+            submission_count=Count(
+                'submitted_contributions',
+                filter=~Q(
+                    submitted_contributions__state__in=['rejected', 'canceled']
+                ),
+                distinct=True,
+            )
+        )
     
     def get_current_multiplier(self, obj):
         from leaderboard.models import GlobalLeaderboardMultiplier
@@ -388,11 +400,13 @@ class SubmissionNoteInline(admin.TabularInline):
 
 @admin.register(SubmittedContribution)
 class SubmittedContributionAdmin(admin.ModelAdmin):
-    list_display = ('user', 'contribution_type', 'proposed_points', 'evidence_count', 'state',
+    list_display = ('user', 'contribution_type', 'proposed_points', 'state',
                    'contribution_date', 'created_at', 'reviewed_by')
     list_filter = ('state', 'contribution_type__category', 'contribution_type', 'created_at', 'reviewed_at')
     search_fields = ('user__email', 'user__name', 'notes', 'staff_reply', 'mission__name')
     date_hierarchy = 'created_at'
+    list_per_page = 25
+    show_full_result_count = False
     readonly_fields = ('id', 'created_at', 'updated_at', 'last_edited_at',
                       'converted_contribution_link', 'contribution_type_info', 'proposed_points')
     inlines = [EvidenceInline, SubmissionNoteInline]
@@ -459,15 +473,15 @@ class SubmittedContributionAdmin(admin.ModelAdmin):
         return readonly
 
     def get_queryset(self, request):
-        """Annotate queryset with evidence count to avoid N+1 queries."""
+        """Keep the changelist query cheap for large submission tables."""
         qs = super().get_queryset(request)
-        return qs.annotate(evidence_count_annotated=Count('evidence_items'))
-
-    def evidence_count(self, obj):
-        """Display evidence count from annotation."""
-        return obj.evidence_count_annotated
-    evidence_count.short_description = 'Evidence'
-    evidence_count.admin_order_field = 'evidence_count_annotated'
+        return qs.select_related(
+            'user',
+            'contribution_type',
+            'contribution_type__category',
+            'reviewed_by',
+            'mission',
+        )
 
     class Media:
         js = ('admin/js/contribution_type_dynamic.js',)
@@ -676,6 +690,16 @@ class MissionAdmin(admin.ModelAdmin):
             'classes': ('collapse',)
         }),
     )
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related('contribution_type').annotate(
+            submission_count=Count(
+                'submissions',
+                filter=~Q(submissions__state__in=['rejected', 'canceled']),
+                distinct=True,
+            )
+        )
 
     def get_status(self, obj):
         if obj.is_active():

--- a/backend/contributions/models.py
+++ b/backend/contributions/models.py
@@ -765,6 +765,9 @@ class Mission(BaseModel):
         """
         if not user or not getattr(user, 'is_authenticated', False):
             return None
+        annotated_count = getattr(self, 'user_submission_count', None)
+        if annotated_count is not None:
+            return annotated_count
         return self.submissions.filter(user=user).exclude(
             state__in=['rejected', 'canceled']
         ).count()

--- a/backend/contributions/serializers.py
+++ b/backend/contributions/serializers.py
@@ -1043,10 +1043,15 @@ class MissionSerializer(serializers.ModelSerializer):
         contribution_type = obj.contribution_type
         data = LightContributionTypeSerializer(contribution_type).data
         submission_count = getattr(obj, 'contribution_type_submission_count', None)
-        if submission_count is None:
-            submission_count = contribution_type.get_submission_count()
-
         max_submissions = contribution_type.max_submissions
+        if submission_count is None and max_submissions is not None:
+            submission_count = contribution_type.get_submission_count()
+        if submission_count is None:
+            data['submission_count'] = None
+            data['submissions_remaining'] = None
+            data['is_full'] = False
+            return data
+
         data['submission_count'] = submission_count
         data['submissions_remaining'] = (
             None
@@ -1060,6 +1065,8 @@ class MissionSerializer(serializers.ModelSerializer):
         return data
 
     def get_submission_count(self, obj):
+        if obj.max_submissions is None:
+            return getattr(obj, 'submission_count', None)
         return obj.get_submission_count()
 
     def get_submissions_remaining(self, obj):
@@ -1076,6 +1083,8 @@ class MissionSerializer(serializers.ModelSerializer):
         return None
 
     def get_user_submission_count(self, obj):
+        if obj.max_submissions_per_user is None:
+            return getattr(obj, 'user_submission_count', None)
         return obj.get_user_submission_count(self._current_user())
 
     def get_user_submissions_remaining(self, obj):

--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -1908,25 +1908,7 @@ class MissionViewSet(viewsets.ReadOnlyModelViewSet):
         queryset = Mission.objects.all().select_related(
             'contribution_type',
             'contribution_type__category',
-        ).annotate(
-            submission_count=Count(
-                'submissions',
-                filter=~Q(
-                    submissions__state__in=['rejected', 'canceled']
-                ),
-                distinct=True,
-            ),
-            contribution_type_submission_count=Count(
-                'contribution_type__submitted_contributions',
-                filter=~Q(
-                    contribution_type__submitted_contributions__state__in=[
-                        'rejected',
-                        'canceled',
-                    ]
-                ),
-                distinct=True,
-            )
-        )
+        ).order_by('-created_at')
 
         include_inactive = (
             self.request.query_params.get('include_inactive', '').lower()

--- a/frontend/src/components/Missions.svelte
+++ b/frontend/src/components/Missions.svelte
@@ -100,10 +100,6 @@
     }
   }
 
-  function spotsLeftLabel(count) {
-    return `${count} ${Number(count) === 1 ? 'spot' : 'spots'} left`;
-  }
-
   function toggleMissionExpanded(missionId) {
     const newExpanded = new Set(expandedMissions);
     if (newExpanded.has(missionId)) {
@@ -260,11 +256,6 @@
       {@const isExpanded = expandedMissions.has(mission.id)}
       {@const hasLongText = needsExpansion(mission.description)}
       {@const parentType = mission.contribution_type_details}
-      {@const missionIsFull = mission.user_is_full === true || mission.is_full === true || (mission.max_submissions != null && mission.submissions_remaining != null && Number(mission.submissions_remaining) <= 0)}
-      {@const contributionTypeIsFull = parentType?.is_full === true || (parentType?.max_submissions != null && parentType?.submissions_remaining != null && Number(parentType.submissions_remaining) <= 0)}
-      {@const submissionClosed = missionIsFull || contributionTypeIsFull}
-      {@const capacityLabel = mission.user_is_full === true ? 'Your limit reached' : missionIsFull ? 'Full' : contributionTypeIsFull ? 'Submissions closed' : mission.max_submissions != null ? spotsLeftLabel(mission.submissions_remaining) : parentType?.max_submissions != null ? spotsLeftLabel(parentType.submissions_remaining) : null}
-      {@const submitLabel = mission.user_is_full === true ? 'Limit reached' : missionIsFull ? 'Full' : contributionTypeIsFull ? 'Submissions closed' : 'Submit →'}
 
       <div class="px-4 py-3 border-b last:border-b-0 hover:bg-gray-50 transition-colors">
         <!-- Title row with badges and submit button -->
@@ -303,19 +294,13 @@
               <span class="text-xs text-gray-600">Ongoing</span>
             {/if}
 
-            {#if capacityLabel}
-              <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium {submissionClosed ? 'bg-gray-100 text-gray-700' : 'bg-emerald-100 text-emerald-800'}">
-                {capacityLabel}
-              </span>
-            {/if}
           </div>
 
           <button
-            onclick={() => !submissionClosed && push(`/submit-contribution?mission=${mission.id}`)}
-            disabled={submissionClosed}
-            class="inline-flex min-h-11 w-full flex-shrink-0 items-center justify-center rounded-[8px] border border-gray-200 px-3 text-sm font-normal transition-colors sm:min-h-0 sm:w-auto sm:border-0 sm:p-0 {submissionClosed ? 'cursor-not-allowed text-gray-400' : `${colors.titleText} ${colors.titleTextHover}`}"
+            onclick={() => push(`/submit-contribution?mission=${mission.id}`)}
+            class="inline-flex min-h-11 w-full flex-shrink-0 items-center justify-center rounded-[8px] border border-gray-200 px-3 text-sm font-normal transition-colors sm:min-h-0 sm:w-auto sm:border-0 sm:p-0 {colors.titleText} {colors.titleTextHover}"
           >
-            {submitLabel}
+            Submit →
           </button>
         </div>
 

--- a/frontend/src/components/portal/submit-contribution/SubmitContribution.svelte
+++ b/frontend/src/components/portal/submit-contribution/SubmitContribution.svelte
@@ -128,15 +128,7 @@
             const parentType = types.find((t) => t.id === mission.contribution_type);
             if (parentType) {
               selectedCategory = parentType.category || "builder";
-              if (isTypeFull(parentType)) {
-                selectedType = null;
-                selectedMission = null;
-                selectedMissionData = null;
-                formData.contribution_type = "";
-                searchQuery = "";
-                showTypeDropdown = true;
-                error = "This contribution type has reached its submission limit.";
-              } else if (isMissionSubmittable(mission)) {
+              if (isMissionActive(mission)) {
                 selectedType = parentType;
                 selectedMission = mission.id;
                 selectedMissionData = mission;
@@ -149,9 +141,7 @@
                 formData.contribution_type = "";
                 searchQuery = "";
                 showTypeDropdown = true;
-                error = isMissionFull(mission)
-                  ? missionLimitError(mission)
-                  : "This mission is not currently accepting submissions.";
+                error = "This mission is not currently accepting submissions.";
               }
             }
           }
@@ -164,15 +154,9 @@
         if (type) {
           selectedCategory = type.category || "builder";
           searchQuery = type.name;
-          if (type.is_submittable && !isTypeFull(type)) {
+          if (type.is_submittable) {
             selectedType = type;
             formData.contribution_type = type.id;
-          } else if (isTypeFull(type)) {
-            selectedType = null;
-            formData.contribution_type = "";
-            searchQuery = "";
-            showTypeDropdown = true;
-            error = "This contribution type has reached its submission limit.";
           } else {
             showTypeDropdown = true;
           }
@@ -310,58 +294,15 @@
     return true;
   }
 
-  function isMissionFull(mission) {
-    if (!mission) return false;
-    if (mission.user_is_full === true) return true;
-    if (mission.is_full === true) return true;
-    return (
-      mission.max_submissions !== null &&
-      mission.max_submissions !== undefined &&
-      mission.submissions_remaining !== null &&
-      mission.submissions_remaining !== undefined &&
-      Number(mission.submissions_remaining) <= 0
-    );
-  }
-
-  function missionLimitError(mission) {
-    if (mission?.user_is_full === true) {
-      return "You have reached your submission limit for this mission.";
-    }
-    return "This mission has reached its submission limit.";
-  }
-
-  function isMissionSubmittable(mission) {
-    return isMissionActive(mission) && !isMissionFull(mission);
-  }
-
-  function isTypeFull(type) {
-    if (!type) return false;
-    if (type.is_full === true) return true;
-    return (
-      type.max_submissions !== null &&
-      type.max_submissions !== undefined &&
-      type.submissions_remaining !== null &&
-      type.submissions_remaining !== undefined &&
-      Number(type.submissions_remaining) <= 0
-    );
-  }
-
   function canSubmitTypeDirectly(type) {
-    return type.is_submittable && !isTypeFull(type);
-  }
-
-  function spotsLeftLabel(count) {
-    return `${count} ${Number(count) === 1 ? "spot" : "spots"} left`;
+    return type.is_submittable;
   }
 
   function activeMissionsForType(typeId) {
-    const type = types.find((t) => String(t.id) === String(typeId));
-    if (isTypeFull(type)) return [];
-
     return missions.filter(
       (mission) =>
         String(mission.contribution_type) === String(typeId) &&
-        isMissionSubmittable(mission),
+        isMissionActive(mission),
     );
   }
 
@@ -473,11 +414,6 @@
   }
 
   function selectType(t) {
-    if (isTypeFull(t)) {
-      error = "This contribution type has reached its submission limit.";
-      return;
-    }
-
     if (!t.is_submittable) {
       searchQuery = t.name;
       showTypeDropdown = true;
@@ -497,14 +433,8 @@
     if (item.itemType === "type") {
       selectType(item.data);
     } else if (item.itemType === "mission") {
-      if (isTypeFull(item.parentType)) {
-        error = "This contribution type has reached its submission limit.";
-        return;
-      }
-      if (!isMissionSubmittable(item.data)) {
-        error = isMissionFull(item.data)
-          ? missionLimitError(item.data)
-          : "This mission is not currently accepting submissions.";
+      if (!isMissionActive(item.data)) {
+        error = "This mission is not currently accepting submissions.";
         return;
       }
       selectedType = item.parentType;
@@ -891,12 +821,6 @@
     error = "";
 
     try {
-      if (isTypeFull(selectedType)) {
-        error = "This contribution type has reached its submission limit.";
-        submitting = false;
-        return;
-      }
-
       const submissionData = {
         contribution_type: formData.contribution_type,
         contribution_date: formData.contribution_date + "T00:00:00Z",
@@ -908,11 +832,6 @@
       // Include mission when selected from the URL preselection or dropdown.
       const missionToSubmit = selectedMission;
       if (missionToSubmit) {
-        if (isMissionFull(selectedMissionData)) {
-          error = missionLimitError(selectedMissionData);
-          submitting = false;
-          return;
-        }
         submissionData.mission = missionToSubmit;
       }
 
@@ -1221,12 +1140,6 @@
                         >For: {item.parentType.name}</span
                       >
                     {/if}
-                    {#if item.itemType === "mission" && item.data.max_submissions != null}
-                      <span
-                        class="font-['Switzer'] text-[11px] text-emerald-700 mt-0.5"
-                        >{spotsLeftLabel(item.data.submissions_remaining)}</span
-                      >
-                    {/if}
                     {#if item.itemType === "type"}
                       <div class="mt-1 flex items-center gap-1">
                         <span
@@ -1238,12 +1151,6 @@
                             )} pts{:else}{item.data.min_points}
                             - {item.data.max_points} pts{/if}</span
                         >
-                        {#if item.data.max_submissions != null}
-                          <span
-                            class="bg-emerald-100 text-emerald-700 text-xs px-2 py-0.5 rounded font-medium"
-                            >{spotsLeftLabel(item.data.submissions_remaining)}</span
-                          >
-                        {/if}
                       </div>
                     {/if}
                   </button>
@@ -1282,21 +1189,11 @@
             <p class="font-['Switzer'] text-[12px] text-gray-500 mt-0.5">
               Type: {selectedType.name}
             </p>
-            {#if selectedMissionData.max_submissions != null}
-              <p class="font-['Switzer'] text-[12px] text-gray-500 mt-0.5">
-                Mission capacity: {spotsLeftLabel(selectedMissionData.submissions_remaining)}
-              </p>
-            {/if}
           {:else}
             <span
               class="font-['Switzer'] font-semibold text-[14px] text-black"
               >{selectedType.name}</span
             >
-            {#if selectedType.max_submissions != null}
-              <p class="font-['Switzer'] text-[12px] text-gray-500 mt-0.5">
-                Capacity: {spotsLeftLabel(selectedType.submissions_remaining)}
-              </p>
-            {/if}
             {#if selectedType.description}
               <p class="font-['Switzer'] text-[12px] text-gray-500 mt-1">
                 {selectedType.description}

--- a/frontend/src/routes/MissionDetail.svelte
+++ b/frontend/src/routes/MissionDetail.svelte
@@ -73,29 +73,6 @@
   let allContributionsPath = $derived(
     `/all-contributions?category=${explorerCategory}&mission=${params.id}`
   );
-  let missionIsFull = $derived(
-    mission?.user_is_full === true ||
-      mission?.is_full === true ||
-      (mission?.max_submissions != null &&
-        mission?.submissions_remaining != null &&
-        Number(mission.submissions_remaining) <= 0)
-  );
-  let contributionTypeIsFull = $derived(
-    contributionType?.is_full === true ||
-      (contributionType?.max_submissions != null &&
-        contributionType?.submissions_remaining != null &&
-        Number(contributionType.submissions_remaining) <= 0)
-  );
-  let submissionClosed = $derived(missionIsFull || contributionTypeIsFull);
-  let capacityLabel = $derived.by(() => {
-    if (mission?.user_is_full === true) return 'Your limit reached';
-    if (mission?.max_submissions == null) {
-      return contributionTypeIsFull ? 'Submissions closed' : 'Unlimited';
-    }
-    if (missionIsFull) return 'Full';
-    if (contributionTypeIsFull) return 'Submissions closed';
-    return `${formatNumber(mission.submissions_remaining)} left`;
-  });
 
   function formatDate(dateString) {
     if (!dateString) return 'Ongoing';
@@ -236,15 +213,12 @@
 
           <button
             type="button"
-            onclick={() => !submissionClosed && push(`/submit-contribution?mission=${mission.id}`)}
-            disabled={submissionClosed}
-            class="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-[8px] border border-black bg-black px-4 text-[13px] font-semibold text-white shadow-[0_8px_22px_rgba(31,42,68,0.12)] transition sm:w-auto {submissionClosed ? 'cursor-not-allowed opacity-60' : 'hover:-translate-y-0.5 hover:shadow-[0_14px_26px_rgba(31,42,68,0.16)]'}"
-            style={submissionClosed ? '' : submitButtonStyle}
+            onclick={() => push(`/submit-contribution?mission=${mission.id}`)}
+            class="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-[8px] border border-black bg-black px-4 text-[13px] font-semibold text-white shadow-[0_8px_22px_rgba(31,42,68,0.12)] transition hover:-translate-y-0.5 hover:shadow-[0_14px_26px_rgba(31,42,68,0.16)] sm:w-auto"
+            style={submitButtonStyle}
           >
-            {submissionClosed ? 'Submissions closed' : 'Submit to mission'}
-            {#if !submissionClosed}
-              <img src="/assets/icons/arrow-right-line-white.svg" alt="" class="h-4 w-4" />
-            {/if}
+            Submit to mission
+            <img src="/assets/icons/arrow-right-line-white.svg" alt="" class="h-4 w-4" />
           </button>
         </div>
 
@@ -260,12 +234,6 @@
           <div class="rounded-[8px] border border-[#e8ebf2] bg-white p-4 shadow-[0_8px_18px_rgba(31,42,68,0.07)]">
             <p class="text-[12px] font-semibold uppercase text-[#7b8798]">Points Earned</p>
             <p class="mt-2 font-display text-[28px] font-semibold leading-none text-black">{formatNumber(stats.points_earned)}</p>
-          </div>
-          <div class="rounded-[8px] border border-[#e8ebf2] bg-white p-4 shadow-[0_8px_18px_rgba(31,42,68,0.07)]">
-            <p class="text-[12px] font-semibold uppercase text-[#7b8798]">Capacity</p>
-            <p class="mt-2 text-[16px] font-semibold text-black">
-              {capacityLabel}
-            </p>
           </div>
         </div>
       </section>
@@ -286,14 +254,6 @@
               <div class="flex items-center justify-between gap-4">
                 <span class="text-[12px] font-semibold uppercase text-[#7b8798]">End</span>
                 <span class="text-[13px] font-semibold text-black">{formatDate(mission.end_date)}</span>
-              </div>
-              <div class="flex items-center justify-between gap-4">
-                <span class="text-[12px] font-semibold uppercase text-[#7b8798]">Submissions</span>
-                <span class="text-[13px] font-semibold text-black">
-                  {mission.max_submissions == null
-                    ? `${formatNumber(mission.submission_count)} / Unlimited`
-                    : `${formatNumber(mission.submission_count)} / ${formatNumber(mission.max_submissions)}`}
-                </span>
               </div>
             </div>
           </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "damascus-v1",
+  "name": "irvine",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Removes expensive mission submission-count annotations from the missions API so mission list/detail requests no longer scan submitted contributions for uncapped missions. Hides mission capacity UI for now while leaving backend submission-cap enforcement intact. Simplifies the Submitted Contributions admin changelist by dropping the evidence-count aggregate and using select_related with smaller pages. Also includes the workspace package-lock name update.