### PR TITLE
Fix mission contribution loading performance

### DIFF
--- a/backend/contributions/admin.py
+++ b/backend/contributions/admin.py
@@ -7,7 +7,16 @@ from django.shortcuts import render, redirect
 from django.utils import timezone
 from django.utils.html import format_html
 from django.db import transaction
-from django.db.models import Count, Q
+from django.db.models import (
+    Count,
+    DecimalField,
+    Exists,
+    IntegerField,
+    OuterRef,
+    Subquery,
+    Value,
+)
+from django.db.models.functions import Coalesce
 from django.core.exceptions import ValidationError
 from django.contrib.auth import get_user_model
 from datetime import datetime
@@ -17,6 +26,50 @@ from leaderboard.models import GlobalLeaderboardMultiplier
 from utils.admin_mixins import CloudinaryUploadMixin
 
 User = get_user_model()
+
+NON_CAPACITY_STATES = ['rejected', 'canceled']
+
+
+def active_submission_count_subquery(fk_name):
+    return SubmittedContribution.objects.exclude(
+        state__in=NON_CAPACITY_STATES
+    ).filter(
+        **{fk_name: OuterRef('pk')}
+    ).values(
+        fk_name
+    ).annotate(
+        count=Count('pk')
+    ).values('count')
+
+
+def coalesced_count(subquery):
+    return Coalesce(
+        Subquery(subquery, output_field=IntegerField()),
+        Value(0),
+        output_field=IntegerField(),
+    )
+
+
+class ContributionTypeListFilter(admin.SimpleListFilter):
+    title = 'contribution type'
+    parameter_name = 'contribution_type__id__exact'
+
+    def lookups(self, request, model_admin):
+        contribution_types = ContributionType.objects.select_related(
+            'category'
+        ).order_by('category__name', 'name')
+        return [
+            (
+                str(contribution_type.id),
+                str(contribution_type),
+            )
+            for contribution_type in contribution_types
+        ]
+
+    def queryset(self, request, queryset):
+        if self.value():
+            return queryset.filter(contribution_type_id=self.value())
+        return queryset
 
 
 @admin.register(Category)
@@ -50,22 +103,31 @@ class ContributionTypeAdmin(admin.ModelAdmin):
     prepopulated_fields = { 'slug': ('name',) }
     filter_horizontal = ('accepted_evidence_url_types', 'required_evidence_url_types')
     inlines = [GlobalLeaderboardMultiplierInline]
+    show_facets = admin.ShowFacets.NEVER
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
+        multiplier_field = DecimalField(max_digits=10, decimal_places=2)
+        current_multiplier = GlobalLeaderboardMultiplier.objects.filter(
+            contribution_type_id=OuterRef('pk')
+        ).order_by('-valid_from').values('multiplier_value')[:1]
+
         return qs.select_related('category').annotate(
-            submission_count=Count(
-                'submitted_contributions',
-                filter=~Q(
-                    submitted_contributions__state__in=['rejected', 'canceled']
-                ),
-                distinct=True,
-            )
+            submission_count=coalesced_count(
+                active_submission_count_subquery('contribution_type_id')
+            ),
+            current_multiplier_value=Coalesce(
+                Subquery(current_multiplier, output_field=multiplier_field),
+                Value(1.0, output_field=multiplier_field),
+                output_field=multiplier_field,
+            ),
         )
     
     def get_current_multiplier(self, obj):
-        from leaderboard.models import GlobalLeaderboardMultiplier
-        return f"{GlobalLeaderboardMultiplier.get_current_multiplier_value(obj)}x"
+        multiplier = getattr(obj, 'current_multiplier_value', None)
+        if multiplier is None:
+            multiplier = GlobalLeaderboardMultiplier.get_current_multiplier_value(obj)
+        return f"{multiplier}x"
     get_current_multiplier.short_description = "Current Multiplier"
 
     def get_submission_usage(self, obj):
@@ -79,7 +141,7 @@ class ContributionTypeAdmin(admin.ModelAdmin):
 @admin.register(GlobalLeaderboardMultiplier)
 class GlobalLeaderboardMultiplierAdmin(admin.ModelAdmin):
     list_display = ('contribution_type', 'multiplier_value', 'valid_from', 'description', 'created_at')
-    list_filter = ('contribution_type', 'valid_from')
+    list_filter = (ContributionTypeListFilter, 'valid_from')
     search_fields = ('contribution_type__name', 'description', 'notes')
     readonly_fields = ('created_at', 'updated_at')
 
@@ -138,7 +200,7 @@ class ContributionAdmin(admin.ModelAdmin):
     list_display = ('id', 'user_display', 'user_address_short', 'contribution_type', 'points',
                    'frozen_global_points', 'contribution_date_display', 'has_evidence',
                    'has_highlight', 'created_at')
-    list_filter = ('contribution_type__category', 'contribution_type', 'contribution_date', 'created_at',
+    list_filter = ('contribution_type__category', ContributionTypeListFilter, 'contribution_date', 'created_at',
                   ('evidence_items', admin.EmptyFieldListFilter))
     search_fields = ('user__email', 'user__name', 'user__address', 'contribution_type__name',
                     'notes', 'evidence_items__description', 'evidence_items__url', 'mission__name')
@@ -147,9 +209,10 @@ class ContributionAdmin(admin.ModelAdmin):
     ordering = ('-contribution_date', '-created_at')  # Most recent contributions first
     inlines = [ContributionHighlightInline, EvidenceInline]
     list_per_page = 50
-    date_hierarchy = 'contribution_date'
     list_select_related = ['user', 'contribution_type']
     autocomplete_fields = ['user', 'contribution_type']
+    show_full_result_count = False
+    show_facets = admin.ShowFacets.NEVER
     change_form_template = 'admin/contributions/contribution_change_form.html'
     fieldsets = (
         (None, {
@@ -344,9 +407,20 @@ class ContributionAdmin(admin.ModelAdmin):
             return JsonResponse({'error': 'Not found'}, status=404)
     
     def get_queryset(self, request):
-        """Optimize queryset to avoid N+1 queries."""
+        """Keep the contribution changelist cheap for large contribution tables."""
         qs = super().get_queryset(request)
-        return qs.select_related('user', 'contribution_type').prefetch_related('source_submission', 'evidence_items', 'highlights')
+        return qs.select_related(
+            'user',
+            'contribution_type',
+            'contribution_type__category',
+        ).annotate(
+            has_evidence_value=Exists(
+                Evidence.objects.filter(contribution_id=OuterRef('pk'))
+            ),
+            has_highlight_value=Exists(
+                ContributionHighlight.objects.filter(contribution_id=OuterRef('pk'))
+            ),
+        )
     
     def user_display(self, obj):
         """Display user name with email."""
@@ -373,13 +447,19 @@ class ContributionAdmin(admin.ModelAdmin):
     
     def has_evidence(self, obj):
         """Check if contribution has evidence."""
+        annotated = getattr(obj, 'has_evidence_value', None)
+        if annotated is not None:
+            return annotated
         return obj.evidence_items.exists()
     has_evidence.boolean = True
     has_evidence.short_description = 'Evidence'
     
     def has_highlight(self, obj):
         """Check if contribution has a highlight."""
-        return obj.highlights.filter().exists()
+        annotated = getattr(obj, 'has_highlight_value', None)
+        if annotated is not None:
+            return annotated
+        return obj.highlights.exists()
     has_highlight.boolean = True
     has_highlight.short_description = 'Highlighted'
     
@@ -402,11 +482,12 @@ class SubmissionNoteInline(admin.TabularInline):
 class SubmittedContributionAdmin(admin.ModelAdmin):
     list_display = ('user', 'contribution_type', 'proposed_points', 'state',
                    'contribution_date', 'created_at', 'reviewed_by')
-    list_filter = ('state', 'contribution_type__category', 'contribution_type', 'created_at', 'reviewed_at')
+    list_filter = ('state', 'contribution_type__category', ContributionTypeListFilter, 'created_at', 'reviewed_at')
     search_fields = ('user__email', 'user__name', 'notes', 'staff_reply', 'mission__name')
-    date_hierarchy = 'created_at'
     list_per_page = 25
     show_full_result_count = False
+    show_facets = admin.ShowFacets.NEVER
+    autocomplete_fields = ('user', 'contribution_type', 'reviewed_by')
     readonly_fields = ('id', 'created_at', 'updated_at', 'last_edited_at',
                       'converted_contribution_link', 'contribution_type_info', 'proposed_points')
     inlines = [EvidenceInline, SubmissionNoteInline]
@@ -661,10 +742,14 @@ class MissionAdmin(admin.ModelAdmin):
         'id', 'name', 'contribution_type', 'get_status',
         'get_submission_usage', 'start_date', 'end_date', 'created_at',
     )
-    list_filter = ('contribution_type', 'start_date', 'end_date', 'created_at')
+    list_filter = (ContributionTypeListFilter, 'start_date', 'end_date', 'created_at')
     search_fields = ('name', 'description')
     readonly_fields = ('id', 'created_at', 'updated_at')
     list_editable = ()
+    list_per_page = 25
+    show_full_result_count = False
+    show_facets = admin.ShowFacets.NEVER
+    autocomplete_fields = ('contribution_type',)
 
     fieldsets = (
         (None, {
@@ -694,12 +779,10 @@ class MissionAdmin(admin.ModelAdmin):
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         return qs.select_related('contribution_type').annotate(
-            submission_count=Count(
-                'submissions',
-                filter=~Q(submissions__state__in=['rejected', 'canceled']),
-                distinct=True,
+            submission_count=coalesced_count(
+                active_submission_count_subquery('mission_id')
             )
-        )
+        ).order_by('-created_at', '-id')
 
     def get_status(self, obj):
         if obj.is_active():

--- a/backend/contributions/serializers.py
+++ b/backend/contributions/serializers.py
@@ -131,11 +131,26 @@ class ContributionTypeSerializer(serializers.ModelSerializer):
 
     def get_current_multiplier(self, obj):
         """Get the current multiplier value for this contribution type."""
+        annotated_multiplier = getattr(obj, 'current_multiplier_value', None)
+        if annotated_multiplier is not None:
+            return float(annotated_multiplier)
+
         from leaderboard.models import GlobalLeaderboardMultiplier
         try:
             return float(GlobalLeaderboardMultiplier.get_current_multiplier_value(obj))
         except Exception:
             return 1.0
+
+    def _all_evidence_url_types(self):
+        cached = self.context.get('_all_evidence_url_types')
+        if cached is None:
+            cached = list(EvidenceURLType.objects.all().order_by('order', 'name'))
+            self.context['_all_evidence_url_types'] = cached
+        return cached
+
+    @staticmethod
+    def _ordered_url_types(url_types):
+        return sorted(url_types, key=lambda t: (t.order, t.name))
 
     def get_accepted_evidence_url_types(self, obj):
         """Return accepted evidence URL types with patterns for client-side detection.
@@ -147,20 +162,22 @@ class ContributionTypeSerializer(serializers.ModelSerializer):
         Required types are merged in when an explicit accepted list is set,
         so they are always part of the returned list.
         """
-        accepted = obj.accepted_evidence_url_types.all()
-        if not accepted.exists():
-            url_types = EvidenceURLType.objects.all().order_by('order')
+        accepted = list(obj.accepted_evidence_url_types.all())
+        if not accepted:
+            url_types = self._all_evidence_url_types()
         else:
-            required = obj.required_evidence_url_types.all()
+            required = list(obj.required_evidence_url_types.all())
             merged = {t.id: t for t in accepted}
             for t in required:
                 merged.setdefault(t.id, t)
-            url_types = sorted(merged.values(), key=lambda t: (t.order, t.name))
+            url_types = self._ordered_url_types(merged.values())
         return EvidenceURLTypeSerializer(url_types, many=True).data
 
     def get_required_evidence_url_types(self, obj):
         """Return required evidence URL types (at least one must match)."""
-        url_types = obj.required_evidence_url_types.all().order_by('order')
+        url_types = self._ordered_url_types(
+            obj.required_evidence_url_types.all()
+        )
         return EvidenceURLTypeSerializer(url_types, many=True).data
 
     def get_submission_count(self, obj):
@@ -1044,13 +1061,8 @@ class MissionSerializer(serializers.ModelSerializer):
         data = LightContributionTypeSerializer(contribution_type).data
         submission_count = getattr(obj, 'contribution_type_submission_count', None)
         max_submissions = contribution_type.max_submissions
-        if submission_count is None and max_submissions is not None:
-            submission_count = contribution_type.get_submission_count()
         if submission_count is None:
-            data['submission_count'] = None
-            data['submissions_remaining'] = None
-            data['is_full'] = False
-            return data
+            submission_count = contribution_type.get_submission_count()
 
         data['submission_count'] = submission_count
         data['submissions_remaining'] = (
@@ -1065,8 +1077,6 @@ class MissionSerializer(serializers.ModelSerializer):
         return data
 
     def get_submission_count(self, obj):
-        if obj.max_submissions is None:
-            return getattr(obj, 'submission_count', None)
         return obj.get_submission_count()
 
     def get_submissions_remaining(self, obj):
@@ -1083,8 +1093,6 @@ class MissionSerializer(serializers.ModelSerializer):
         return None
 
     def get_user_submission_count(self, obj):
-        if obj.max_submissions_per_user is None:
-            return getattr(obj, 'user_submission_count', None)
         return obj.get_user_submission_count(self._current_user())
 
     def get_user_submissions_remaining(self, obj):

--- a/backend/contributions/tests/test_submission_limits.py
+++ b/backend/contributions/tests/test_submission_limits.py
@@ -1,7 +1,9 @@
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -217,6 +219,48 @@ class SubmissionLimitTest(TestCase):
         self.assertEqual(response.data['user_submission_count'], 1)
         self.assertEqual(response.data['user_submissions_remaining'], 0)
         self.assertTrue(response.data['user_is_full'])
+
+    def test_mission_list_exposes_capacity_fields_with_constant_queries(self):
+        self.contribution_type.max_submissions = 4
+        self.contribution_type.save(update_fields=['max_submissions'])
+        mission = Mission.objects.create(
+            name='Limited Mission',
+            description='Test mission',
+            contribution_type=self.contribution_type,
+            max_submissions=3,
+            max_submissions_per_user=1,
+        )
+        other_mission = Mission.objects.create(
+            name='Other Mission',
+            description='Other mission',
+            contribution_type=self.contribution_type,
+        )
+        self._create_submission(state='pending', mission=mission, user=self.user)
+        self._create_submission(state='accepted', mission=mission, user=self.other_user)
+        self._create_submission(state='canceled', mission=mission, user=self.other_user)
+        self._create_submission(state='pending', mission=other_mission, user=self.other_user)
+
+        with CaptureQueriesContext(connection) as queries:
+            response = self.client.get('/api/v1/missions/?include_inactive=true&page_size=100')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertLessEqual(len(queries), 4)
+
+        missions = response.data['results']
+        mission_data = next(
+            item for item in missions if item['id'] == mission.id
+        )
+        type_data = mission_data['contribution_type_details']
+
+        self.assertEqual(mission_data['submission_count'], 2)
+        self.assertEqual(mission_data['submissions_remaining'], 1)
+        self.assertFalse(mission_data['is_full'])
+        self.assertEqual(mission_data['user_submission_count'], 1)
+        self.assertEqual(mission_data['user_submissions_remaining'], 0)
+        self.assertTrue(mission_data['user_is_full'])
+        self.assertEqual(type_data['submission_count'], 3)
+        self.assertEqual(type_data['submissions_remaining'], 1)
+        self.assertFalse(type_data['is_full'])
 
     def test_contribution_type_api_exposes_capacity_fields(self):
         self.contribution_type.max_submissions = 2

--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -5,7 +5,19 @@ from django_filters.rest_framework import DjangoFilterBackend
 from django_filters import FilterSet, CharFilter, BooleanFilter, NumberFilter
 from django.utils import timezone
 from django.db import transaction
-from django.db.models import Count, Max, F, Q, Exists, OuterRef, Subquery, Sum
+from django.db.models import (
+    Count,
+    DecimalField,
+    Exists,
+    F,
+    IntegerField,
+    Max,
+    OuterRef,
+    Q,
+    Subquery,
+    Sum,
+    Value,
+)
 from django.db.models.functions import TruncDate, TruncWeek, TruncMonth
 from django.db.models.functions import Coalesce
 from django.shortcuts import render, redirect, get_object_or_404
@@ -40,14 +52,30 @@ class ContributionTypeViewSet(viewsets.ReadOnlyModelViewSet):
     ordering_fields = ['name', 'created_at']
     
     def get_queryset(self):
-        queryset = ContributionType.objects.all().annotate(
-            submission_count=Count(
-                'submitted_contributions',
-                filter=~Q(
-                    submitted_contributions__state__in=['rejected', 'canceled']
-                ),
-                distinct=True,
-            )
+        active_submissions = SubmittedContribution.objects.exclude(
+            state__in=['rejected', 'canceled']
+        )
+        submission_count = active_submissions.filter(
+            contribution_type_id=OuterRef('pk')
+        ).values('contribution_type_id').annotate(
+            count=Count('pk')
+        ).values('count')
+        multiplier_field = DecimalField(max_digits=10, decimal_places=2)
+        current_multiplier = GlobalLeaderboardMultiplier.objects.filter(
+            contribution_type_id=OuterRef('pk')
+        ).order_by('-valid_from').values('multiplier_value')[:1]
+
+        queryset = ContributionType.objects.select_related('category').annotate(
+            submission_count=Coalesce(
+                Subquery(submission_count, output_field=IntegerField()),
+                Value(0),
+                output_field=IntegerField(),
+            ),
+            current_multiplier_value=Coalesce(
+                Subquery(current_multiplier, output_field=multiplier_field),
+                Value(1.0, output_field=multiplier_field),
+                output_field=multiplier_field,
+            ),
         )
 
         # Filter by category if provided
@@ -66,7 +94,7 @@ class ContributionTypeViewSet(viewsets.ReadOnlyModelViewSet):
         return queryset.prefetch_related(
             'accepted_evidence_url_types',
             'required_evidence_url_types',
-        )
+        ).order_by('category__name', 'name', 'id')
 
     @action(detail=False, methods=['get'], permission_classes=[permissions.AllowAny])
     def statistics(self, request):
@@ -79,8 +107,6 @@ class ContributionTypeViewSet(viewsets.ReadOnlyModelViewSet):
             - last date someone earned each type
             - total points given for each type
         """
-        from django.db.models import Sum
-        
         # Start with all contribution types
         queryset = ContributionType.objects.all()
 
@@ -92,26 +118,28 @@ class ContributionTypeViewSet(viewsets.ReadOnlyModelViewSet):
             if category == 'builder':
                 queryset = queryset.exclude(slug='builder-welcome')
         
+        multiplier_field = DecimalField(max_digits=10, decimal_places=2)
+        current_multiplier = GlobalLeaderboardMultiplier.objects.filter(
+            contribution_type_id=OuterRef('pk')
+        ).order_by('-valid_from').values('multiplier_value')[:1]
+
         types_with_stats = queryset.annotate(
             count=Count('contributions'),
             participants_count=Count('contributions__user', distinct=True),
             last_earned=Coalesce(Max('contributions__contribution_date'), timezone.now()),
-            total_points_given=Coalesce(Sum('contributions__frozen_global_points'), 0)
-        ).values('id', 'name', 'description', 'min_points', 'max_points', 'count', 'participants_count', 'last_earned', 'total_points_given', 'is_submittable', 'show_in_contributions')
-        
-        # Add current multiplier for each type
-        result = []
-        for type_data in types_with_stats:
-            try:
-                contribution_type = ContributionType.objects.get(id=type_data['id'])
-                multiplier_value = GlobalLeaderboardMultiplier.get_current_multiplier_value(contribution_type)
-                type_data['current_multiplier'] = multiplier_value
-            except Exception:
-                type_data['current_multiplier'] = 1.0
+            total_points_given=Coalesce(Sum('contributions__frozen_global_points'), 0),
+            current_multiplier=Coalesce(
+                Subquery(current_multiplier, output_field=multiplier_field),
+                Value(1.0, output_field=multiplier_field),
+                output_field=multiplier_field,
+            ),
+        ).values(
+            'id', 'name', 'description', 'min_points', 'max_points', 'count',
+            'participants_count', 'last_earned', 'total_points_given',
+            'is_submittable', 'show_in_contributions', 'current_multiplier',
+        )
             
-            result.append(type_data)
-            
-        return Response(result)
+        return Response(list(types_with_stats))
     
     @action(detail=True, methods=['get'], permission_classes=[permissions.AllowAny])
     def top_contributors(self, request, pk=None):
@@ -1905,10 +1933,54 @@ class MissionViewSet(viewsets.ReadOnlyModelViewSet):
         Return active missions by default.
         Supports filtering by contribution_type and category.
         """
+        active_submissions = SubmittedContribution.objects.exclude(
+            state__in=['rejected', 'canceled']
+        )
+        mission_submission_count = active_submissions.filter(
+            mission_id=OuterRef('pk')
+        ).values('mission_id').annotate(
+            count=Count('pk')
+        ).values('count')
+        contribution_type_submission_count = active_submissions.filter(
+            contribution_type_id=OuterRef('contribution_type_id')
+        ).values('contribution_type_id').annotate(
+            count=Count('pk')
+        ).values('count')
+
+        annotations = {
+            'submission_count': Coalesce(
+                Subquery(mission_submission_count, output_field=IntegerField()),
+                Value(0),
+                output_field=IntegerField(),
+            ),
+            'contribution_type_submission_count': Coalesce(
+                Subquery(
+                    contribution_type_submission_count,
+                    output_field=IntegerField(),
+                ),
+                Value(0),
+                output_field=IntegerField(),
+            ),
+        }
+
+        user = getattr(self.request, 'user', None)
+        if user and getattr(user, 'is_authenticated', False):
+            user_submission_count = active_submissions.filter(
+                mission_id=OuterRef('pk'),
+                user_id=user.id,
+            ).values('mission_id').annotate(
+                count=Count('pk')
+            ).values('count')
+            annotations['user_submission_count'] = Coalesce(
+                Subquery(user_submission_count, output_field=IntegerField()),
+                Value(0),
+                output_field=IntegerField(),
+            )
+
         queryset = Mission.objects.all().select_related(
             'contribution_type',
             'contribution_type__category',
-        ).order_by('-created_at')
+        ).annotate(**annotations).order_by('-created_at', '-id')
 
         include_inactive = (
             self.request.query_params.get('include_inactive', '').lower()

--- a/frontend/src/components/Missions.svelte
+++ b/frontend/src/components/Missions.svelte
@@ -100,6 +100,35 @@
     }
   }
 
+  function spotsLeftLabel(count) {
+    return `${count} ${Number(count) === 1 ? 'spot' : 'spots'} left`;
+  }
+
+  function isFull(entity) {
+    if (!entity) return false;
+    if (entity.is_full === true) return true;
+    return (
+      entity.max_submissions !== null &&
+      entity.max_submissions !== undefined &&
+      entity.submissions_remaining !== null &&
+      entity.submissions_remaining !== undefined &&
+      Number(entity.submissions_remaining) <= 0
+    );
+  }
+
+  function missionCapacityLabel(mission, parentType) {
+    if (mission?.user_is_full === true) return 'Your limit reached';
+    if (isFull(mission)) return 'Full';
+    if (isFull(parentType)) return 'Submissions closed';
+    if (mission?.max_submissions != null && mission?.submissions_remaining != null) {
+      return spotsLeftLabel(mission.submissions_remaining);
+    }
+    if (parentType?.max_submissions != null && parentType?.submissions_remaining != null) {
+      return spotsLeftLabel(parentType.submissions_remaining);
+    }
+    return null;
+  }
+
   function toggleMissionExpanded(missionId) {
     const newExpanded = new Set(expandedMissions);
     if (newExpanded.has(missionId)) {
@@ -256,6 +285,9 @@
       {@const isExpanded = expandedMissions.has(mission.id)}
       {@const hasLongText = needsExpansion(mission.description)}
       {@const parentType = mission.contribution_type_details}
+      {@const submissionClosed = mission.user_is_full === true || isFull(mission) || isFull(parentType)}
+      {@const capacityLabel = missionCapacityLabel(mission, parentType)}
+      {@const submitLabel = mission.user_is_full === true ? 'Limit reached' : isFull(mission) ? 'Full' : isFull(parentType) ? 'Submissions closed' : 'Submit →'}
 
       <div class="px-4 py-3 border-b last:border-b-0 hover:bg-gray-50 transition-colors">
         <!-- Title row with badges and submit button -->
@@ -294,13 +326,20 @@
               <span class="text-xs text-gray-600">Ongoing</span>
             {/if}
 
+            {#if capacityLabel}
+              <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium {submissionClosed ? 'bg-gray-100 text-gray-700' : 'bg-emerald-100 text-emerald-800'}">
+                {capacityLabel}
+              </span>
+            {/if}
+
           </div>
 
           <button
-            onclick={() => push(`/submit-contribution?mission=${mission.id}`)}
-            class="inline-flex min-h-11 w-full flex-shrink-0 items-center justify-center rounded-[8px] border border-gray-200 px-3 text-sm font-normal transition-colors sm:min-h-0 sm:w-auto sm:border-0 sm:p-0 {colors.titleText} {colors.titleTextHover}"
+            onclick={() => !submissionClosed && push(`/submit-contribution?mission=${mission.id}`)}
+            disabled={submissionClosed}
+            class="inline-flex min-h-11 w-full flex-shrink-0 items-center justify-center rounded-[8px] border border-gray-200 px-3 text-sm font-normal transition-colors sm:min-h-0 sm:w-auto sm:border-0 sm:p-0 {submissionClosed ? 'cursor-not-allowed text-gray-400' : `${colors.titleText} ${colors.titleTextHover}`}"
           >
-            Submit →
+            {submitLabel}
           </button>
         </div>
 

--- a/frontend/src/components/portal/submit-contribution/SubmitContribution.svelte
+++ b/frontend/src/components/portal/submit-contribution/SubmitContribution.svelte
@@ -128,7 +128,15 @@
             const parentType = types.find((t) => t.id === mission.contribution_type);
             if (parentType) {
               selectedCategory = parentType.category || "builder";
-              if (isMissionActive(mission)) {
+              if (isTypeFull(parentType)) {
+                selectedType = null;
+                selectedMission = null;
+                selectedMissionData = null;
+                formData.contribution_type = "";
+                searchQuery = "";
+                showTypeDropdown = true;
+                error = "This contribution type has reached its submission limit.";
+              } else if (isMissionSubmittable(mission)) {
                 selectedType = parentType;
                 selectedMission = mission.id;
                 selectedMissionData = mission;
@@ -141,7 +149,9 @@
                 formData.contribution_type = "";
                 searchQuery = "";
                 showTypeDropdown = true;
-                error = "This mission is not currently accepting submissions.";
+                error = isMissionFull(mission)
+                  ? missionLimitError(mission)
+                  : "This mission is not currently accepting submissions.";
               }
             }
           }
@@ -154,9 +164,15 @@
         if (type) {
           selectedCategory = type.category || "builder";
           searchQuery = type.name;
-          if (type.is_submittable) {
+          if (type.is_submittable && !isTypeFull(type)) {
             selectedType = type;
             formData.contribution_type = type.id;
+          } else if (isTypeFull(type)) {
+            selectedType = null;
+            formData.contribution_type = "";
+            searchQuery = "";
+            showTypeDropdown = true;
+            error = "This contribution type has reached its submission limit.";
           } else {
             showTypeDropdown = true;
           }
@@ -168,9 +184,15 @@
             if (type) {
               selectedCategory = type.category || "builder";
               searchQuery = type.name;
-              if (type.is_submittable) {
+              if (type.is_submittable && !isTypeFull(type)) {
                 selectedType = type;
                 formData.contribution_type = type.id;
+              } else if (isTypeFull(type)) {
+                selectedType = null;
+                formData.contribution_type = "";
+                searchQuery = "";
+                showTypeDropdown = true;
+                error = "This contribution type has reached its submission limit.";
               } else {
                 showTypeDropdown = true;
               }
@@ -294,15 +316,58 @@
     return true;
   }
 
+  function isMissionFull(mission) {
+    if (!mission) return false;
+    if (mission.user_is_full === true) return true;
+    if (mission.is_full === true) return true;
+    return (
+      mission.max_submissions !== null &&
+      mission.max_submissions !== undefined &&
+      mission.submissions_remaining !== null &&
+      mission.submissions_remaining !== undefined &&
+      Number(mission.submissions_remaining) <= 0
+    );
+  }
+
+  function missionLimitError(mission) {
+    if (mission?.user_is_full === true) {
+      return "You have reached your submission limit for this mission.";
+    }
+    return "This mission has reached its submission limit.";
+  }
+
+  function isMissionSubmittable(mission) {
+    return isMissionActive(mission) && !isMissionFull(mission);
+  }
+
+  function isTypeFull(type) {
+    if (!type) return false;
+    if (type.is_full === true) return true;
+    return (
+      type.max_submissions !== null &&
+      type.max_submissions !== undefined &&
+      type.submissions_remaining !== null &&
+      type.submissions_remaining !== undefined &&
+      Number(type.submissions_remaining) <= 0
+    );
+  }
+
   function canSubmitTypeDirectly(type) {
-    return type.is_submittable;
+    return type.is_submittable && !isTypeFull(type);
+  }
+
+  function spotsLeftLabel(count) {
+    return `${count} ${Number(count) === 1 ? "spot" : "spots"} left`;
   }
 
   function activeMissionsForType(typeId) {
+    const type = types.find((t) => String(t.id) === String(typeId));
+    if (isTypeFull(type)) return [];
+
     return missions.filter(
       (mission) =>
         String(mission.contribution_type) === String(typeId) &&
-        isMissionActive(mission),
+        isMissionSubmittable(mission),
     );
   }
 
@@ -414,6 +479,11 @@
   }
 
   function selectType(t) {
+    if (isTypeFull(t)) {
+      error = "This contribution type has reached its submission limit.";
+      return;
+    }
+
     if (!t.is_submittable) {
       searchQuery = t.name;
       showTypeDropdown = true;
@@ -433,8 +503,14 @@
     if (item.itemType === "type") {
       selectType(item.data);
     } else if (item.itemType === "mission") {
-      if (!isMissionActive(item.data)) {
-        error = "This mission is not currently accepting submissions.";
+      if (isTypeFull(item.parentType)) {
+        error = "This contribution type has reached its submission limit.";
+        return;
+      }
+      if (!isMissionSubmittable(item.data)) {
+        error = isMissionFull(item.data)
+          ? missionLimitError(item.data)
+          : "This mission is not currently accepting submissions.";
         return;
       }
       selectedType = item.parentType;
@@ -821,6 +897,12 @@
     error = "";
 
     try {
+      if (isTypeFull(selectedType)) {
+        error = "This contribution type has reached its submission limit.";
+        submitting = false;
+        return;
+      }
+
       const submissionData = {
         contribution_type: formData.contribution_type,
         contribution_date: formData.contribution_date + "T00:00:00Z",
@@ -832,6 +914,11 @@
       // Include mission when selected from the URL preselection or dropdown.
       const missionToSubmit = selectedMission;
       if (missionToSubmit) {
+        if (isMissionFull(selectedMissionData)) {
+          error = missionLimitError(selectedMissionData);
+          submitting = false;
+          return;
+        }
         submissionData.mission = missionToSubmit;
       }
 
@@ -1140,6 +1227,12 @@
                         >For: {item.parentType.name}</span
                       >
                     {/if}
+                    {#if item.itemType === "mission" && item.data.max_submissions != null && item.data.submissions_remaining != null}
+                      <span
+                        class="font-['Switzer'] text-[11px] text-emerald-700 mt-0.5"
+                        >{spotsLeftLabel(item.data.submissions_remaining)}</span
+                      >
+                    {/if}
                     {#if item.itemType === "type"}
                       <div class="mt-1 flex items-center gap-1">
                         <span
@@ -1151,6 +1244,12 @@
                             )} pts{:else}{item.data.min_points}
                             - {item.data.max_points} pts{/if}</span
                         >
+                        {#if item.data.max_submissions != null && item.data.submissions_remaining != null}
+                          <span
+                            class="bg-emerald-100 text-emerald-700 text-xs px-2 py-0.5 rounded font-medium"
+                            >{spotsLeftLabel(item.data.submissions_remaining)}</span
+                          >
+                        {/if}
                       </div>
                     {/if}
                   </button>
@@ -1189,11 +1288,21 @@
             <p class="font-['Switzer'] text-[12px] text-gray-500 mt-0.5">
               Type: {selectedType.name}
             </p>
+            {#if selectedMissionData.max_submissions != null && selectedMissionData.submissions_remaining != null}
+              <p class="font-['Switzer'] text-[12px] text-gray-500 mt-0.5">
+                Mission capacity: {spotsLeftLabel(selectedMissionData.submissions_remaining)}
+              </p>
+            {/if}
           {:else}
             <span
               class="font-['Switzer'] font-semibold text-[14px] text-black"
               >{selectedType.name}</span
             >
+            {#if selectedType.max_submissions != null && selectedType.submissions_remaining != null}
+              <p class="font-['Switzer'] text-[12px] text-gray-500 mt-0.5">
+                Capacity: {spotsLeftLabel(selectedType.submissions_remaining)}
+              </p>
+            {/if}
             {#if selectedType.description}
               <p class="font-['Switzer'] text-[12px] text-gray-500 mt-1">
                 {selectedType.description}

--- a/frontend/src/routes/MissionDetail.svelte
+++ b/frontend/src/routes/MissionDetail.svelte
@@ -73,6 +73,29 @@
   let allContributionsPath = $derived(
     `/all-contributions?category=${explorerCategory}&mission=${params.id}`
   );
+  let missionIsFull = $derived(
+    mission?.user_is_full === true ||
+      mission?.is_full === true ||
+      (mission?.max_submissions != null &&
+        mission?.submissions_remaining != null &&
+        Number(mission.submissions_remaining) <= 0)
+  );
+  let contributionTypeIsFull = $derived(
+    contributionType?.is_full === true ||
+      (contributionType?.max_submissions != null &&
+        contributionType?.submissions_remaining != null &&
+        Number(contributionType.submissions_remaining) <= 0)
+  );
+  let submissionClosed = $derived(missionIsFull || contributionTypeIsFull);
+  let capacityLabel = $derived.by(() => {
+    if (mission?.user_is_full === true) return 'Your limit reached';
+    if (mission?.max_submissions == null) {
+      return contributionTypeIsFull ? 'Submissions closed' : 'Unlimited';
+    }
+    if (missionIsFull) return 'Full';
+    if (contributionTypeIsFull) return 'Submissions closed';
+    return `${formatNumber(mission.submissions_remaining)} left`;
+  });
 
   function formatDate(dateString) {
     if (!dateString) return 'Ongoing';
@@ -213,12 +236,15 @@
 
           <button
             type="button"
-            onclick={() => push(`/submit-contribution?mission=${mission.id}`)}
-            class="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-[8px] border border-black bg-black px-4 text-[13px] font-semibold text-white shadow-[0_8px_22px_rgba(31,42,68,0.12)] transition hover:-translate-y-0.5 hover:shadow-[0_14px_26px_rgba(31,42,68,0.16)] sm:w-auto"
-            style={submitButtonStyle}
+            onclick={() => !submissionClosed && push(`/submit-contribution?mission=${mission.id}`)}
+            disabled={submissionClosed}
+            class="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-[8px] border border-black bg-black px-4 text-[13px] font-semibold text-white shadow-[0_8px_22px_rgba(31,42,68,0.12)] transition sm:w-auto {submissionClosed ? 'cursor-not-allowed opacity-60' : 'hover:-translate-y-0.5 hover:shadow-[0_14px_26px_rgba(31,42,68,0.16)]'}"
+            style={submissionClosed ? '' : submitButtonStyle}
           >
-            Submit to mission
-            <img src="/assets/icons/arrow-right-line-white.svg" alt="" class="h-4 w-4" />
+            {submissionClosed ? 'Submissions closed' : 'Submit to mission'}
+            {#if !submissionClosed}
+              <img src="/assets/icons/arrow-right-line-white.svg" alt="" class="h-4 w-4" />
+            {/if}
           </button>
         </div>
 
@@ -234,6 +260,12 @@
           <div class="rounded-[8px] border border-[#e8ebf2] bg-white p-4 shadow-[0_8px_18px_rgba(31,42,68,0.07)]">
             <p class="text-[12px] font-semibold uppercase text-[#7b8798]">Points Earned</p>
             <p class="mt-2 font-display text-[28px] font-semibold leading-none text-black">{formatNumber(stats.points_earned)}</p>
+          </div>
+          <div class="rounded-[8px] border border-[#e8ebf2] bg-white p-4 shadow-[0_8px_18px_rgba(31,42,68,0.07)]">
+            <p class="text-[12px] font-semibold uppercase text-[#7b8798]">Capacity</p>
+            <p class="mt-2 text-[16px] font-semibold text-black">
+              {capacityLabel}
+            </p>
           </div>
         </div>
       </section>
@@ -254,6 +286,14 @@
               <div class="flex items-center justify-between gap-4">
                 <span class="text-[12px] font-semibold uppercase text-[#7b8798]">End</span>
                 <span class="text-[13px] font-semibold text-black">{formatDate(mission.end_date)}</span>
+              </div>
+              <div class="flex items-center justify-between gap-4">
+                <span class="text-[12px] font-semibold uppercase text-[#7b8798]">Submissions</span>
+                <span class="text-[13px] font-semibold text-black">
+                  {mission.max_submissions == null
+                    ? `${formatNumber(mission.submission_count)} / Unlimited`
+                    : `${formatNumber(mission.submission_count)} / ${formatNumber(mission.max_submissions)}`}
+                </span>
               </div>
             </div>
           </div>

--- a/frontend/src/routes/MissionDetail.svelte
+++ b/frontend/src/routes/MissionDetail.svelte
@@ -87,6 +87,13 @@
         Number(contributionType.submissions_remaining) <= 0)
   );
   let submissionClosed = $derived(missionIsFull || contributionTypeIsFull);
+  let submitButtonLabel = $derived(
+    mission?.user_is_full === true
+      ? 'Limit reached'
+      : submissionClosed
+        ? 'Submissions closed'
+        : 'Submit to mission'
+  );
   let capacityLabel = $derived.by(() => {
     if (mission?.user_is_full === true) return 'Your limit reached';
     if (mission?.max_submissions == null) {
@@ -241,7 +248,7 @@
             class="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-[8px] border border-black bg-black px-4 text-[13px] font-semibold text-white shadow-[0_8px_22px_rgba(31,42,68,0.12)] transition sm:w-auto {submissionClosed ? 'cursor-not-allowed opacity-60' : 'hover:-translate-y-0.5 hover:shadow-[0_14px_26px_rgba(31,42,68,0.16)]'}"
             style={submissionClosed ? '' : submitButtonStyle}
           >
-            {submissionClosed ? 'Submissions closed' : 'Submit to mission'}
+            {submitButtonLabel}
             {#if !submissionClosed}
               <img src="/assets/icons/arrow-right-line-white.svg" alt="" class="h-4 w-4" />
             {/if}


### PR DESCRIPTION
Fixes mission and contribution type loading by replacing joined submission-count aggregates with subquery annotations, preserving capacity fields, and removing serializer N+1 multiplier/evidence lookups.

Optimizes Django admin mission/contribution changelists with cheap count annotations, custom contribution-type filters, disabled expensive facets/full counts/date drilldowns on large tables, and restores frontend capacity labels and submit guards.

Validated with env/bin/python manage.py check, npm run build, git diff --check, and local queryset/admin changelist smoke checks; targeted Django tests are blocked by existing migration 0037_seed_featured_content.py requiring albert@genlayer.foundation in an empty test DB.