### PR TITLE
Move POAP management to admin

### DIFF
--- a/backend/poaps/admin.py
+++ b/backend/poaps/admin.py
@@ -1,14 +1,59 @@
+import csv
+
+from django import forms
 from django.contrib import admin
+from django.contrib import messages
+from django.conf import settings
+from django.http import HttpResponse
 
 from utils.admin_mixins import CloudinaryUploadMixin
 
 from .models import PoapClaim, PoapDistribution, PoapDrop, PoapImportBatch, PoapMintLink
+from .services import decrypt_token, encrypt_token, hash_secret, hash_token
+
+
+class PoapDistributionAdminForm(forms.ModelForm):
+    secret_phrase = forms.CharField(
+        required=False,
+        help_text='For secret phrase distributions only. Enter a new value to set or rotate the phrase.',
+        widget=forms.PasswordInput(render_value=False),
+    )
+
+    class Meta:
+        model = PoapDistribution
+        fields = '__all__'
+
+    def clean(self):
+        cleaned_data = super().clean()
+        method = cleaned_data.get('method')
+        secret_phrase = (cleaned_data.get('secret_phrase') or '').strip()
+        existing_secret_hash = getattr(self.instance, 'secret_hash', '')
+
+        if method == PoapDistribution.METHOD_SECRET and not secret_phrase and not existing_secret_hash:
+            raise forms.ValidationError('Secret phrase is required for secret phrase distributions.')
+
+        return cleaned_data
+
+    def save(self, commit=True):
+        instance = super().save(commit=False)
+        secret_phrase = (self.cleaned_data.get('secret_phrase') or '').strip()
+        if instance.method == PoapDistribution.METHOD_SECRET:
+            if secret_phrase:
+                instance.secret_hash = hash_secret(secret_phrase)
+        else:
+            instance.secret_hash = ''
+
+        if commit:
+            instance.save()
+            self.save_m2m()
+        return instance
 
 
 class PoapDistributionInline(admin.TabularInline):
     model = PoapDistribution
+    form = PoapDistributionAdminForm
     extra = 0
-    fields = ('method', 'active', 'starts_at', 'ends_at', 'max_claims', 'claimed_count')
+    fields = ('method', 'active', 'starts_at', 'ends_at', 'max_claims', 'secret_phrase', 'claimed_count')
     readonly_fields = ('claimed_count',)
 
 
@@ -64,19 +109,95 @@ class PoapDropAdmin(CloudinaryUploadMixin, admin.ModelAdmin):
 
 @admin.register(PoapDistribution)
 class PoapDistributionAdmin(admin.ModelAdmin):
+    form = PoapDistributionAdminForm
     list_display = ('drop', 'method', 'active', 'starts_at', 'ends_at', 'max_claims', 'claimed_count')
     list_filter = ('method', 'active')
     search_fields = ('drop__title', 'drop__slug')
     readonly_fields = ('claimed_count', 'created_at', 'updated_at')
     autocomplete_fields = ('drop',)
+    fieldsets = (
+        (None, {
+            'fields': ('drop', 'method', 'active'),
+        }),
+        ('Claim window and cap', {
+            'fields': ('starts_at', 'ends_at', 'max_claims', 'claimed_count'),
+        }),
+        ('Secret phrase', {
+            'fields': ('secret_phrase',),
+            'description': 'Only used when method is Secret phrase. Existing phrases are stored hashed and cannot be viewed.',
+        }),
+        ('Timestamps', {
+            'fields': ('created_at', 'updated_at'),
+            'classes': ('collapse',),
+        }),
+    )
 
 
 @admin.register(PoapMintLink)
 class PoapMintLinkAdmin(admin.ModelAdmin):
-    list_display = ('distribution', 'max_uses', 'used_count', 'expires_at', 'created_at')
+    list_display = ('distribution', 'claim_url', 'max_uses', 'used_count', 'expires_at', 'created_at')
     list_filter = ('expires_at',)
     search_fields = ('distribution__drop__title', 'distribution__drop__slug')
-    readonly_fields = ('token_hash', 'token_ciphertext', 'used_count', 'created_at', 'updated_at')
+    readonly_fields = ('claim_url', 'token_hash', 'token_ciphertext', 'used_count', 'created_at', 'updated_at')
+    autocomplete_fields = ('distribution',)
+    actions = ('download_selected_claim_urls',)
+    fieldsets = (
+        (None, {
+            'fields': ('distribution', 'max_uses', 'expires_at'),
+        }),
+        ('Generated claim link', {
+            'fields': ('claim_url', 'token_hash', 'token_ciphertext', 'used_count'),
+            'description': 'The token is generated automatically when a mint link is created.',
+        }),
+        ('Timestamps', {
+            'fields': ('created_at', 'updated_at'),
+            'classes': ('collapse',),
+        }),
+    )
+
+    def save_model(self, request, obj, form, change):
+        generated_token = ''
+        if not obj.token_hash:
+            generated_token = PoapMintLink.generate_token()
+            obj.token_hash = hash_token(generated_token)
+            obj.token_ciphertext = encrypt_token(generated_token)
+
+        super().save_model(request, obj, form, change)
+
+        if generated_token:
+            messages.success(request, f'Mint link generated: {self._claim_url_from_token(generated_token)}')
+
+    @admin.display(description='Claim URL')
+    def claim_url(self, obj):
+        token = decrypt_token(obj.token_ciphertext)
+        if not token:
+            return ''
+        return self._claim_url_from_token(token)
+
+    @admin.action(description='Download selected claim URLs')
+    def download_selected_claim_urls(self, request, queryset):
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename="poap-mint-links.csv"'
+        writer = csv.writer(response)
+        writer.writerow(['drop', 'distribution_id', 'mint_link_id', 'claim_url', 'max_uses', 'used_count', 'expires_at'])
+        for link in queryset.select_related('distribution__drop'):
+            token = decrypt_token(link.token_ciphertext)
+            writer.writerow([
+                link.distribution.drop.title,
+                link.distribution_id,
+                link.id,
+                self._claim_url_from_token(token) if token else '',
+                link.max_uses,
+                link.used_count,
+                link.expires_at.isoformat() if link.expires_at else '',
+            ])
+        return response
+
+    def _claim_url_from_token(self, token):
+        frontend_url = getattr(settings, 'FRONTEND_URL', '').rstrip('/')
+        if not frontend_url:
+            return f'/#/claim/poap/{token}'
+        return f'{frontend_url}/#/claim/poap/{token}'
 
 
 @admin.register(PoapClaim)

--- a/backend/poaps/admin.py
+++ b/backend/poaps/admin.py
@@ -9,7 +9,7 @@ from django.http import HttpResponse
 from utils.admin_mixins import CloudinaryUploadMixin
 
 from .models import PoapClaim, PoapDistribution, PoapDrop, PoapImportBatch, PoapMintLink
-from .services import decrypt_token, encrypt_token, hash_secret, hash_token
+from .services import decrypt_token, encrypt_token, generate_mint_links, hash_secret, hash_token
 
 
 class PoapDropAdminForm(forms.ModelForm):
@@ -44,6 +44,25 @@ class PoapDistributionAdminForm(forms.ModelForm):
         help_text='For secret phrase distributions only. Enter a new value to set or rotate the phrase.',
         widget=forms.PasswordInput(render_value=False),
     )
+    mint_link_count = forms.IntegerField(
+        required=False,
+        min_value=1,
+        max_value=500,
+        label='Generate mint links',
+        help_text='Optional. Creates this many mint links when saving a mint-link distribution.',
+    )
+    mint_link_max_uses = forms.IntegerField(
+        required=False,
+        min_value=1,
+        max_value=100,
+        initial=1,
+        label='Uses per generated link',
+    )
+    mint_link_expires_at = forms.DateTimeField(
+        required=False,
+        label='Generated link expiration',
+        help_text='Optional expiration applied to links generated from this save.',
+    )
 
     class Meta:
         model = PoapDistribution
@@ -57,16 +76,38 @@ class PoapDistributionAdminForm(forms.ModelForm):
         starts_at = cleaned_data.get('starts_at')
         ends_at = cleaned_data.get('ends_at')
         max_claims = cleaned_data.get('max_claims')
+        mint_link_count = cleaned_data.get('mint_link_count') or 0
+        mint_link_max_uses = cleaned_data.get('mint_link_max_uses') or 1
+        mint_link_expires_at = cleaned_data.get('mint_link_expires_at')
         errors = {}
 
         if method == PoapDistribution.METHOD_SECRET and not secret_phrase and not existing_secret_hash:
             errors['secret_phrase'] = 'Secret phrase is required for secret phrase distributions.'
 
+        if mint_link_count and method != PoapDistribution.METHOD_MINT_LINK:
+            errors['mint_link_count'] = 'Mint links can only be generated for mint-link distributions.'
+
         if starts_at and ends_at and ends_at <= starts_at:
             errors['ends_at'] = 'End time must be after start time.'
 
+        if starts_at and mint_link_expires_at and mint_link_expires_at <= starts_at:
+            errors['mint_link_expires_at'] = 'Expiration must be after start time.'
+
         if max_claims is not None and self.instance.pk and max_claims < self.instance.claimed_count:
             errors['max_claims'] = f'Max claims cannot be lower than the current claimed count ({self.instance.claimed_count}).'
+
+        if mint_link_count:
+            requested_claims = mint_link_count * mint_link_max_uses
+            claimed_count = getattr(self.instance, 'claimed_count', 0)
+            if max_claims is not None and requested_claims > max_claims - claimed_count:
+                errors['mint_link_count'] = f'Only {max_claims - claimed_count} claim slots remain on this distribution.'
+
+            drop = cleaned_data.get('drop')
+            if drop and drop.max_claims is not None:
+                drop_claimed_count = drop.claims.filter(user__isnull=False).count()
+                remaining_drop_claims = drop.max_claims - drop_claimed_count
+                if requested_claims > remaining_drop_claims:
+                    errors['mint_link_count'] = f'Only {remaining_drop_claims} claim slots remain on this POAP.'
 
         if errors:
             raise forms.ValidationError(errors)
@@ -166,11 +207,29 @@ class PoapDistributionAdmin(admin.ModelAdmin):
             'fields': ('secret_phrase',),
             'description': 'Only used when method is Secret phrase. Existing phrases are stored hashed and cannot be viewed.',
         }),
+        ('Mint links', {
+            'fields': ('mint_link_count', 'mint_link_max_uses', 'mint_link_expires_at'),
+            'description': 'Only used when method is Mint link. Generated URLs can be downloaded from the POAP mint links admin list.',
+        }),
         ('Timestamps', {
             'fields': ('created_at', 'updated_at'),
             'classes': ('collapse',),
         }),
     )
+
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        mint_link_count = form.cleaned_data.get('mint_link_count') or 0
+        if not mint_link_count:
+            return
+
+        created = generate_mint_links(
+            distribution=obj,
+            count=mint_link_count,
+            max_uses=form.cleaned_data.get('mint_link_max_uses') or 1,
+            expires_at=form.cleaned_data.get('mint_link_expires_at'),
+        )
+        messages.success(request, f'Generated {len(created)} mint link(s).')
 
 
 @admin.register(PoapMintLink)

--- a/backend/poaps/admin.py
+++ b/backend/poaps/admin.py
@@ -4,12 +4,25 @@ from django import forms
 from django.contrib import admin
 from django.contrib import messages
 from django.conf import settings
+from django.db.models import F, IntegerField, Q, Sum
 from django.http import HttpResponse
+from django.utils import timezone
 
 from utils.admin_mixins import CloudinaryUploadMixin
 
 from .models import PoapClaim, PoapDistribution, PoapDrop, PoapImportBatch, PoapMintLink
 from .services import decrypt_token, encrypt_token, generate_mint_links, hash_secret, hash_token
+
+
+def unused_mint_link_capacity(queryset):
+    now = timezone.now()
+    return queryset.filter(
+        max_uses__gt=F('used_count'),
+    ).filter(
+        Q(expires_at__isnull=True) | Q(expires_at__gte=now),
+    ).aggregate(
+        total=Sum(F('max_uses') - F('used_count'), output_field=IntegerField())
+    )['total'] or 0
 
 
 class PoapDropAdminForm(forms.ModelForm):
@@ -29,8 +42,15 @@ class PoapDropAdminForm(forms.ModelForm):
 
         if self.instance.pk and max_claims is not None:
             claimed_count = self.instance.claims.filter(user__isnull=False).count()
-            if max_claims < claimed_count:
-                errors['max_claims'] = f'Max claims cannot be lower than the current claimed count ({claimed_count}).'
+            reserved_link_capacity = unused_mint_link_capacity(
+                PoapMintLink.objects.filter(distribution__drop=self.instance)
+            )
+            minimum_max_claims = claimed_count + reserved_link_capacity
+            if max_claims < minimum_max_claims:
+                errors['max_claims'] = (
+                    f'Max claims cannot be lower than the current claimed count plus '
+                    f'unused mint-link capacity ({minimum_max_claims}).'
+                )
 
         if errors:
             raise forms.ValidationError(errors)
@@ -93,21 +113,40 @@ class PoapDistributionAdminForm(forms.ModelForm):
         if starts_at and mint_link_expires_at and mint_link_expires_at <= starts_at:
             errors['mint_link_expires_at'] = 'Expiration must be after start time.'
 
-        if max_claims is not None and self.instance.pk and max_claims < self.instance.claimed_count:
-            errors['max_claims'] = f'Max claims cannot be lower than the current claimed count ({self.instance.claimed_count}).'
+        existing_distribution_link_capacity = 0
+        if self.instance.pk and method == PoapDistribution.METHOD_MINT_LINK:
+            existing_distribution_link_capacity = unused_mint_link_capacity(
+                PoapMintLink.objects.filter(distribution=self.instance)
+            )
+
+        if max_claims is not None and self.instance.pk:
+            minimum_max_claims = self.instance.claimed_count + existing_distribution_link_capacity
+            if max_claims < minimum_max_claims:
+                errors['max_claims'] = (
+                    f'Max claims cannot be lower than the current claimed count plus '
+                    f'unused mint-link capacity ({minimum_max_claims}).'
+                )
 
         if mint_link_count:
             requested_claims = mint_link_count * mint_link_max_uses
             claimed_count = getattr(self.instance, 'claimed_count', 0)
-            if max_claims is not None and requested_claims > max_claims - claimed_count:
-                errors['mint_link_count'] = f'Only {max_claims - claimed_count} claim slots remain on this distribution.'
+            if max_claims is not None:
+                remaining_distribution_claims = max_claims - claimed_count - existing_distribution_link_capacity
+                if requested_claims > remaining_distribution_claims:
+                    errors['mint_link_count'] = (
+                        f'Only {max(remaining_distribution_claims, 0)} unreserved claim slot(s) '
+                        'remain on this distribution.'
+                    )
 
             drop = cleaned_data.get('drop')
             if drop and drop.max_claims is not None:
                 drop_claimed_count = drop.claims.filter(user__isnull=False).count()
-                remaining_drop_claims = drop.max_claims - drop_claimed_count
+                existing_drop_link_capacity = unused_mint_link_capacity(
+                    PoapMintLink.objects.filter(distribution__drop=drop)
+                )
+                remaining_drop_claims = drop.max_claims - drop_claimed_count - existing_drop_link_capacity
                 if requested_claims > remaining_drop_claims:
-                    errors['mint_link_count'] = f'Only {remaining_drop_claims} claim slots remain on this POAP.'
+                    errors['mint_link_count'] = f'Only {max(remaining_drop_claims, 0)} unreserved claim slot(s) remain on this POAP.'
 
         if errors:
             raise forms.ValidationError(errors)

--- a/backend/poaps/admin.py
+++ b/backend/poaps/admin.py
@@ -12,6 +12,32 @@ from .models import PoapClaim, PoapDistribution, PoapDrop, PoapImportBatch, Poap
 from .services import decrypt_token, encrypt_token, hash_secret, hash_token
 
 
+class PoapDropAdminForm(forms.ModelForm):
+    class Meta:
+        model = PoapDrop
+        fields = '__all__'
+
+    def clean(self):
+        cleaned_data = super().clean()
+        start = cleaned_data.get('event_start_at')
+        end = cleaned_data.get('event_end_at')
+        max_claims = cleaned_data.get('max_claims')
+        errors = {}
+
+        if start and end and end <= start:
+            errors['event_end_at'] = 'End time must be after start time.'
+
+        if self.instance.pk and max_claims is not None:
+            claimed_count = self.instance.claims.filter(user__isnull=False).count()
+            if max_claims < claimed_count:
+                errors['max_claims'] = f'Max claims cannot be lower than the current claimed count ({claimed_count}).'
+
+        if errors:
+            raise forms.ValidationError(errors)
+
+        return cleaned_data
+
+
 class PoapDistributionAdminForm(forms.ModelForm):
     secret_phrase = forms.CharField(
         required=False,
@@ -28,9 +54,22 @@ class PoapDistributionAdminForm(forms.ModelForm):
         method = cleaned_data.get('method')
         secret_phrase = (cleaned_data.get('secret_phrase') or '').strip()
         existing_secret_hash = getattr(self.instance, 'secret_hash', '')
+        starts_at = cleaned_data.get('starts_at')
+        ends_at = cleaned_data.get('ends_at')
+        max_claims = cleaned_data.get('max_claims')
+        errors = {}
 
         if method == PoapDistribution.METHOD_SECRET and not secret_phrase and not existing_secret_hash:
-            raise forms.ValidationError('Secret phrase is required for secret phrase distributions.')
+            errors['secret_phrase'] = 'Secret phrase is required for secret phrase distributions.'
+
+        if starts_at and ends_at and ends_at <= starts_at:
+            errors['ends_at'] = 'End time must be after start time.'
+
+        if max_claims is not None and self.instance.pk and max_claims < self.instance.claimed_count:
+            errors['max_claims'] = f'Max claims cannot be lower than the current claimed count ({self.instance.claimed_count}).'
+
+        if errors:
+            raise forms.ValidationError(errors)
 
         return cleaned_data
 
@@ -68,6 +107,7 @@ class PoapClaimInline(admin.TabularInline):
 
 @admin.register(PoapDrop)
 class PoapDropAdmin(CloudinaryUploadMixin, admin.ModelAdmin):
+    form = PoapDropAdminForm
     cloudinary_upload_fields = {
         'artwork_url': {
             'public_id_field': 'artwork_public_id',

--- a/backend/poaps/serializers.py
+++ b/backend/poaps/serializers.py
@@ -2,8 +2,7 @@ from rest_framework import serializers
 
 from users.serializers import LightUserSerializer
 
-from .models import PoapClaim, PoapDistribution, PoapDrop
-from .services import hash_secret
+from .models import PoapClaim, PoapDrop
 
 
 class PoapDropListSerializer(serializers.ModelSerializer):
@@ -80,12 +79,11 @@ class PoapDropListSerializer(serializers.ModelSerializer):
 class PoapDropDetailSerializer(PoapDropListSerializer):
     distributions = serializers.SerializerMethodField()
     current_user_claim = serializers.SerializerMethodField()
-    can_manage = serializers.SerializerMethodField()
 
     class Meta(PoapDropListSerializer.Meta):
         fields = PoapDropListSerializer.Meta.fields + [
             'artwork_public_id', 'legacy_poap_id', 'discord_role_id',
-            'distributions', 'current_user_claim', 'can_manage',
+            'distributions', 'current_user_claim',
         ]
 
     def get_distributions(self, obj):
@@ -116,35 +114,6 @@ class PoapDropDetailSerializer(PoapDropListSerializer):
             'claim_method': claim.claim_method,
             'source': claim.source,
         }
-
-    def get_can_manage(self, obj):
-        request = self.context.get('request')
-        return bool(request and request.user and request.user.is_staff)
-
-
-class PoapDropWriteSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = PoapDrop
-        fields = [
-            'id', 'title', 'slug', 'description', 'artwork_url',
-            'artwork_public_id', 'event_start_at', 'event_end_at',
-            'status', 'max_claims', 'legacy_poap_id', 'discord_role_id',
-        ]
-        read_only_fields = ['id']
-
-    def validate(self, attrs):
-        start = attrs.get('event_start_at', getattr(self.instance, 'event_start_at', None))
-        end = attrs.get('event_end_at', getattr(self.instance, 'event_end_at', None))
-        if start and end and end <= start:
-            raise serializers.ValidationError({'event_end_at': 'End time must be after start time.'})
-        max_claims = attrs.get('max_claims', getattr(self.instance, 'max_claims', None))
-        if self.instance and max_claims is not None:
-            claimed_count = self.instance.claims.filter(user__isnull=False).count()
-            if max_claims < claimed_count:
-                raise serializers.ValidationError({
-                    'max_claims': f'Max claims cannot be lower than the current claimed count ({claimed_count}).'
-                })
-        return attrs
 
 
 class PoapClaimSerializer(serializers.ModelSerializer):
@@ -180,53 +149,3 @@ class PoapProfileClaimSerializer(serializers.ModelSerializer):
         model = PoapClaim
         fields = ['id', 'drop', 'claim_method', 'claimed_at', 'source']
         read_only_fields = fields
-
-
-class SecretDistributionCreateSerializer(serializers.Serializer):
-    secret = serializers.CharField(max_length=255, write_only=True)
-    starts_at = serializers.DateTimeField(required=False, allow_null=True)
-    ends_at = serializers.DateTimeField(required=False, allow_null=True)
-    max_claims = serializers.IntegerField(required=False, allow_null=True, min_value=1)
-    active = serializers.BooleanField(default=True)
-
-    def validate_secret(self, value):
-        if not value or not value.strip():
-            raise serializers.ValidationError('Secret phrase is required.')
-        return value
-
-    def validate(self, attrs):
-        starts_at = attrs.get('starts_at')
-        ends_at = attrs.get('ends_at')
-        if starts_at and ends_at and ends_at <= starts_at:
-            raise serializers.ValidationError({'ends_at': 'End time must be after start time.'})
-        return attrs
-
-    def create(self, validated_data):
-        drop = self.context['drop']
-        return PoapDistribution.objects.create(
-            drop=drop,
-            method=PoapDistribution.METHOD_SECRET,
-            active=validated_data.get('active', True),
-            starts_at=validated_data.get('starts_at'),
-            ends_at=validated_data.get('ends_at'),
-            max_claims=validated_data.get('max_claims'),
-            secret_hash=hash_secret(validated_data['secret']),
-        )
-
-
-class MintLinkGenerateSerializer(serializers.Serializer):
-    count = serializers.IntegerField(min_value=1, max_value=500, default=1)
-    max_uses = serializers.IntegerField(min_value=1, max_value=100, default=1)
-    expires_at = serializers.DateTimeField(required=False, allow_null=True)
-    starts_at = serializers.DateTimeField(required=False, allow_null=True)
-    ends_at = serializers.DateTimeField(required=False, allow_null=True)
-
-    def validate(self, attrs):
-        starts_at = attrs.get('starts_at')
-        ends_at = attrs.get('ends_at')
-        expires_at = attrs.get('expires_at')
-        if starts_at and ends_at and ends_at <= starts_at:
-            raise serializers.ValidationError({'ends_at': 'End time must be after start time.'})
-        if starts_at and expires_at and expires_at <= starts_at:
-            raise serializers.ValidationError({'expires_at': 'Expiration must be after start time.'})
-        return attrs

--- a/backend/poaps/services.py
+++ b/backend/poaps/services.py
@@ -1,7 +1,5 @@
 import base64
-import csv
 import hashlib
-import io
 
 from cryptography.fernet import Fernet, InvalidToken
 from django.conf import settings
@@ -188,29 +186,6 @@ def generate_mint_links(*, distribution, count, max_uses=1, expires_at=None):
         )
         created.append((link, token))
     return created
-
-
-def mint_links_csv(drop):
-    buffer = io.StringIO()
-    writer = csv.writer(buffer)
-    writer.writerow(['drop_slug', 'token', 'path', 'max_uses', 'used_count', 'expires_at'])
-    links = (
-        PoapMintLink.objects
-        .filter(distribution__drop=drop)
-        .select_related('distribution', 'distribution__drop')
-        .order_by('created_at')
-    )
-    for link in links:
-        token = decrypt_token(link.token_ciphertext)
-        writer.writerow([
-            drop.slug,
-            token,
-            f'/#/claim/poap/{token}' if token else '',
-            link.max_uses,
-            link.used_count,
-            link.expires_at.isoformat() if link.expires_at else '',
-        ])
-    return buffer.getvalue()
 
 
 def attach_unmatched_claims_for_user(user):

--- a/backend/poaps/tests/test_poaps.py
+++ b/backend/poaps/tests/test_poaps.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from poaps.admin import PoapDropAdminForm
+from poaps.admin import PoapDistributionAdminForm, PoapDropAdminForm
 from poaps.models import PoapClaim, PoapDistribution, PoapDrop, PoapImportBatch
 from poaps.services import generate_mint_links, hash_secret
 
@@ -309,6 +309,67 @@ class PoapAPITest(TestCase):
         )
         self.assertFalse(form.is_valid())
         self.assertIn('max_claims', form.errors)
+
+    def test_poap_distribution_admin_form_counts_existing_unused_links_against_distribution_capacity(self):
+        distribution = PoapDistribution.objects.create(
+            drop=self.drop,
+            method=PoapDistribution.METHOD_MINT_LINK,
+            active=True,
+            max_claims=10,
+        )
+        generate_mint_links(distribution=distribution, count=10)
+
+        form = PoapDistributionAdminForm(
+            data={
+                'drop': self.drop.pk,
+                'method': PoapDistribution.METHOD_MINT_LINK,
+                'active': 'on',
+                'starts_at': '',
+                'ends_at': '',
+                'max_claims': 10,
+                'claimed_count': distribution.claimed_count,
+                'secret_hash': '',
+                'secret_phrase': '',
+                'mint_link_count': 1,
+                'mint_link_max_uses': 1,
+                'mint_link_expires_at': '',
+            },
+            instance=distribution,
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('mint_link_count', form.errors)
+
+    def test_poap_distribution_admin_form_counts_existing_unused_links_against_drop_capacity(self):
+        self.drop.max_claims = 10
+        self.drop.save(update_fields=['max_claims', 'updated_at'])
+        existing_distribution = PoapDistribution.objects.create(
+            drop=self.drop,
+            method=PoapDistribution.METHOD_MINT_LINK,
+            active=True,
+            max_claims=10,
+        )
+        generate_mint_links(distribution=existing_distribution, count=10)
+
+        form = PoapDistributionAdminForm(
+            data={
+                'drop': self.drop.pk,
+                'method': PoapDistribution.METHOD_MINT_LINK,
+                'active': 'on',
+                'starts_at': '',
+                'ends_at': '',
+                'max_claims': 1,
+                'claimed_count': 0,
+                'secret_hash': '',
+                'secret_phrase': '',
+                'mint_link_count': 1,
+                'mint_link_max_uses': 1,
+                'mint_link_expires_at': '',
+            },
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('mint_link_count', form.errors)
 
     def test_legacy_unmatched_claim_attaches_when_user_matches_wallet(self):
         claim = PoapClaim.objects.create(

--- a/backend/poaps/tests/test_poaps.py
+++ b/backend/poaps/tests/test_poaps.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from poaps.admin import PoapDropAdminForm
 from poaps.models import PoapClaim, PoapDistribution, PoapDrop, PoapImportBatch
 from poaps.services import generate_mint_links, hash_secret
 
@@ -237,71 +238,48 @@ class PoapAPITest(TestCase):
         self.assertNotIn('legacy_external_id', claim)
         self.assertNotIn('legacy_ens', claim)
 
-    def test_staff_permissions_and_generation(self):
-        self.client.force_authenticate(user=self.user)
+    def test_poap_management_api_is_not_exposed(self):
+        self.client.force_authenticate(user=self.staff)
+
         response = self.client.post(
             '/api/v1/poaps/',
             {
-                'title': 'Private',
+                'title': 'Admin Only',
                 'event_start_at': timezone.now().isoformat(),
                 'status': PoapDrop.STATUS_ACTIVE,
             },
             format='json',
         )
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
-        self.client.force_authenticate(user=self.staff)
+        response = self.client.patch(
+            '/api/v1/poaps/ama-session/',
+            {'max_claims': 10},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
         response = self.client.post(
             '/api/v1/poaps/ama-session/distributions/secret/',
             {'secret': 'secret-code'},
             format='json',
         )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         response = self.client.post(
             '/api/v1/poaps/ama-session/mint-links/generate/',
             {'count': 2},
             format='json',
         )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data['created'], 2)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_staff_distribution_generation_rejects_archived_and_over_capacity_drops(self):
-        archived_drop = PoapDrop.objects.create(
-            title='Archived',
-            slug='archived',
-            event_start_at=timezone.now(),
-            status=PoapDrop.STATUS_ARCHIVED,
-        )
-        full_drop = PoapDrop.objects.create(
-            title='Full',
-            slug='full',
-            event_start_at=timezone.now(),
-            status=PoapDrop.STATUS_ACTIVE,
-            max_claims=1,
-        )
-        PoapClaim.objects.create(
-            drop=full_drop,
-            user=self.user,
-            claim_method=PoapClaim.CLAIM_LEGACY,
-        )
+        response = self.client.get('/api/v1/poaps/ama-session/mint-links/download/')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-        self.client.force_authenticate(user=self.staff)
-        response = self.client.post(
-            '/api/v1/poaps/archived/mint-links/generate/',
-            {'count': 1},
-            format='json',
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        response = self.client.get('/api/v1/poaps/permissions/')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-        response = self.client.post(
-            '/api/v1/poaps/full/distributions/secret/',
-            {'secret': 'closed'},
-            format='json',
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_cannot_lower_drop_max_claims_below_current_claims(self):
+    def test_poap_drop_admin_form_rejects_lower_max_claims_below_current_claims(self):
         PoapClaim.objects.create(
             drop=self.drop,
             user=self.user,
@@ -313,15 +291,24 @@ class PoapAPITest(TestCase):
             claim_method=PoapClaim.CLAIM_LEGACY,
         )
 
-        self.client.force_authenticate(user=self.staff)
-        response = self.client.patch(
-            '/api/v1/poaps/ama-session/',
-            {'max_claims': 1},
-            format='json',
+        form = PoapDropAdminForm(
+            data={
+                'title': self.drop.title,
+                'slug': self.drop.slug,
+                'description': self.drop.description,
+                'artwork_url': self.drop.artwork_url,
+                'event_start_at': self.drop.event_start_at.isoformat(),
+                'event_end_at': '',
+                'status': self.drop.status,
+                'max_claims': 1,
+                'created_by': '',
+                'legacy_poap_id': self.drop.legacy_poap_id,
+                'discord_role_id': self.drop.discord_role_id,
+            },
+            instance=self.drop,
         )
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn('max_claims', response.data)
+        self.assertFalse(form.is_valid())
+        self.assertIn('max_claims', form.errors)
 
     def test_legacy_unmatched_claim_attaches_when_user_matches_wallet(self):
         claim = PoapClaim.objects.create(

--- a/backend/poaps/views.py
+++ b/backend/poaps/views.py
@@ -1,7 +1,6 @@
 from datetime import timezone as datetime_timezone
 
 from django.db.models import BooleanField, Count, Exists, F, OuterRef, Prefetch, Q, Value
-from django.http import HttpResponse
 from django.utils import timezone
 from rest_framework import filters, permissions, status, viewsets
 from rest_framework.decorators import action
@@ -9,20 +8,15 @@ from rest_framework.response import Response
 
 from .models import PoapClaim, PoapDistribution, PoapDrop
 from .serializers import (
-    MintLinkGenerateSerializer,
     PoapClaimSerializer,
     PoapDropDetailSerializer,
     PoapDropListSerializer,
-    PoapDropWriteSerializer,
     PoapProfileClaimSerializer,
-    SecretDistributionCreateSerializer,
 )
 from .services import (
     PoapClaimError,
     claim_with_mint_link,
     claim_with_secret,
-    generate_mint_links,
-    mint_links_csv,
 )
 
 
@@ -50,34 +44,15 @@ def open_distribution_queryset(at_time=None):
     )
 
 
-def drop_claimed_count(drop):
-    return PoapClaim.objects.filter(drop=drop, user__isnull=False).count()
-
-
-def drop_has_capacity(drop):
-    if drop.max_claims is None:
-        return True
-    return drop_claimed_count(drop) < drop.max_claims
-
-
-class IsStaffOrReadOnly(permissions.BasePermission):
-    def has_permission(self, request, view):
-        if request.method in permissions.SAFE_METHODS:
-            return True
-        return bool(request.user and request.user.is_staff)
-
-
-class PoapDropViewSet(viewsets.ModelViewSet):
+class PoapDropViewSet(viewsets.ReadOnlyModelViewSet):
     lookup_field = 'slug'
-    permission_classes = [IsStaffOrReadOnly]
+    permission_classes = [permissions.AllowAny]
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
     search_fields = ['title', 'description', 'legacy_poap_id']
     ordering_fields = ['event_start_at', 'created_at', 'title']
     ordering = ['-event_start_at']
 
     def get_serializer_class(self):
-        if self.action in ['create', 'update', 'partial_update']:
-            return PoapDropWriteSerializer
         if self.action == 'retrieve':
             return PoapDropDetailSerializer
         return PoapDropListSerializer
@@ -139,9 +114,6 @@ class PoapDropViewSet(viewsets.ModelViewSet):
 
         return queryset
 
-    def perform_create(self, serializer):
-        serializer.save(created_by=self.request.user if self.request.user.is_authenticated else None)
-
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
         if request.user.is_authenticated:
@@ -199,88 +171,6 @@ class PoapDropViewSet(viewsets.ModelViewSet):
             'claim': PoapClaimSerializer(claim).data,
             'drop': PoapDropListSerializer(claim.drop, context={'request': request}).data,
         }, status=status.HTTP_201_CREATED)
-
-    @action(detail=True, methods=['post'], url_path='distributions/secret', permission_classes=[permissions.IsAdminUser])
-    def create_secret_distribution(self, request, slug=None):
-        drop = self.get_object()
-        serializer = SecretDistributionCreateSerializer(data=request.data, context={'drop': drop})
-        serializer.is_valid(raise_exception=True)
-        if drop.status == PoapDrop.STATUS_ARCHIVED:
-            return Response({'error': 'Archived POAPs cannot receive new distributions.'}, status=status.HTTP_400_BAD_REQUEST)
-        if not drop_has_capacity(drop):
-            return Response({'error': 'This POAP has reached its claim limit.'}, status=status.HTTP_400_BAD_REQUEST)
-        requested_max = serializer.validated_data.get('max_claims')
-        if drop.max_claims is not None and requested_max is not None:
-            remaining = drop.max_claims - drop_claimed_count(drop)
-            if requested_max > remaining:
-                return Response({'error': f'Only {remaining} claim slots remain for this POAP.'}, status=status.HTTP_400_BAD_REQUEST)
-        distribution = serializer.save()
-        return Response({
-            'id': distribution.id,
-            'method': distribution.method,
-            'active': distribution.active,
-            'starts_at': distribution.starts_at,
-            'ends_at': distribution.ends_at,
-            'max_claims': distribution.max_claims,
-            'claimed_count': distribution.claimed_count,
-        }, status=status.HTTP_201_CREATED)
-
-    @action(detail=True, methods=['post'], url_path='mint-links/generate', permission_classes=[permissions.IsAdminUser])
-    def generate_mint_links_action(self, request, slug=None):
-        drop = self.get_object()
-        serializer = MintLinkGenerateSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        if drop.status == PoapDrop.STATUS_ARCHIVED:
-            return Response({'error': 'Archived POAPs cannot receive new mint links.'}, status=status.HTTP_400_BAD_REQUEST)
-        if not drop_has_capacity(drop):
-            return Response({'error': 'This POAP has reached its claim limit.'}, status=status.HTTP_400_BAD_REQUEST)
-        data = serializer.validated_data
-        requested_claims = data['count'] * data['max_uses']
-        if drop.max_claims is not None:
-            remaining = drop.max_claims - drop_claimed_count(drop)
-            if requested_claims > remaining:
-                return Response({'error': f'Only {remaining} claim slots remain for this POAP.'}, status=status.HTTP_400_BAD_REQUEST)
-        distribution = PoapDistribution.objects.create(
-            drop=drop,
-            method=PoapDistribution.METHOD_MINT_LINK,
-            active=True,
-            starts_at=data.get('starts_at'),
-            ends_at=data.get('ends_at'),
-            max_claims=requested_claims,
-        )
-        created = generate_mint_links(
-            distribution=distribution,
-            count=data['count'],
-            max_uses=data['max_uses'],
-            expires_at=data.get('expires_at'),
-        )
-        links = [
-            {
-                'id': link.id,
-                'token': token,
-                'path': f'/claim/poap/{token}',
-                'hash_path': f'/#/claim/poap/{token}',
-                'max_uses': link.max_uses,
-                'expires_at': link.expires_at,
-            }
-            for link, token in created
-        ]
-        return Response({
-            'distribution_id': distribution.id,
-            'created': len(links),
-            'links': links,
-        }, status=status.HTTP_201_CREATED)
-
-    @action(detail=True, methods=['get'], url_path='mint-links/download', permission_classes=[permissions.IsAdminUser])
-    def download_mint_links(self, request, slug=None):
-        drop = self.get_object()
-        response = HttpResponse(mint_links_csv(drop), content_type='text/csv')
-        response['Content-Disposition'] = f'attachment; filename="{drop.slug}-mint-links.csv"'
-        return response
-
-    @action(detail=False, methods=['get'], permission_classes=[permissions.AllowAny])
-    def permissions(self, request):
-        return Response({'can_manage_poaps': bool(request.user and request.user.is_staff)})
 
 
 class UserPoapMixin:

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -299,10 +299,6 @@ export const poapsAPI = {
   list: (params) => api.get('/poaps/', { params }),
   /** @param {string} slug */
   get: (slug) => api.get(`/poaps/${slug}/`),
-  /** @param {PoapApiPayload} data */
-  create: (data) => api.post('/poaps/', data),
-  /** @param {string} slug @param {PoapApiPayload} data */
-  update: (slug, data) => api.patch(`/poaps/${slug}/`, data),
   /** @param {string} slug @param {PoapApiPayload} [params] */
   getClaims: (slug, params) => api.get(`/poaps/${slug}/claims/`, { params }),
   /** @param {string} address @param {PoapApiPayload} [params] */
@@ -311,11 +307,6 @@ export const poapsAPI = {
   claimSecret: (slug, secret) => api.post(`/poaps/${slug}/claim-secret/`, { secret }),
   /** @param {string} token */
   claimLink: (token) => api.post(`/poaps/claim-link/${encodeURIComponent(token)}/`),
-  /** @param {string} slug @param {PoapApiPayload} data */
-  createSecretDistribution: (slug, data) => api.post(`/poaps/${slug}/distributions/secret/`, data),
-  /** @param {string} slug @param {PoapApiPayload} data */
-  generateMintLinks: (slug, data) => api.post(`/poaps/${slug}/mint-links/generate/`, data),
-  permissions: () => api.get('/poaps/permissions/'),
 };
 
 export default api;

--- a/frontend/src/routes/CommunityPoaps.svelte
+++ b/frontend/src/routes/CommunityPoaps.svelte
@@ -1,8 +1,7 @@
 <script>
   import { onMount } from 'svelte';
-  import { push } from 'svelte-spa-router';
   import { poapsAPI } from '../lib/api.js';
-  import { showError, showSuccess } from '../lib/toastStore.js';
+  import { showError } from '../lib/toastStore.js';
   import PoapCollectionWall from '../components/poaps/PoapCollectionWall.svelte';
   import CategoryIcon from '../components/portal/CategoryIcon.svelte';
 
@@ -12,19 +11,6 @@
   let count = $state(0);
   let search = $state('');
   let monthFilter = $state('');
-  let permissions = $state({ can_manage_poaps: false });
-  let showCreate = $state(false);
-  let creating = $state(false);
-  /** @type {any} */
-  let createForm = $state({
-    title: '',
-    description: '',
-    artwork_url: '',
-    event_start_at: '',
-    event_end_at: '',
-    status: 'active',
-    max_claims: '',
-  });
 
   const PAGE_SIZE = 100;
 
@@ -72,56 +58,13 @@
     }
   }
 
-  async function loadPermissions() {
-    try {
-      const response = await poapsAPI.permissions();
-      permissions = response.data || { can_manage_poaps: false };
-    } catch {
-      permissions = { can_manage_poaps: false };
-    }
-  }
-
   function clearFilters() {
     search = '';
     monthFilter = '';
     loadPoaps();
   }
 
-  async function createPoap() {
-    if (!createForm.title || !createForm.event_start_at) {
-      showError('Title and event start date are required.');
-      return;
-    }
-    creating = true;
-    try {
-      const payload = {
-        ...createForm,
-        max_claims: createForm.max_claims ? Number(createForm.max_claims) : null,
-        event_end_at: createForm.event_end_at || null,
-      };
-      const response = await poapsAPI.create(payload);
-      showSuccess('POAP created.');
-      showCreate = false;
-      createForm = {
-        title: '',
-        description: '',
-        artwork_url: '',
-        event_start_at: '',
-        event_end_at: '',
-        status: 'active',
-        max_claims: '',
-      };
-      push(`/community/poaps/${response.data.slug}`);
-    } catch (err) {
-      const data = /** @type {any} */ (err).response?.data;
-      showError(typeof data === 'string' ? data : data?.detail || data?.error || 'Unable to create POAP.');
-    } finally {
-      creating = false;
-    }
-  }
-
   onMount(() => {
-    loadPermissions();
     loadPoaps();
   });
 </script>
@@ -181,14 +124,6 @@
             </button>
           {/if}
 
-          {#if permissions.can_manage_poaps}
-            <button
-              class="inline-flex h-10 items-center justify-center rounded-[24px] bg-[#101010] px-4 text-[14px] font-medium text-white transition-colors hover:bg-black"
-              onclick={() => (showCreate = true)}
-            >
-              New POAP
-            </button>
-          {/if}
         </div>
       </div>
     </header>
@@ -217,56 +152,3 @@
     </section>
   </div>
 </div>
-
-{#if showCreate}
-  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" role="dialog" aria-modal="true">
-    <div class="w-full max-w-2xl rounded-[10px] bg-white p-6 shadow-[0_24px_80px_rgba(0,0,0,0.24)]">
-      <div class="mb-5 flex items-start justify-between gap-4">
-        <div>
-          <h2 class="text-[22px] font-semibold text-black">New POAP</h2>
-          <p class="mt-1 text-[14px] text-[#777]">Create the badge first, then add distribution methods on the detail page.</p>
-        </div>
-        <button class="rounded-full p-2 hover:bg-[#f5f5f5]" onclick={() => (showCreate = false)} aria-label="Close">
-          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12" /></svg>
-        </button>
-      </div>
-      <div class="grid gap-4">
-        <label class="grid gap-1 text-[13px] font-medium text-[#555]">Title
-          <input bind:value={createForm.title} class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] text-black outline-none focus:border-[#8d81e1]" />
-        </label>
-        <label class="grid gap-1 text-[13px] font-medium text-[#555]">Artwork URL
-          <input bind:value={createForm.artwork_url} class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] text-black outline-none focus:border-[#8d81e1]" placeholder="https://..." />
-        </label>
-        <label class="grid gap-1 text-[13px] font-medium text-[#555]">Description
-          <textarea bind:value={createForm.description} class="min-h-[96px] rounded-[8px] border border-[#e6e6e6] p-3 text-[14px] text-black outline-none focus:border-[#8d81e1]"></textarea>
-        </label>
-        <div class="grid gap-4 sm:grid-cols-2">
-          <label class="grid gap-1 text-[13px] font-medium text-[#555]">Event start
-            <input bind:value={createForm.event_start_at} type="datetime-local" class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] text-black outline-none focus:border-[#8d81e1]" />
-          </label>
-          <label class="grid gap-1 text-[13px] font-medium text-[#555]">Event end
-            <input bind:value={createForm.event_end_at} type="datetime-local" class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] text-black outline-none focus:border-[#8d81e1]" />
-          </label>
-        </div>
-        <div class="grid gap-4 sm:grid-cols-2">
-          <label class="grid gap-1 text-[13px] font-medium text-[#555]">Status
-            <select bind:value={createForm.status} class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] text-black outline-none focus:border-[#8d81e1]">
-              <option value="draft">Draft</option>
-              <option value="active">Active</option>
-              <option value="archived">Archived</option>
-            </select>
-          </label>
-          <label class="grid gap-1 text-[13px] font-medium text-[#555]">Max claims
-            <input bind:value={createForm.max_claims} type="number" min="1" class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] text-black outline-none focus:border-[#8d81e1]" placeholder="Unlimited" />
-          </label>
-        </div>
-      </div>
-      <div class="mt-6 flex justify-end gap-2">
-        <button class="h-10 rounded-[8px] border border-[#e6e6e6] px-4 text-[14px] font-medium text-[#555]" onclick={() => (showCreate = false)}>Cancel</button>
-        <button class="h-10 rounded-[8px] bg-[#101010] px-4 text-[14px] font-medium text-white disabled:opacity-50" disabled={creating} onclick={createPoap}>
-          {creating ? 'Creating...' : 'Create POAP'}
-        </button>
-      </div>
-    </div>
-  </div>
-{/if}

--- a/frontend/src/routes/PoapDetail.svelte
+++ b/frontend/src/routes/PoapDetail.svelte
@@ -1,7 +1,6 @@
 <script>
   import { params, push } from 'svelte-spa-router';
   import { format } from 'date-fns';
-  import { API_BASE_URL } from '../lib/config.js';
   import { authState } from '../lib/auth.js';
   import { poapsAPI } from '../lib/api.js';
   import { showError, showSuccess } from '../lib/toastStore.js';
@@ -18,37 +17,6 @@
   let claimPage = $state(1);
   let secret = $state('');
   let claiming = $state(false);
-  let creatingSecret = $state(false);
-  let generatingLinks = $state(false);
-  /** @type {any[]} */
-  let generatedLinks = $state([]);
-  let showEdit = $state(false);
-  let showManage = $state(false);
-  let savingDrop = $state(false);
-  /** @type {any} */
-  let editForm = $state({
-    title: '',
-    description: '',
-    artwork_url: '',
-    event_start_at: '',
-    event_end_at: '',
-    status: 'active',
-    max_claims: '',
-  });
-  let secretForm = $state({
-    secret: '',
-    starts_at: '',
-    ends_at: '',
-    max_claims: '',
-    active: true,
-  });
-  let linkForm = $state({
-    count: 1,
-    max_uses: 1,
-    expires_at: '',
-    starts_at: '',
-    ends_at: '',
-  });
 
   const CLAIM_PAGE_SIZE = 10;
 
@@ -105,29 +73,6 @@
     return statusCode === 401 || statusCode === 403;
   }
 
-  /** @param {string | Date | null | undefined} value */
-  function toDateTimeLocal(value) {
-    if (!value) return '';
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return '';
-    const offsetDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
-    return offsetDate.toISOString().slice(0, 16);
-  }
-
-  function openEdit() {
-    if (!poap) return;
-    editForm = {
-      title: poap.title || '',
-      description: poap.description || '',
-      artwork_url: poap.artwork_url || '',
-      event_start_at: toDateTimeLocal(poap.event_start_at),
-      event_end_at: toDateTimeLocal(poap.event_end_at),
-      status: poap.status || 'active',
-      max_claims: poap.max_claims || '',
-    };
-    showEdit = true;
-  }
-
   function signInForClaim() {
     sessionStorage.setItem('redirectAfterLogin', `/community/poaps/${slug}`);
     window.setTimeout(() => {
@@ -143,7 +88,6 @@
     try {
       const response = await poapsAPI.get(slug);
       poap = response.data;
-      showManage = false;
     } catch (err) {
       const requestError = /** @type {any} */ (err);
       error = requestError.response?.data?.detail || 'Unable to load this POAP.';
@@ -169,29 +113,6 @@
       claimsCount = 0;
     } finally {
       claimsLoading = false;
-    }
-  }
-
-  async function saveDrop() {
-    if (!editForm.title || !editForm.event_start_at) {
-      showError('Title and event start date are required.');
-      return;
-    }
-    savingDrop = true;
-    try {
-      await poapsAPI.update(slug, {
-        ...editForm,
-        event_end_at: editForm.event_end_at || null,
-        max_claims: editForm.max_claims ? Number(editForm.max_claims) : null,
-      });
-      showSuccess('POAP updated.');
-      showEdit = false;
-      await loadPoap();
-    } catch (err) {
-      const data = /** @type {any} */ (err).response?.data;
-      showError(typeof data === 'string' ? data : data?.detail || data?.error || 'Unable to update POAP.');
-    } finally {
-      savingDrop = false;
     }
   }
 
@@ -223,78 +144,6 @@
     } finally {
       claiming = false;
     }
-  }
-
-  async function createSecretDistribution() {
-    if (!secretForm.secret.trim()) {
-      showError('Secret phrase is required.');
-      return;
-    }
-    creatingSecret = true;
-    try {
-      await poapsAPI.createSecretDistribution(slug, {
-        secret: secretForm.secret,
-        starts_at: secretForm.starts_at || null,
-        ends_at: secretForm.ends_at || null,
-        max_claims: secretForm.max_claims ? Number(secretForm.max_claims) : null,
-        active: secretForm.active,
-      });
-      showSuccess('Secret distribution created.');
-      secretForm = { secret: '', starts_at: '', ends_at: '', max_claims: '', active: true };
-      await loadPoap();
-    } catch (err) {
-      const requestError = /** @type {any} */ (err);
-      showError(requestError.response?.data?.detail || requestError.response?.data?.error || 'Unable to create distribution.');
-    } finally {
-      creatingSecret = false;
-    }
-  }
-
-  async function generateLinks() {
-    generatingLinks = true;
-    generatedLinks = [];
-    try {
-      const response = await poapsAPI.generateMintLinks(slug, {
-        count: Number(linkForm.count) || 1,
-        max_uses: Number(linkForm.max_uses) || 1,
-        expires_at: linkForm.expires_at || null,
-        starts_at: linkForm.starts_at || null,
-        ends_at: linkForm.ends_at || null,
-      });
-      generatedLinks = response.data?.links || [];
-      showSuccess(`${response.data?.created || generatedLinks.length} mint link${generatedLinks.length === 1 ? '' : 's'} generated.`);
-      await loadPoap();
-    } catch (err) {
-      const requestError = /** @type {any} */ (err);
-      showError(requestError.response?.data?.detail || requestError.response?.data?.error || 'Unable to generate mint links.');
-    } finally {
-      generatingLinks = false;
-    }
-  }
-
-  /** @param {any} link */
-  function mintLinkUrl(link) {
-    const path = typeof link === 'string' ? link : link?.hash_path || link?.path || '';
-    if (!path) return window.location.origin;
-    if (/^https?:\/\//.test(path)) return path;
-    if (path.startsWith('/#/')) return `${window.location.origin}${path}`;
-    if (path.startsWith('#/')) return `${window.location.origin}/${path}`;
-    return `${window.location.origin}#${path.startsWith('/') ? path : `/${path}`}`;
-  }
-
-  /** @param {any} link */
-  async function copyLink(link) {
-    const absolute = mintLinkUrl(link);
-    try {
-      await navigator.clipboard.writeText(absolute);
-      showSuccess('Link copied.');
-    } catch {
-      showError('Unable to copy link.');
-    }
-  }
-
-  function downloadMintLinks() {
-    window.open(`${API_BASE_URL}/api/v1/poaps/${slug}/mint-links/download/`, '_blank', 'noopener,noreferrer');
   }
 
   $effect(() => {
@@ -344,15 +193,6 @@
               {#if poap.has_claimed}
                 <span class="rounded-full border border-[#d8f0df] bg-[#f2fbf5] px-3 py-1 text-[12px] font-semibold uppercase text-[#167b48]">Claimed</span>
               {/if}
-              {#if poap.can_manage}
-                <button class="rounded-full border border-[#d9d2ff] bg-white px-3 py-1 text-[12px] font-semibold text-[#6b5bd6] hover:bg-[#f7f4ff]" onclick={openEdit}>Edit</button>
-                <button
-                  class="rounded-full border border-[#d9d2ff] bg-white px-3 py-1 text-[12px] font-semibold text-[#6b5bd6] hover:bg-[#f7f4ff]"
-                  onclick={() => (showManage = !showManage)}
-                >
-                  Distribution
-                </button>
-              {/if}
             </div>
 
             {#if poap.max_claims}
@@ -388,90 +228,6 @@
           </aside>
         </div>
       </section>
-
-      {#if poap.can_manage && showManage}
-        <section class="rounded-[10px] border border-[#e8e3ff] bg-white p-5 shadow-[0_12px_34px_rgba(80,64,150,0.08)] sm:p-6">
-          <div class="mb-5 flex flex-wrap items-center justify-between gap-3">
-            <div>
-              <h2 class="text-[20px] font-semibold text-black">Distribution</h2>
-              <p class="mt-1 text-[14px] text-[#777]">Create secret phrases or individual mint links for this POAP.</p>
-            </div>
-            <button class="rounded-[8px] border border-[#d9d2ff] px-3 py-2 text-[13px] font-medium text-[#6b5bd6] hover:bg-[#f7f4ff]" onclick={downloadMintLinks}>Download mint links</button>
-          </div>
-
-          <div class="grid gap-5 lg:grid-cols-2">
-            <div class="rounded-[8px] border border-[#f0f0f0] p-4">
-              <h3 class="text-[15px] font-semibold text-black">Secret phrase</h3>
-              <div class="mt-4 grid gap-3">
-                <input bind:value={secretForm.secret} class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] outline-none focus:border-[#8d81e1]" placeholder="friend-scientist-natural" />
-                <div class="grid gap-3 sm:grid-cols-2">
-                  <input bind:value={secretForm.starts_at} type="datetime-local" class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] outline-none focus:border-[#8d81e1]" />
-                  <input bind:value={secretForm.ends_at} type="datetime-local" class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] outline-none focus:border-[#8d81e1]" />
-                </div>
-                <input bind:value={secretForm.max_claims} type="number" min="1" class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] outline-none focus:border-[#8d81e1]" placeholder="Max claims, optional" />
-                <label class="flex items-center gap-2 text-[13px] text-[#555]"><input bind:checked={secretForm.active} type="checkbox" /> Active</label>
-                <button class="h-10 rounded-[8px] bg-[#101010] px-4 text-[14px] font-medium text-white disabled:opacity-50" disabled={creatingSecret} onclick={createSecretDistribution}>
-                  {creatingSecret ? 'Creating...' : 'Create secret'}
-                </button>
-              </div>
-            </div>
-
-            <div class="rounded-[8px] border border-[#f0f0f0] p-4">
-              <h3 class="text-[15px] font-semibold text-black">Individual mint links</h3>
-              <div class="mt-4 grid gap-3">
-                <div class="grid gap-3 sm:grid-cols-2">
-                  <label class="grid gap-1 text-[13px] text-[#555]">Links
-                    <input bind:value={linkForm.count} type="number" min="1" max="500" class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] outline-none focus:border-[#8d81e1]" />
-                  </label>
-                  <label class="grid gap-1 text-[13px] text-[#555]">Uses per link
-                    <input bind:value={linkForm.max_uses} type="number" min="1" max="100" class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] outline-none focus:border-[#8d81e1]" />
-                  </label>
-                </div>
-                <input bind:value={linkForm.expires_at} type="datetime-local" class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] outline-none focus:border-[#8d81e1]" />
-                <button class="h-10 rounded-[8px] bg-[#101010] px-4 text-[14px] font-medium text-white disabled:opacity-50" disabled={generatingLinks} onclick={generateLinks}>
-                  {generatingLinks ? 'Generating...' : 'Generate links'}
-                </button>
-              </div>
-              {#if generatedLinks.length > 0}
-                <div class="mt-4 max-h-44 overflow-auto rounded-[8px] bg-[#fafafa] p-3">
-                  {#each generatedLinks as link}
-                    <button class="mb-2 block w-full truncate rounded-[6px] border border-[#e6e6e6] bg-white px-3 py-2 text-left text-[12px] text-[#555] hover:border-[#d9d2ff]" onclick={() => copyLink(link)}>
-                      {mintLinkUrl(link)}
-                    </button>
-                  {/each}
-                </div>
-              {/if}
-            </div>
-          </div>
-
-          {#if poap.distributions?.length}
-            <div class="mt-5 overflow-x-auto">
-              <table class="min-w-full text-left text-[13px]">
-                <thead class="text-[#777]">
-                  <tr class="border-b border-[#ededed]">
-                    <th class="py-2 pr-4 font-medium">Method</th>
-                    <th class="py-2 pr-4 font-medium">Active</th>
-                    <th class="py-2 pr-4 font-medium">Claims</th>
-                    <th class="py-2 pr-4 font-medium">Window</th>
-                    <th class="py-2 pr-4 font-medium">Links</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {#each poap.distributions as distribution}
-                    <tr class="border-b border-[#f5f5f5]">
-                      <td class="py-2 pr-4 text-black">{distribution.method}</td>
-                      <td class="py-2 pr-4">{distribution.active ? 'Yes' : 'No'}</td>
-                      <td class="py-2 pr-4">{distribution.claimed_count}{distribution.max_claims ? ` / ${distribution.max_claims}` : ''}</td>
-                      <td class="py-2 pr-4">{distribution.starts_at ? formatDate(distribution.starts_at, 'MMM d, h:mm a') : 'Live'} - {distribution.ends_at ? formatDate(distribution.ends_at, 'MMM d, h:mm a') : 'No end'}</td>
-                      <td class="py-2 pr-4">{distribution.mint_link_count || 0}</td>
-                    </tr>
-                  {/each}
-                </tbody>
-              </table>
-            </div>
-          {/if}
-        </section>
-      {/if}
 
       <section class="poap-collectors-card">
         <div class="poap-collectors-header">
@@ -536,59 +292,6 @@
     {/if}
   </div>
 </div>
-
-{#if showEdit}
-  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" role="dialog" aria-modal="true">
-    <div class="w-full max-w-2xl rounded-[10px] bg-white p-6 shadow-[0_24px_80px_rgba(0,0,0,0.24)]">
-      <div class="mb-5 flex items-start justify-between gap-4">
-        <div>
-          <h2 class="text-[22px] font-semibold text-black">Edit POAP</h2>
-          <p class="mt-1 text-[14px] text-[#777]">Update badge metadata and availability.</p>
-        </div>
-        <button class="rounded-full p-2 hover:bg-[#f5f5f5]" onclick={() => (showEdit = false)} aria-label="Close">
-          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12" /></svg>
-        </button>
-      </div>
-      <div class="grid gap-4">
-        <label class="grid gap-1 text-[13px] font-medium text-[#555]">Title
-          <input bind:value={editForm.title} class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] text-black outline-none focus:border-[#8d81e1]" />
-        </label>
-        <label class="grid gap-1 text-[13px] font-medium text-[#555]">Artwork URL
-          <input bind:value={editForm.artwork_url} class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] text-black outline-none focus:border-[#8d81e1]" placeholder="https://..." />
-        </label>
-        <label class="grid gap-1 text-[13px] font-medium text-[#555]">Description
-          <textarea bind:value={editForm.description} class="min-h-[96px] rounded-[8px] border border-[#e6e6e6] p-3 text-[14px] text-black outline-none focus:border-[#8d81e1]"></textarea>
-        </label>
-        <div class="grid gap-4 sm:grid-cols-2">
-          <label class="grid gap-1 text-[13px] font-medium text-[#555]">Event start
-            <input bind:value={editForm.event_start_at} type="datetime-local" class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] text-black outline-none focus:border-[#8d81e1]" />
-          </label>
-          <label class="grid gap-1 text-[13px] font-medium text-[#555]">Event end
-            <input bind:value={editForm.event_end_at} type="datetime-local" class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] text-black outline-none focus:border-[#8d81e1]" />
-          </label>
-        </div>
-        <div class="grid gap-4 sm:grid-cols-2">
-          <label class="grid gap-1 text-[13px] font-medium text-[#555]">Status
-            <select bind:value={editForm.status} class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] text-black outline-none focus:border-[#8d81e1]">
-              <option value="draft">Draft</option>
-              <option value="active">Active</option>
-              <option value="archived">Archived</option>
-            </select>
-          </label>
-          <label class="grid gap-1 text-[13px] font-medium text-[#555]">Max claims
-            <input bind:value={editForm.max_claims} type="number" min="1" class="h-10 rounded-[8px] border border-[#e6e6e6] px-3 text-[14px] text-black outline-none focus:border-[#8d81e1]" placeholder="Unlimited" />
-          </label>
-        </div>
-      </div>
-      <div class="mt-6 flex justify-end gap-2">
-        <button class="h-10 rounded-[8px] border border-[#e6e6e6] px-4 text-[14px] font-medium text-[#555]" onclick={() => (showEdit = false)}>Cancel</button>
-        <button class="h-10 rounded-[8px] bg-[#101010] px-4 text-[14px] font-medium text-white disabled:opacity-50" disabled={savingDrop} onclick={saveDrop}>
-          {savingDrop ? 'Saving...' : 'Save POAP'}
-        </button>
-      </div>
-    </div>
-  </div>
-{/if}
 
 <style>
   .poap-detail-card {


### PR DESCRIPTION
## Summary
- Remove POAP creation, editing, distribution, and mint-link management from the portal frontend.
- Remove the staff-only POAP management REST endpoints so the portal API remains read/claim-only.
- Keep user-facing POAP browsing and claiming flows intact.
- Add Django admin support for POAP validation, secret phrase distributions, bulk mint-link generation, auto-generated claim URLs, and mint-link CSV export.
- Prevent admins from generating mint links beyond distribution or POAP drop capacity already reserved by unused links.

## Verification
- `./env/bin/python manage.py check`
- `./env/bin/python manage.py makemigrations --check --dry-run poaps`
- `npm run build`
- Rolled-back admin-only smoke check for removed management API routes and admin max-claim validation.
- Rolled-back admin smoke check for bulk mint-link generation.
- Rolled-back admin smoke check for reserved mint-link capacity validation.

## Note
- `./env/bin/python manage.py test poaps.tests.test_poaps.PoapAPITest --keepdb` is still blocked by the existing `contributions/migrations/0037_seed_featured_content.py` seed failure.