### PR TITLE
Optimize steward submissions loading

### DIFF
--- a/backend/contributions/serializers.py
+++ b/backend/contributions/serializers.py
@@ -903,6 +903,7 @@ class StewardSubmissionSerializer(serializers.ModelSerializer):
     assigned_to = serializers.PrimaryKeyRelatedField(read_only=True)
     # Proposal fields
     proposed_by_details = serializers.SerializerMethodField()
+    proposed_user_details = serializers.SerializerMethodField()
     has_proposal = serializers.SerializerMethodField()
     proposed_template_name = serializers.SerializerMethodField()
     notes_count = serializers.SerializerMethodField()
@@ -914,7 +915,7 @@ class StewardSubmissionSerializer(serializers.ModelSerializer):
                   'reviewed_by', 'reviewed_at', 'assigned_to',
                   'evidence_items', 'proposed_points',
                   # Proposal fields
-                  'proposed_action', 'proposed_contribution_type', 'proposed_user',
+                  'proposed_action', 'proposed_contribution_type', 'proposed_user', 'proposed_user_details',
                   'proposed_staff_reply', 'proposed_create_highlight',
                   'proposed_highlight_title', 'proposed_highlight_description',
                   'proposed_by', 'proposed_at', 'proposed_by_details', 'has_proposal',
@@ -1002,6 +1003,17 @@ class StewardSubmissionSerializer(serializers.ModelSerializer):
             }
         return None
 
+    def get_proposed_user_details(self, obj):
+        if obj.proposed_user:
+            return {
+                'id': obj.proposed_user.id,
+                'name': obj.proposed_user.name,
+                'address': obj.proposed_user.address,
+                'display_name': obj.proposed_user.name or f"{obj.proposed_user.address[:6]}...{obj.proposed_user.address[-4:]}",
+                'profile_image_url': obj.proposed_user.profile_image_url,
+            }
+        return None
+
     def get_has_proposal(self, obj):
         return obj.proposed_action is not None
 
@@ -1011,6 +1023,9 @@ class StewardSubmissionSerializer(serializers.ModelSerializer):
         return None
 
     def get_notes_count(self, obj):
+        if hasattr(obj, 'internal_notes_count'):
+            return obj.internal_notes_count
+
         # Use prefetched data if available
         if hasattr(obj, '_prefetched_objects_cache') and 'internal_notes' in obj._prefetched_objects_cache:
             return len(obj._prefetched_objects_cache['internal_notes'])

--- a/backend/contributions/views.py
+++ b/backend/contributions/views.py
@@ -1158,6 +1158,12 @@ class StewardSubmissionViewSet(viewsets.ModelViewSet):
             else:
                 queryset = queryset.none()
 
+        notes_count = SubmissionNote.objects.filter(
+            submitted_contribution_id=OuterRef('pk')
+        ).values('submitted_contribution_id').annotate(
+            count=Count('pk')
+        ).values('count')
+
         # Comprehensive prefetch for optimization
         queryset = queryset.select_related(
             'user',
@@ -1176,7 +1182,13 @@ class StewardSubmissionViewSet(viewsets.ModelViewSet):
             'proposed_contribution_type',
             'proposed_user',
             'proposed_template',
-        ).prefetch_related('evidence_items', 'internal_notes')
+        ).prefetch_related('evidence_items').annotate(
+            internal_notes_count=Coalesce(
+                Subquery(notes_count, output_field=IntegerField()),
+                Value(0),
+                output_field=IntegerField(),
+            )
+        )
 
         return queryset
 

--- a/frontend/src/components/SubmissionCard.svelte
+++ b/frontend/src/components/SubmissionCard.svelte
@@ -21,6 +21,8 @@
     successMessage = '',
     contributionTypes = [],
     users = [],
+    usersLoading = false,
+    usersLoaded = false,
     multipliers = {},
     isOwnSubmission = false,
     permissions = {},
@@ -30,6 +32,7 @@
     onAddNote = null,
     onToggleInteresting = null,
     onRequestNotes = null,
+    onRequestUsers = null,
     onAppeal = null
   } = $props();
 
@@ -37,6 +40,7 @@
   let copyingReviewContext = $state(false);
   let appealReason = $state('');
   let submittingAppeal = $state(false);
+  let showUserPicker = $state(false);
 
   let canCopyReviewContext = $derived(
     showReviewForm && !isOwnSubmission && submission.state === 'pending'
@@ -240,6 +244,25 @@
   );
   let selectedUser = $state(reviewData?.user || submission.user);
   let selectedType = $state(reviewData?.contribution_type || submission.contribution_type);
+  let defaultSelectedUserDetails = $derived(
+    String(selectedUser) === String(submission.user)
+      ? submission.user_details
+      : String(selectedUser) === String(submission.proposed_user)
+        ? submission.proposed_user_details
+        : null
+  );
+  let selectedUserDetails = $derived(
+    showUserPicker
+      ? users.find(u => String(u.id) === String(selectedUser)) || defaultSelectedUserDetails
+      : defaultSelectedUserDetails
+  );
+  let selectedUserLabel = $derived(
+    selectedUserDetails?.display_name ||
+    selectedUserDetails?.name ||
+    selectedUserDetails?.address ||
+    (selectedUser ? `User #${selectedUser}` : 'Current submitter')
+  );
+  let selectedTypeDetails = $derived(contributionTypes.find(t => t.id === selectedType));
   let points = $state(reviewData?.points || submission.proposed_points || submission.contribution_type_details?.min_points || 0);
   let staffReply = $state(reviewData?.staff_reply || '');
   let createHighlight = $state(reviewData?.create_highlight || false);
@@ -370,7 +393,7 @@
   }
 
   function adjustPoints(delta) {
-    const type = contributionTypes.find(t => t.id === selectedType);
+    const type = selectedTypeDetails;
     if (!type) return;
 
     const newPoints = points + delta;
@@ -397,6 +420,13 @@
     if (template) {
       staffReply = template.text;
       selectedTemplateId = template.id;
+    }
+  }
+
+  async function handleShowUserPicker() {
+    showUserPicker = true;
+    if (!usersLoaded && onRequestUsers) {
+      await onRequestUsers();
     }
   }
 
@@ -813,16 +843,16 @@
                     {/if}
                     {#if reviewAction === 'accept' || proposedAction === 'accept'}
                     <div class="space-y-3">
-                    {#if users.length > 0}
-                      <div>
-                        <label class="block text-sm font-medium text-gray-700">
-                          Assign Contribution To
-                        </label>
-                        <div class="mt-1 flex items-center gap-2">
-                          <Avatar
-                            user={users.find(u => u.id === selectedUser)}
-                            size="sm"
-                          />
+                    <div>
+                      <label class="block text-sm font-medium text-gray-700">
+                        Assign Contribution To
+                      </label>
+                      <div class="mt-1 flex items-center gap-2">
+                        <Avatar
+                          user={selectedUserDetails}
+                          size="sm"
+                        />
+                        {#if showUserPicker && users.length > 0}
                           <select
                             bind:value={selectedUser}
                             class="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm bg-white"
@@ -833,12 +863,24 @@
                               </option>
                             {/each}
                           </select>
-                        </div>
-                        <p class="text-xs text-gray-500 mt-1">
-                          The contribution will be assigned to this user
-                        </p>
+                        {:else}
+                          <div class="flex-1 min-w-0 px-3 py-2 border border-gray-200 rounded-md text-sm bg-white text-gray-700 truncate">
+                            {selectedUserLabel}
+                          </div>
+                          <button
+                            type="button"
+                            onclick={handleShowUserPicker}
+                            disabled={usersLoading}
+                            class="px-3 py-2 border border-gray-300 rounded-md text-sm text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            {usersLoading ? 'Loading...' : 'Change'}
+                          </button>
+                        {/if}
                       </div>
-                    {/if}
+                      <p class="text-xs text-gray-500 mt-1">
+                        The contribution will be assigned to this user
+                      </p>
+                    </div>
 
                     <div>
                       <label class="block text-sm font-medium text-gray-700 mb-2">
@@ -884,7 +926,7 @@
                           </button>
                         </div>
                         <p class="text-xs text-gray-500 mt-1">
-                          Range: {contributionTypes.find(t => t.id === selectedType)?.min_points || 0}-{contributionTypes.find(t => t.id === selectedType)?.max_points || 100}
+                          Range: {selectedTypeDetails?.min_points || 0}-{selectedTypeDetails?.max_points || 100}
                         </p>
                       </div>
 

--- a/frontend/src/routes/StewardSubmissions.svelte
+++ b/frontend/src/routes/StewardSubmissions.svelte
@@ -16,6 +16,9 @@
   let submissions = $state([]);
   let contributionTypes = $state([]);
   let users = $state([]);
+  let usersLoading = $state(false);
+  let usersLoaded = $state(false);
+  let usersRequest = null;
   let loading = $state(true);
   let error = $state(null);
   let currentPage = $state(1);
@@ -42,6 +45,9 @@
   // CRM Notes state - keyed by submission ID
   let submissionNotes = $state({});
   let notesLoading = $state({});
+  let submissionsRequestId = 0;
+  let notesBatchRequestId = 0;
+  const NOTES_CONCURRENCY = 4;
 
   // Bulk selection state
   let selectedSubmissions = $state(new Set());
@@ -73,7 +79,6 @@
       loadPermissions(),
       loadTemplates(),
       loadContributionTypes(),
-      loadUsers(),
       loadStewards(),
       loadMissions()
     ]);
@@ -102,11 +107,33 @@
   }
 
   async function loadUsers() {
+    if (usersLoaded) return users;
+    if (usersRequest) return usersRequest;
+
+    usersLoading = true;
+    usersRequest = (async () => {
+      try {
+        const response = await stewardAPI.getUsers();
+        users = response.data;
+        usersLoaded = true;
+        return users;
+      } catch (err) {
+        showError('Failed to load users: ' + (err.response?.data?.detail || err.message));
+        return users;
+      } finally {
+        usersLoading = false;
+        usersRequest = null;
+      }
+    })();
+
+    return usersRequest;
+  }
+
+  async function ensureUsersLoaded() {
     try {
-      const response = await stewardAPI.getUsers();
-      users = response.data;
+      return await loadUsers();
     } catch (err) {
-      // Error loading users silently handled
+      return users;
     }
   }
 
@@ -193,6 +220,7 @@
   }
 
   async function loadSubmissions() {
+    const requestId = ++submissionsRequestId;
     loading = true;
     error = null;
     clearSelection();
@@ -221,7 +249,10 @@
       params.page_size = pageSize;
 
       const response = await stewardAPI.getSubmissions(params);
-      submissions = response.data.results || [];
+      if (requestId !== submissionsRequestId) return;
+
+      const loadedSubmissions = response.data.results || [];
+      submissions = loadedSubmissions;
       totalCount = response.data.count || 0;
 
       // If we got no results and we're not on page 1, it means this page doesn't exist anymore
@@ -233,7 +264,7 @@
       }
 
       // Initialize review data for each submission
-      submissions.forEach(sub => {
+      loadedSubmissions.forEach(sub => {
         if (!reviewData[sub.id]) {
           reviewData[sub.id] = {
             action: 'accept',
@@ -248,13 +279,10 @@
         }
       });
 
-      // Load notes for visible pending/more_info_needed submissions
-      for (const sub of submissions) {
-        if (sub.state === 'pending' || sub.state === 'more_info_needed') {
-          loadNotes(sub.id);
-        }
-      }
+      loadVisibleNotes(loadedSubmissions, requestId);
     } catch (err) {
+      if (requestId !== submissionsRequestId) return;
+
       // If we get a 404 error and we're not on page 1, it might mean the page doesn't exist
       // Try going to the previous page
       if (err.response?.status === 404 && currentPage > 1) {
@@ -268,8 +296,56 @@
         ? 'You do not have permission to access steward tools'
         : 'Failed to load submissions';
     } finally {
-      loading = false;
+      if (requestId === submissionsRequestId) {
+        loading = false;
+      }
     }
+  }
+
+  async function loadVisibleNotes(visibleSubmissions, requestId) {
+    const ids = visibleSubmissions
+      .filter(sub =>
+        (sub.state === 'pending' || sub.state === 'more_info_needed') &&
+        (sub.notes_count ?? 0) > 0
+      )
+      .map(sub => sub.id);
+
+    if (ids.length === 0) return;
+
+    const batchId = ++notesBatchRequestId;
+    const loadingUpdates = {};
+    ids.forEach(id => {
+      loadingUpdates[id] = true;
+    });
+    notesLoading = { ...notesLoading, ...loadingUpdates };
+
+    const loadedNotes = {};
+    const finishedLoading = {};
+    let nextIndex = 0;
+
+    async function loadNext() {
+      while (nextIndex < ids.length) {
+        const id = ids[nextIndex];
+        nextIndex += 1;
+
+        try {
+          const response = await stewardAPI.getNotes(id);
+          loadedNotes[id] = response.data || [];
+        } catch (err) {
+          loadedNotes[id] = [];
+        } finally {
+          finishedLoading[id] = false;
+        }
+      }
+    }
+
+    const workerCount = Math.min(NOTES_CONCURRENCY, ids.length);
+    await Promise.all(Array.from({ length: workerCount }, loadNext));
+
+    if (requestId !== submissionsRequestId || batchId !== notesBatchRequestId) return;
+
+    submissionNotes = { ...submissionNotes, ...loadedNotes };
+    notesLoading = { ...notesLoading, ...finishedLoading };
   }
 
   async function loadNotes(submissionId) {
@@ -663,7 +739,7 @@
 
     <div class="space-y-4">
       {#each submissions as submission (submission.id)}
-        <div>
+        <div class="submission-row">
           {#if submission.state === 'pending' || submission.state === 'more_info_needed'}
             <div class="mb-2 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white px-4 py-2 shadow-sm">
               <label class="flex items-center gap-2 text-sm text-gray-700">
@@ -706,6 +782,8 @@
             successMessage={''}
             {contributionTypes}
             {users}
+            {usersLoading}
+            {usersLoaded}
             {multipliers}
             isOwnSubmission={false}
             permissions={permissionsMap}
@@ -715,6 +793,7 @@
             onAddNote={handleAddNote}
             onToggleInteresting={handleToggleInteresting}
             onRequestNotes={fetchNotesForCopy}
+            onRequestUsers={ensureUsersLoaded}
           />
         </div>
       {/each}
@@ -736,3 +815,10 @@
     {/if}
   {/if}
 </div>
+
+<style>
+  .submission-row {
+    content-visibility: auto;
+    contain-intrinsic-size: 900px;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Lazy-load the steward user list only when changing a contribution assignee.
- Batch visible CRM note loading and ignore stale submission responses during rapid page/filter changes.
- Count internal notes in the submission list query without prefetching full note rows, and include proposed assignee details so the review form displays the actual selected user.

## Validation
- npm run build
- python3 -m py_compile backend/contributions/views.py backend/contributions/serializers.py
