### PR TITLE
Move profile POAPs under community

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -103,7 +103,6 @@
   import GenNews from './routes/GenNews.svelte';
   import GenTV from './routes/GenTV.svelte';
   import Referrals from './routes/Referrals.svelte';
-  import Community from './routes/Community.svelte';
   import CommunityPoaps from './routes/CommunityPoaps.svelte';
   import PoapDetail from './routes/PoapDetail.svelte';
   import PoapClaim from './routes/PoapClaim.svelte';
@@ -133,7 +132,8 @@
     '/community': ReferralProgram,
     '/community/contributions': Contributions,
     '/community/all-contributions': AllContributions,
-    '/community/leaderboard': Community,
+    '/community/referrals': Referrals,
+    '/community/leaderboard': Referrals,
     '/community/poaps': CommunityPoaps,
     '/community/poaps/:slug': PoapDetail,
     '/community/contribution/:id': ContributionPreview,

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -133,7 +133,6 @@
     '/community/contributions': Contributions,
     '/community/all-contributions': AllContributions,
     '/community/referrals': Referrals,
-    '/community/leaderboard': Referrals,
     '/community/poaps': CommunityPoaps,
     '/community/poaps/:slug': PoapDetail,
     '/community/contribution/:id': ContributionPreview,

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -320,7 +320,7 @@
               href="/community/referrals"
               onclick={(e) => { e.preventDefault(); navigate('/community/referrals'); }}
               class="flex items-center border-l-[1.5px] px-3 py-2 text-[14px] font-medium text-black tracking-[0.28px] {
-                isActive('/community/referrals') || isActive('/community/leaderboard') ? 'border-[#8D81E1]' : 'border-[#f5f5f5]'
+                isActive('/community/referrals') ? 'border-[#8D81E1]' : 'border-[#f5f5f5]'
               }"
             >
               Referrals
@@ -721,7 +721,7 @@
             href="/community/referrals"
             onclick={(e) => { e.preventDefault(); navigate('/community/referrals'); }}
             class="flex items-center border-l-[1.5px] px-3 py-2 text-[14px] font-medium text-black tracking-[0.28px] {
-              isActive('/community/referrals') || isActive('/community/leaderboard') ? 'border-[#8D81E1]' : 'border-[#f5f5f5]'
+              isActive('/community/referrals') ? 'border-[#8D81E1]' : 'border-[#f5f5f5]'
             }"
           >
             Referrals

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -317,10 +317,10 @@
               Contributions
             </a>
             <a
-              href="/community/leaderboard"
-              onclick={(e) => { e.preventDefault(); navigate('/community/leaderboard'); }}
+              href="/community/referrals"
+              onclick={(e) => { e.preventDefault(); navigate('/community/referrals'); }}
               class="flex items-center border-l-[1.5px] px-3 py-2 text-[14px] font-medium text-black tracking-[0.28px] {
-                isActive('/community/leaderboard') ? 'border-[#8D81E1]' : 'border-[#f5f5f5]'
+                isActive('/community/referrals') || isActive('/community/leaderboard') ? 'border-[#8D81E1]' : 'border-[#f5f5f5]'
               }"
             >
               Referrals
@@ -718,10 +718,10 @@
             Contributions
           </a>
           <a
-            href="/community/leaderboard"
-            onclick={(e) => { e.preventDefault(); navigate('/community/leaderboard'); }}
+            href="/community/referrals"
+            onclick={(e) => { e.preventDefault(); navigate('/community/referrals'); }}
             class="flex items-center border-l-[1.5px] px-3 py-2 text-[14px] font-medium text-black tracking-[0.28px] {
-              isActive('/community/leaderboard') ? 'border-[#8D81E1]' : 'border-[#f5f5f5]'
+              isActive('/community/referrals') || isActive('/community/leaderboard') ? 'border-[#8D81E1]' : 'border-[#f5f5f5]'
             }"
           >
             Referrals

--- a/frontend/src/components/portal/MiniLeaderboard.svelte
+++ b/frontend/src/components/portal/MiniLeaderboard.svelte
@@ -221,7 +221,7 @@
         {@render labelIcon('community')}
         <span class="text-[14px] font-medium text-black" style="letter-spacing: 0.28px;">Community</span>
       </div>
-      <button onclick={() => push('/community/leaderboard')} class="flex items-center gap-[4px] text-[14px] text-[#6b6b6b] hover:text-black transition-colors" style="letter-spacing: 0.28px;">
+      <button onclick={() => push('/community/referrals')} class="flex items-center gap-[4px] text-[14px] text-[#6b6b6b] hover:text-black transition-colors" style="letter-spacing: 0.28px;">
         View all
         <img src="/assets/icons/arrow-right-line.svg" alt="" class="w-4 h-4">
       </button>

--- a/frontend/src/components/profile/CommunityView.svelte
+++ b/frontend/src/components/profile/CommunityView.svelte
@@ -3,12 +3,15 @@
     import ProfileHighlights from "./ProfileHighlights.svelte";
     import ProfileRecentContributions from "./ProfileRecentContributions.svelte";
     import CommunityProgressJourney from "./CommunityProgressJourney.svelte";
+    import ProfilePoaps from "../poaps/ProfilePoaps.svelte";
 
     let {
         participant = null,
         isOwnProfile = false,
         communityStats = { totalContributions: 0, totalPoints: 0 },
         communityStatsLoading = false,
+        poapCount = 0,
+        poapCountLoading = false,
         onSocialLinked = () => {},
         onClaimX = () => {},
         onClaimDiscord = () => {},
@@ -21,6 +24,8 @@
         participant?.creator &&
         !(participant?.has_community_link_x && participant?.has_community_link_discord)
     );
+    let showCommunityActivity = $derived(Boolean(participant?.creator));
+    let showPoaps = $derived(poapCount > 0);
 </script>
 
 <div class="community-view w-full flex flex-col items-start mt-8">
@@ -50,11 +55,13 @@
                 Community
             </h2>
         </div>
-        <span
-            class="text-[12px] font-medium text-[#ac6df3] tracking-[0.24px] leading-[16px]"
-        >
-            Community Member
-        </span>
+        {#if showCommunityActivity}
+            <span
+                class="text-[12px] font-medium text-[#ac6df3] tracking-[0.24px] leading-[16px]"
+            >
+                Community Member
+            </span>
+        {/if}
     </div>
 
     <!-- Social Link Journey (conditional) -->
@@ -73,89 +80,137 @@
 
     <!-- Metrics Row: 2 cards -->
     <div class="community-metrics flex flex-col md:flex-row gap-4 w-full">
-        <!-- Community Points Card -->
-        <div
-            class="community-metric-card bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative overflow-hidden"
-        >
-            {#if communityStatsLoading}
-                <div class="flex h-full items-center animate-pulse">
-                    <div
-                        class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"
-                    ></div>
-                    <div class="flex flex-col gap-2">
-                        <div class="h-7 w-16 bg-gray-200 rounded"></div>
-                        <div class="h-3 w-28 bg-gray-100 rounded"></div>
+        {#if showCommunityActivity}
+            <!-- Community Points Card -->
+            <div
+                class="community-metric-card bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative overflow-hidden"
+            >
+                {#if communityStatsLoading}
+                    <div class="flex h-full items-center animate-pulse">
+                        <div
+                            class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"
+                        ></div>
+                        <div class="flex flex-col gap-2">
+                            <div class="h-7 w-16 bg-gray-200 rounded"></div>
+                            <div class="h-3 w-28 bg-gray-100 rounded"></div>
+                        </div>
                     </div>
-                </div>
-            {:else}
-                <div class="community-metric-content flex h-full items-center min-w-0">
-                    <div
-                        class="community-metric-icon w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
-                    >
-                        <img
-                            src="/assets/icons/hexagon-community.svg"
-                            alt=""
-                            class="w-full h-full"
-                        />
-                        <img
-                            src="/assets/icons/group-white.svg"
-                            alt=""
-                            class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
-                            style="width: 24px; height: 24px;"
-                        />
-                    </div>
-                    <div
-                        class="community-metric-text flex flex-col h-full items-start justify-center whitespace-nowrap z-10 min-w-0"
-                    >
-                        <p
-                            class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
+                {:else}
+                    <div class="community-metric-content flex h-full items-center min-w-0">
+                        <div
+                            class="community-metric-icon w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
                         >
-                            {communityStats.totalPoints || 0}
-                        </p>
-                        <p
-                            class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
-                        >
-                            Community Points
-                        </p>
-                    </div>
-                </div>
-            {/if}
-        </div>
-
-        <!-- Community Contributions Card -->
-        <div
-            class="community-metric-card bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative overflow-hidden"
-        >
-            {#if communityStatsLoading}
-                <div class="flex h-full items-center animate-pulse">
-                    <div
-                        class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"
-                    ></div>
-                    <div class="flex flex-col gap-2">
-                        <div class="h-7 w-16 bg-gray-200 rounded"></div>
-                        <div class="h-3 w-28 bg-gray-100 rounded"></div>
-                    </div>
-                </div>
-            {:else}
-                <div class="community-metric-content flex h-full items-center min-w-0">
-                    <div
-                        class="community-metric-icon w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
-                    >
-                        <img
-                            src="/assets/icons/hexagon-community.svg"
-                            alt=""
-                            class="w-full h-full"
-                        />
-                        <svg
-                            class="community-contributions-icon absolute text-white"
-                            viewBox="0 0 24 24"
-                            fill="currentColor"
-                            aria-hidden="true"
-                        >
-                            <path
-                                d="M21 8V20.9932C21 21.5501 20.5552 22 20.0066 22H3.9934C3.44495 22 3 21.556 3 21.0082V2.9918C3 2.44405 3.44476 2 3.9934 2H14.9968L21 8ZM19 9H14V4H5V20H19V9ZM8 12H16V14H8V12ZM8 16H16V18H8V16Z"
+                            <img
+                                src="/assets/icons/hexagon-community.svg"
+                                alt=""
+                                class="w-full h-full"
                             />
-                        </svg>
+                            <img
+                                src="/assets/icons/group-white.svg"
+                                alt=""
+                                class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+                                style="width: 24px; height: 24px;"
+                            />
+                        </div>
+                        <div
+                            class="community-metric-text flex flex-col h-full items-start justify-center whitespace-nowrap z-10 min-w-0"
+                        >
+                            <p
+                                class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
+                            >
+                                {communityStats.totalPoints || 0}
+                            </p>
+                            <p
+                                class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
+                            >
+                                Community Points
+                            </p>
+                        </div>
+                    </div>
+                {/if}
+            </div>
+        {/if}
+
+        {#if showCommunityActivity}
+            <!-- Community Contributions Card -->
+            <div
+                class="community-metric-card bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative overflow-hidden"
+            >
+                {#if communityStatsLoading}
+                    <div class="flex h-full items-center animate-pulse">
+                        <div
+                            class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"
+                        ></div>
+                        <div class="flex flex-col gap-2">
+                            <div class="h-7 w-16 bg-gray-200 rounded"></div>
+                            <div class="h-3 w-28 bg-gray-100 rounded"></div>
+                        </div>
+                    </div>
+                {:else}
+                    <div class="community-metric-content flex h-full items-center min-w-0">
+                        <div
+                            class="community-metric-icon w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
+                        >
+                            <img
+                                src="/assets/icons/hexagon-community.svg"
+                                alt=""
+                                class="w-full h-full"
+                            />
+                            <svg
+                                class="community-contributions-icon absolute text-white"
+                                viewBox="0 0 24 24"
+                                fill="currentColor"
+                                aria-hidden="true"
+                            >
+                                <path
+                                    d="M21 8V20.9932C21 21.5501 20.5552 22 20.0066 22H3.9934C3.44495 22 3 21.556 3 21.0082V2.9918C3 2.44405 3.44476 2 3.9934 2H14.9968L21 8ZM19 9H14V4H5V20H19V9ZM8 12H16V14H8V12ZM8 16H16V18H8V16Z"
+                                />
+                            </svg>
+                        </div>
+                        <div
+                            class="community-metric-text flex flex-col h-full items-start justify-center whitespace-nowrap z-10 min-w-0"
+                        >
+                            <p
+                                class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
+                            >
+                                {communityStats.totalContributions || 0}
+                            </p>
+                            <p
+                                class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
+                            >
+                                Community Contributions
+                            </p>
+                        </div>
+                    </div>
+                {/if}
+            </div>
+        {/if}
+
+        <!-- POAPs Card -->
+        <div
+            class="community-metric-card bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative overflow-hidden"
+        >
+            {#if poapCountLoading}
+                <div class="flex h-full items-center animate-pulse">
+                    <div
+                        class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"
+                    ></div>
+                    <div class="flex flex-col gap-2">
+                        <div class="h-7 w-16 bg-gray-200 rounded"></div>
+                        <div class="h-3 w-20 bg-gray-100 rounded"></div>
+                    </div>
+                </div>
+            {:else}
+                <div class="community-metric-content flex h-full items-center min-w-0">
+                    <div
+                        class="community-metric-icon w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
+                    >
+                        <img
+                            src="/assets/icons/hexagon-community.svg"
+                            alt=""
+                            class="w-full h-full"
+                        />
+                        <span class="community-poap-icon" aria-hidden="true"></span>
                     </div>
                     <div
                         class="community-metric-text flex flex-col h-full items-start justify-center whitespace-nowrap z-10 min-w-0"
@@ -163,12 +218,12 @@
                         <p
                             class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
                         >
-                            {communityStats.totalContributions || 0}
+                            {poapCount || 0}
                         </p>
                         <p
                             class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
                         >
-                            Community Contributions
+                            POAPs
                         </p>
                     </div>
                 </div>
@@ -179,55 +234,61 @@
 
     <!-- Content Sections -->
     <div class="space-y-12 w-full mt-4">
-        <div class="w-full">
-            <div class="community-section-header flex items-start justify-between mb-[20px] gap-4">
-                <div>
-                    <h3
-                        class="font-semibold text-[20px] text-black"
-                        style="letter-spacing: 0.4px;"
-                    >
-                        Highlights
-                    </h3>
-                    <p class="text-[14px] text-[#999] mt-1">
-                        Get highlighted: submit impactful or pioneering work to get highlighted
-                    </p>
-                </div>
-                <button
-                    onclick={() => push("/submit-contribution")}
-                    class="community-submit-button flex items-center gap-[6px] bg-[#101010] text-white px-4 py-2 rounded-[24px] text-[14px] font-medium hover:bg-black transition-colors whitespace-nowrap shrink-0"
-                >
-                    Submit contribution
-                    <img
-                        src="/assets/icons/arrow-right-line.svg"
-                        alt=""
-                        class="w-4 h-4 brightness-0 invert"
-                    />
-                </button>
-            </div>
-            <ProfileHighlights
-                userId={participant?.address}
-                limit={3}
-                category="community"
-                {isOwnProfile}
-            />
-        </div>
+        {#if showPoaps}
+            <ProfilePoaps userId={participant?.address} />
+        {/if}
 
-        <div class="w-full">
-            <h3
-                class="font-semibold text-[20px] text-black mb-[20px]"
-                style="letter-spacing: 0.4px;"
-            >
-                Recent Contributions
-            </h3>
-            <ProfileRecentContributions
-                userId={participant?.address}
-                limit={5}
-                category="community"
-                showViewAll={true}
-                viewAllPath={`/all-contributions?user=${participant?.address}&category=community`}
-                viewAllText="View All Community Contributions →"
-            />
-        </div>
+        {#if showCommunityActivity}
+            <div class="w-full">
+                <div class="community-section-header flex items-start justify-between mb-[20px] gap-4">
+                    <div>
+                        <h3
+                            class="font-semibold text-[20px] text-black"
+                            style="letter-spacing: 0.4px;"
+                        >
+                            Highlights
+                        </h3>
+                        <p class="text-[14px] text-[#999] mt-1">
+                            Get highlighted: submit impactful or pioneering work to get highlighted
+                        </p>
+                    </div>
+                    <button
+                        onclick={() => push("/submit-contribution")}
+                        class="community-submit-button flex items-center gap-[6px] bg-[#101010] text-white px-4 py-2 rounded-[24px] text-[14px] font-medium hover:bg-black transition-colors whitespace-nowrap shrink-0"
+                    >
+                        Submit contribution
+                        <img
+                            src="/assets/icons/arrow-right-line.svg"
+                            alt=""
+                            class="w-4 h-4 brightness-0 invert"
+                        />
+                    </button>
+                </div>
+                <ProfileHighlights
+                    userId={participant?.address}
+                    limit={3}
+                    category="community"
+                    {isOwnProfile}
+                />
+            </div>
+
+            <div class="w-full">
+                <h3
+                    class="font-semibold text-[20px] text-black mb-[20px]"
+                    style="letter-spacing: 0.4px;"
+                >
+                    Recent Contributions
+                </h3>
+                <ProfileRecentContributions
+                    userId={participant?.address}
+                    limit={5}
+                    category="community"
+                    showViewAll={true}
+                    viewAllPath={`/all-contributions?user=${participant?.address}&category=community`}
+                    viewAllText="View All Community Contributions →"
+                />
+            </div>
+        {/if}
     </div>
 </div>
 
@@ -238,6 +299,21 @@
         top: 50%;
         transform: translate(-50%, -50%);
         width: 24px;
+    }
+
+    .community-poap-icon {
+        background:
+            radial-gradient(circle at 32% 24%, rgba(255, 255, 255, 0.9), transparent 28%),
+            linear-gradient(135deg, #ffffff, #ded8ff 46%, #7f52e1);
+        border: 2px solid #fff;
+        border-radius: 999px;
+        box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.48);
+        height: 25px;
+        left: 50%;
+        position: absolute;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        width: 25px;
     }
 
     @media (max-width: 767px) {

--- a/frontend/src/components/profile/ReferralsView.svelte
+++ b/frontend/src/components/profile/ReferralsView.svelte
@@ -308,7 +308,7 @@
                     </div>
                     {#if isOwnProfile}
                         <button
-                            onclick={() => push("/referrals")}
+                            onclick={() => push("/community/referrals")}
                             class="flex items-center gap-[4px] text-[14px] text-[#6b6b6b] hover:text-black transition-colors"
                             style="letter-spacing: 0.28px;"
                         >

--- a/frontend/src/components/ui/Podium.svelte
+++ b/frontend/src/components/ui/Podium.svelte
@@ -29,6 +29,10 @@
       firstGradient: 'linear-gradient(135deg, #6bdc8a 0%, #3eb359 48%, #207b39 100%)',
       glow: 'rgba(62, 179, 89, 0.25)',
     },
+    referral: {
+      firstGradient: 'linear-gradient(135deg, #aa8dff 0%, #7f52e1 48%, #4630a3 100%)',
+      glow: 'rgba(127, 82, 225, 0.25)',
+    },
   };
 
   let scheme = $derived(schemes[category] || schemes.builder);

--- a/frontend/src/routes/CommunityPoaps.svelte
+++ b/frontend/src/routes/CommunityPoaps.svelte
@@ -71,13 +71,13 @@
   });
 </script>
 
-<div class="relative -mx-3 -my-3 overflow-hidden bg-white px-3 py-8 sm:px-5 sm:py-10 md:px-8 md:py-12">
+<div class="relative -mx-3 -my-3 min-h-[calc(100vh-64px)] overflow-hidden bg-white px-3 py-8 sm:px-5 sm:py-10 md:px-8 md:py-12">
   <div
-    class="absolute inset-x-0 top-0 h-[320px] pointer-events-none overflow-hidden"
+    class="absolute inset-x-0 top-0 h-[220px] pointer-events-none overflow-hidden"
     style="-webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 100%); mask-image: linear-gradient(to bottom, black 0%, transparent 100%);"
   >
     <div class="absolute inset-0" style={poapGradientStyle}></div>
-    <div class="absolute inset-0 bg-white/25"></div>
+    <div class="absolute inset-0 bg-white/55"></div>
   </div>
 
   <div class="relative z-10 space-y-6">

--- a/frontend/src/routes/CommunityPoaps.svelte
+++ b/frontend/src/routes/CommunityPoaps.svelte
@@ -4,6 +4,7 @@
   import { showError } from '../lib/toastStore.js';
   import PoapCollectionWall from '../components/poaps/PoapCollectionWall.svelte';
   import CategoryIcon from '../components/portal/CategoryIcon.svelte';
+  import { getCategoryGradientStyle } from '../lib/categoryPresentation.js';
 
   let loading = $state(true);
   /** @type {any[]} */
@@ -13,6 +14,7 @@
   let monthFilter = $state('');
 
   const PAGE_SIZE = 100;
+  const poapGradientStyle = getCategoryGradientStyle('community', '#7f52e1');
 
   async function loadPoaps() {
     loading = true;
@@ -69,10 +71,13 @@
   });
 </script>
 
-<div class="relative -mx-3 -my-3 overflow-hidden px-3 py-8 sm:px-5 sm:py-10 md:px-8 md:py-12">
-  <div class="absolute inset-x-0 top-0 h-[260px] pointer-events-none overflow-hidden" style="-webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 100%); mask-image: linear-gradient(to bottom, black 0%, transparent 100%);">
-    <img src="/assets/illustrations/welcome-gradient.png" alt="" class="absolute inset-0 h-full w-full object-cover opacity-60" />
-    <div class="absolute inset-0 bg-white/35"></div>
+<div class="relative -mx-3 -my-3 overflow-hidden bg-white px-3 py-8 sm:px-5 sm:py-10 md:px-8 md:py-12">
+  <div
+    class="absolute inset-x-0 top-0 h-[320px] pointer-events-none overflow-hidden"
+    style="-webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 100%); mask-image: linear-gradient(to bottom, black 0%, transparent 100%);"
+  >
+    <div class="absolute inset-0" style={poapGradientStyle}></div>
+    <div class="absolute inset-0 bg-white/25"></div>
   </div>
 
   <div class="relative z-10 space-y-6">

--- a/frontend/src/routes/Contributions.svelte
+++ b/frontend/src/routes/Contributions.svelte
@@ -63,6 +63,9 @@
   let activeCategory = $derived($currentCategory || 'global');
   let pageConfig = $derived(categoryConfig[activeCategory] || categoryConfig.global);
   let gradientStyle = $derived(getCategoryGradientStyle(activeCategory, pageConfig.accentColor));
+  let pageGradientStyle = $derived(
+    gradientStyle || getCategoryGradientStyle('community', categoryConfig.community.accentColor)
+  );
   let submitButtonStyle = $derived(getCategoryButtonStyle(pageConfig.accentColor));
   let viewAllUrl = $derived(
     activeCategory === 'global' ? '/all-contributions' : `/all-contributions?category=${activeCategory}`
@@ -139,20 +142,12 @@
   </div>
 {/snippet}
 
-<div class="relative -mx-3 -my-3 overflow-hidden px-3 py-8 sm:px-5 sm:py-10 md:px-8 md:py-12">
+<div class="relative -mx-3 -my-3 overflow-hidden bg-white px-3 py-8 sm:px-5 sm:py-10 md:px-8 md:py-12">
   <div
     class="absolute inset-x-0 top-0 h-[320px] pointer-events-none overflow-hidden"
     style="-webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 100%); mask-image: linear-gradient(to bottom, black 0%, transparent 100%);"
   >
-    {#if activeCategory === 'global'}
-      <img
-        src="/assets/illustrations/welcome-gradient.png"
-        alt=""
-        class="absolute inset-0 h-full w-full object-cover opacity-70"
-      />
-    {:else}
-      <div class="absolute inset-0" style={gradientStyle}></div>
-    {/if}
+    <div class="absolute inset-0" style={pageGradientStyle}></div>
     <div class="absolute inset-0 bg-white/25"></div>
   </div>
 

--- a/frontend/src/routes/PoapDetail.svelte
+++ b/frontend/src/routes/PoapDetail.svelte
@@ -5,6 +5,7 @@
   import { poapsAPI } from '../lib/api.js';
   import { showError, showSuccess } from '../lib/toastStore.js';
   import PoapBadgeImage from '../components/poaps/PoapBadgeImage.svelte';
+  import { getCategoryGradientStyle } from '../lib/categoryPresentation.js';
 
   /** @type {any} */
   let poap = $state(null);
@@ -19,6 +20,7 @@
   let claiming = $state(false);
 
   const CLAIM_PAGE_SIZE = 10;
+  const poapGradientStyle = getCategoryGradientStyle('community', '#7f52e1');
 
   let slug = $derived($params?.slug || '');
   let claimTotalPages = $derived(Math.max(1, Math.ceil(claimsCount / CLAIM_PAGE_SIZE)));
@@ -155,8 +157,16 @@
   });
 </script>
 
-<div class="-mx-3 -my-3 px-3 py-8 sm:px-5 sm:py-10 md:px-8 md:py-12">
-  <div class="space-y-6">
+<div class="relative -mx-3 -my-3 overflow-hidden bg-white px-3 py-8 sm:px-5 sm:py-10 md:px-8 md:py-12">
+  <div
+    class="absolute inset-x-0 top-0 h-[320px] pointer-events-none overflow-hidden"
+    style="-webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 100%); mask-image: linear-gradient(to bottom, black 0%, transparent 100%);"
+  >
+    <div class="absolute inset-0" style={poapGradientStyle}></div>
+    <div class="absolute inset-0 bg-white/25"></div>
+  </div>
+
+  <div class="relative z-10 space-y-6">
     <button class="inline-flex items-center gap-2 text-[14px] font-medium text-[#6b5bd6] hover:text-[#4c3dbd]" onclick={() => push('/community/poaps')}>
       <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m15 18-6-6 6-6" /></svg>
       Back to POAPs

--- a/frontend/src/routes/Profile.svelte
+++ b/frontend/src/routes/Profile.svelte
@@ -18,6 +18,7 @@
     getCurrentUser,
     githubAPI,
     validatorsAPI,
+    poapsAPI,
   } from "../lib/api";
   import { authState } from "../lib/auth";
   import { getValidatorBalance } from "../lib/blockchain";
@@ -31,7 +32,6 @@
   import RoleView from "../components/profile/RoleView.svelte";
   import StewardView from "../components/profile/StewardView.svelte";
   import CommunityView from "../components/profile/CommunityView.svelte";
-  import ProfilePoaps from "../components/poaps/ProfilePoaps.svelte";
   import ReferralsView from "../components/profile/ReferralsView.svelte";
   import CTABanner from "../components/shared/CTABanner.svelte";
   import CategoryIcon from "../components/portal/CategoryIcon.svelte";
@@ -92,6 +92,8 @@
   let builderStatsLoaded = $state(false);
   let validatorStatsLoaded = $state(false);
   let communityStatsLoaded = $state(false);
+  let poapCount = $state(0);
+  let poapCountLoaded = $state(false);
 
   // Check if this is the current user's profile
   let isOwnProfile = $derived(
@@ -140,6 +142,9 @@
   );
 
   let showReferralsSection = $derived(isOwnProfile || hasReferralData);
+  let showCommunitySection = $derived(
+    Boolean(participant && (participant.creator || poapCount > 0)),
+  );
 
   $effect(() => {
     const currentParams = $params;
@@ -318,6 +323,32 @@
     } catch (_) {}
   }
 
+  async function fetchPoapCount(participantAddress: string) {
+    const isCurrentRequest = () =>
+      participant?.address?.toLowerCase() === participantAddress.toLowerCase();
+    poapCountLoaded = false;
+    poapCount = 0;
+    try {
+      const response = await poapsAPI.getUserPoaps(participantAddress, {
+        page: 1,
+        page_size: 1,
+      });
+      const data = response.data || {};
+      if (!isCurrentRequest()) {
+        return;
+      }
+      poapCount = data.count ?? (Array.isArray(data) ? data.length : 0);
+    } catch (_) {
+      if (isCurrentRequest()) {
+        poapCount = 0;
+      }
+    } finally {
+      if (isCurrentRequest()) {
+        poapCountLoaded = true;
+      }
+    }
+  }
+
   async function handleClaimX() {
     if (!$authState.isAuthenticated || isClaimingX) return;
     isClaimingX = true;
@@ -358,12 +389,15 @@
       builderStatsLoaded = false;
       validatorStatsLoaded = false;
       communityStatsLoaded = false;
+      poapCountLoaded = false;
+      poapCount = 0;
 
       const res = await usersAPI.getUserByAddress(participantAddress);
       participant = res.data;
       loading = false;
 
       if (participant.address) {
+        fetchPoapCount(participant.address);
         loadingBalance = true;
         getValidatorBalance(participant.address)
           .then((result) => {
@@ -513,6 +547,8 @@
         isValidatorOnly = true;
         loading = false;
         error = null;
+        poapCount = 0;
+        poapCountLoaded = true;
       } else {
         error = err.message || "Failed to load participant data";
         loading = false;
@@ -907,21 +943,16 @@
         </div>
       {/if}
 
-      <!-- POAP Section -->
-      {#if participant}
-        <div id="poaps-section" class="w-full mb-16 pt-10 border-t border-gray-100 mt-10">
-          <ProfilePoaps userId={participant.address} />
-        </div>
-      {/if}
-
       <!-- Community Section -->
-      {#if participant?.creator}
+      {#if showCommunitySection}
         <div id="community-journey-section" class="w-full mb-16 pt-10 border-t border-gray-100 mt-10">
           <CommunityView
             {participant}
             {isOwnProfile}
             communityStats={communityStats}
             communityStatsLoading={!communityStatsLoaded}
+            {poapCount}
+            poapCountLoading={!poapCountLoaded}
             onSocialLinked={handleCommunityLinked}
             onClaimX={handleClaimX}
             onClaimDiscord={handleClaimDiscord}

--- a/frontend/src/routes/ReferralProgram.svelte
+++ b/frontend/src/routes/ReferralProgram.svelte
@@ -184,9 +184,9 @@
 
   function handleGetReferral() {
     if ($authState.isAuthenticated) {
-      push('/referrals');
+      push('/community/referrals');
     } else {
-      sessionStorage.setItem('redirectAfterLogin', '/referrals');
+      sessionStorage.setItem('redirectAfterLogin', '/community/referrals');
       const authButton = document.querySelector('[data-auth-button]');
       if (authButton) authButton.click();
     }

--- a/frontend/src/routes/Referrals.svelte
+++ b/frontend/src/routes/Referrals.svelte
@@ -1,407 +1,403 @@
 <script>
+  // @ts-nocheck
   import { onMount } from 'svelte';
   import { push } from 'svelte-spa-router';
   import Avatar from '../components/Avatar.svelte';
-  import CategoryIcon from '../components/portal/CategoryIcon.svelte';
-  import { usersAPI } from '../lib/api';
-  import { showSuccess } from '../lib/toastStore';
+  import Podium from '../components/ui/Podium.svelte';
+  import { leaderboardAPI } from '../lib/api';
+  import { getCategoryGradientStyle } from '../lib/categoryPresentation.js';
 
-  let referralData = $state(null);
+  const PAGE_SIZE = 10;
+  const PODIUM_SIZE = 3;
+  const REQUEST_SIZE = PAGE_SIZE + 1;
+  const SEARCH_LIMIT = 100;
+
+  let podiumEntries = $state([]);
+  let referrals = $state([]);
   let loading = $state(true);
+  let pageLoading = $state(false);
   let error = $state(null);
   let searchQuery = $state('');
+  let activeSearch = $state('');
+  let currentPage = $state(1);
+  let pendingPage = $state(null);
+  let hasNextPage = $state(false);
+  let totalCount = $state(0);
+  let searchTimer;
+  let requestSequence = 0;
 
-  let totalReferrals = $derived(referralData?.total_referrals ?? 0);
-  let builderReferralPoints = $derived(referralData?.builder_points ?? 0);
-  let validatorReferralPoints = $derived(referralData?.validator_points ?? 0);
-  let totalReferralPoints = $derived(builderReferralPoints + validatorReferralPoints);
+  const pageConfig = {
+    title: 'Referral leaderboard',
+    description: 'Top referrers ranked by eligible referral points.',
+    icon: '/assets/icons/link-m.svg',
+    iconClass: 'bg-[#111827]',
+    accentColor: '#7f52e1',
+    valueLabel: 'RP',
+    podiumCategory: 'referral',
+  };
 
-  let filteredReferrals = $derived(
-    (() => {
-      const list = referralData?.referrals ?? [];
-      const q = searchQuery.trim().toLowerCase();
-      const filtered = !q
-        ? list
-        : list.filter((entry) => {
-            const name = entry.name?.toLowerCase() || '';
-            const address = entry.address?.toLowerCase() || '';
-            return name.includes(q) || address.includes(q);
-          });
-      return filtered
-        .slice()
-        .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
-    })()
-  );
+  const gradientStyle = getCategoryGradientStyle('community', pageConfig.accentColor);
 
-  async function fetchReferrals() {
-    try {
-      loading = true;
-      error = null;
-      const response = await usersAPI.getReferrals();
-      referralData = response.data;
-    } catch (err) {
-      error = err.message || 'Failed to load referrals';
-    } finally {
-      loading = false;
+  let isSearching = $derived(searchQuery.trim().length > 0 || activeSearch.length > 0);
+  let selectedPage = $derived(pendingPage || currentPage);
+  let paginationPages = $derived((() => {
+    const pages = new Set([1, selectedPage]);
+    const start = Math.max(2, currentPage - 2);
+    const end = currentPage + (hasNextPage ? 1 : 0);
+
+    for (let page = start; page <= end; page += 1) {
+      pages.add(page);
     }
+
+    return [...pages].filter((page) => page >= 1).sort((a, b) => a - b);
+  })());
+
+  function shortAddress(address) {
+    if (!address) return '';
+    return `${address.slice(0, 6)}...${address.slice(-4)}`;
   }
 
-  function formatDate(dateString) {
-    if (!dateString) return 'N/A';
-    return new Date(dateString).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
+  function displayName(entry) {
+    const user = entry.user_details || {};
+    return user.name || shortAddress(user.address) || 'Unknown';
   }
 
-  function shortAddress(addr) {
-    if (!addr) return '';
-    return addr.slice(0, 6) + '...' + addr.slice(-4);
+  function getRankClass(rank) {
+    if (rank === 1) return 'bg-[#f8b93d] text-white';
+    if (rank === 2) return 'bg-[#f1f3f7] text-[#333]';
+    if (rank === 3) return 'bg-[#c9956b] text-white';
+    return 'bg-[#f8fafc] text-[#506078]';
   }
 
-  function referralUserObj(referral) {
+  function userMatchesSearch(entry, query) {
+    const user = entry.user_details || {};
+    const name = (user.name || '').toLowerCase();
+    const address = (user.address || '').toLowerCase();
+    return name.includes(query) || address.includes(query);
+  }
+
+  function normalizeReferral(member, fallbackRank) {
+    const totalPoints = member.total_referral_points ?? member.total_points ?? 0;
+
     return {
-      name: referral.name,
-      address: referral.address,
-      profile_image_url: referral.profile_image_url,
-      builder: referral.is_builder,
-      validator: referral.is_validator,
+      id: member.id,
+      rank: member.rank ?? fallbackRank,
+      total_points: totalPoints,
+      points: totalPoints,
+      referral_builder_points: member.referral_builder_points ?? 0,
+      referral_validator_points: member.referral_validator_points ?? 0,
+      user_details: {
+        id: member.id,
+        name: member.name,
+        address: member.address,
+        profile_image_url: member.profile_image_url,
+        builder: member.builder,
+        validator: member.validator,
+        steward: member.steward,
+      },
     };
   }
 
-  function builderEarned(referral) {
-    return Math.round((referral.builder_contribution_points || 0) * 0.1);
+  async function fetchReferralLeaderboard(page = 1, { reset = false } = {}) {
+    const requestId = ++requestSequence;
+    const query = activeSearch.trim().toLowerCase();
+    const shouldShowFullLoader = reset || (podiumEntries.length === 0 && referrals.length === 0);
+
+    try {
+      loading = shouldShowFullLoader;
+      pageLoading = !shouldShowFullLoader;
+      error = null;
+
+      if (query) {
+        const response = await leaderboardAPI.getCommunity({ limit: SEARCH_LIMIT, offset: 0 });
+        if (requestId !== requestSequence) return;
+
+        const entries = (response.data?.results || [])
+          .map((member, index) => normalizeReferral(member, index + 1))
+          .filter((entry) => userMatchesSearch(entry, query));
+
+        podiumEntries = [];
+        referrals = entries.slice(0, PAGE_SIZE);
+        totalCount = entries.length;
+        currentPage = 1;
+        hasNextPage = false;
+        return;
+      }
+
+      const podiumResponse = await leaderboardAPI.getCommunity({ limit: PODIUM_SIZE, offset: 0 });
+      if (requestId !== requestSequence) return;
+
+      const topEntries = (podiumResponse.data?.results || []).map((member, index) => normalizeReferral(member, index + 1));
+      const count = podiumResponse.data?.count ?? topEntries.length;
+      const tableOffset = count >= PODIUM_SIZE
+        ? PODIUM_SIZE + ((page - 1) * PAGE_SIZE)
+        : ((page - 1) * PAGE_SIZE);
+
+      const tableResponse = await leaderboardAPI.getCommunity({ limit: REQUEST_SIZE, offset: tableOffset });
+      if (requestId !== requestSequence) return;
+
+      const tableData = (tableResponse.data?.results || []).map((member, index) => normalizeReferral(member, tableOffset + index + 1));
+
+      podiumEntries = topEntries;
+      referrals = tableData.slice(0, PAGE_SIZE);
+      totalCount = tableResponse.data?.count ?? count;
+      currentPage = page;
+      hasNextPage = tableOffset + tableData.length < totalCount;
+    } catch (err) {
+      if (requestId !== requestSequence) return;
+      error = err.message || 'Failed to load referral leaderboard';
+    } finally {
+      if (requestId === requestSequence) {
+        loading = false;
+        pageLoading = false;
+        pendingPage = null;
+      }
+    }
   }
 
-  function validatorEarned(referral) {
-    return Math.round((referral.validator_contribution_points || 0) * 0.1);
+  function goToPage(page) {
+    if (page === currentPage || page < 1 || loading || pageLoading) return;
+    pendingPage = page;
+    fetchReferralLeaderboard(page);
   }
 
   onMount(() => {
-    fetchReferrals();
+    fetchReferralLeaderboard(1, { reset: true });
+  });
+
+  $effect(() => {
+    const query = searchQuery.trim();
+    clearTimeout(searchTimer);
+
+    searchTimer = setTimeout(() => {
+      if (query !== activeSearch) {
+        activeSearch = query;
+        pendingPage = null;
+        fetchReferralLeaderboard(1, { reset: false });
+      }
+    }, 250);
+
+    return () => clearTimeout(searchTimer);
   });
 </script>
 
-<div class="referrals-page">
-  <!-- Header -->
-  <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-    <div class="flex items-center gap-[10px]">
-      <div
-        class="relative flex-shrink-0"
-        style="width: 32px; height: 32px;"
-      >
-        <img
-          src="/assets/icons/hexagon-genlayer.svg"
-          alt=""
-          class="w-full h-full"
-        />
-        <img
-          src="/assets/icons/link-m.svg"
-          alt=""
-          class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 brightness-0 invert"
-          style="width: 16px; height: 16px;"
-        />
-      </div>
-      <div>
-        <h1
-          class="text-[24px] font-semibold text-black"
-          style="letter-spacing: 0.4px;"
-        >
-          My Referrals
-        </h1>
-        <p class="text-[13px] text-[#999] mt-1">
-          People you've brought to the GenLayer ecosystem
-        </p>
-      </div>
-    </div>
-    <button
-      onclick={() => push('/referral-program')}
-      class="flex items-center gap-[4px] text-[12px] font-medium text-black tracking-[0.24px] leading-[16px] hover:opacity-70 transition-opacity self-start sm:self-center"
-    >
-      Referral Program
-      <img
-        src="/assets/icons/arrow-right-up-line.svg"
-        alt=""
-        class="w-4 h-4"
-      />
-    </button>
+<div class="relative -mx-3 -my-3 min-h-[calc(100vh-64px)] overflow-hidden bg-white px-3 py-8 sm:px-5 sm:py-10 md:px-8 md:py-12">
+  <div
+    class="absolute inset-x-0 top-0 h-[320px] pointer-events-none overflow-hidden"
+    style="-webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 100%); mask-image: linear-gradient(to bottom, black 0%, transparent 100%);"
+  >
+    <div class="absolute inset-0" style={gradientStyle}></div>
+    <div class="absolute inset-0 bg-white/25"></div>
   </div>
 
-  {#if loading}
-    <!-- Stats skeleton -->
-    <div class="flex flex-col md:flex-row gap-4 w-full mb-6">
-      {#each [1, 2, 3] as _}
-        <div
-          class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full animate-pulse"
-        >
-          <div class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"></div>
-          <div class="flex flex-col gap-2">
-            <div class="h-7 w-16 bg-gray-200 rounded"></div>
-            <div class="h-3 w-24 bg-gray-100 rounded"></div>
+  <div class="relative z-10 space-y-6">
+    <header class="flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
+      <div class="space-y-2">
+        <div class="flex items-start gap-3">
+          <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-[12px] {pageConfig.iconClass} shadow-[0_8px_18px_rgba(90,96,125,0.18)]">
+            <img src={pageConfig.icon} alt="" class="h-5 w-5 brightness-0 invert" />
           </div>
+          <h1
+            class="min-w-0 break-words text-[34px] font-semibold leading-none text-black sm:text-[40px] md:text-[46px] font-display"
+            style="letter-spacing: -1px;"
+          >
+            {pageConfig.title}
+          </h1>
         </div>
-      {/each}
-    </div>
+        <p class="max-w-2xl text-[14px] text-[#3f4b5f] sm:text-[15px]" style="letter-spacing: 0.2px;">
+          {pageConfig.description}
+        </p>
+      </div>
 
-    <!-- List skeleton -->
-    <div class="bg-[#fcfcfc] border border-[#f0f0f0] rounded-[16px] p-[16px]">
-      <div class="flex flex-col gap-[6px]">
-        {#each [1, 2, 3, 4, 5] as _}
-          <div
-            class="flex items-center gap-[10px] rounded-[10px] bg-white px-3 py-[14px] animate-pulse"
-          >
-            <div class="w-8 h-8 rounded-full bg-gray-200"></div>
-            <div class="flex-1 h-4 bg-gray-200 rounded"></div>
-            <div class="w-20 h-4 bg-gray-100 rounded"></div>
-          </div>
-        {/each}
-      </div>
-    </div>
-  {:else if error}
-    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-[12px]">
-      <p class="text-sm font-medium">Error loading referrals</p>
-      <p class="text-sm mt-1">{error}</p>
-    </div>
-  {:else if !referralData || referralData.referrals.length === 0}
-    <!-- Empty State -->
-    <div
-      class="bg-[#1a1c1d] w-full rounded-[16px] p-[40px] flex flex-col items-center text-center"
-    >
-      <div
-        class="relative flex-shrink-0 mb-4"
-        style="width: 64px; height: 64px;"
-      >
-        <img
-          src="/assets/icons/hexagon-genlayer.svg"
-          alt=""
-          class="w-full h-full"
-        />
-        <img
-          src="/assets/icons/link-m.svg"
-          alt=""
-          class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 brightness-0 invert"
-          style="width: 32px; height: 32px;"
-        />
-      </div>
-      <h2
-        class="font-['Switzer'] font-semibold text-[20px] text-white leading-[25px] tracking-[0.4px] mb-2"
-      >
-        No referrals yet
-      </h2>
-      <p
-        class="font-['Switzer'] text-[14px] text-[#b0b0b0] leading-[21px] tracking-[0.28px] max-w-[420px]"
-      >
-        Start inviting builders and validators. For each referred user who
-        submits at least one contribution, you receive 10% of the points they
-        earn permanently.
-      </p>
-    </div>
-  {:else}
-    <!-- Stats Cards -->
-    <div class="flex flex-col md:flex-row gap-4 w-full mb-6">
-      <!-- Total Referrals -->
-      <div
-        class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative"
-      >
-        <div class="flex h-full items-center">
-          <div
-            class="w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
-          >
+      {#if !loading && !error && (referrals.length > 0 || podiumEntries.length > 0 || searchQuery)}
+        <div class="flex w-full flex-col gap-2 md:w-[320px]">
+          <label for="referral-search" class="sr-only">Search referrers</label>
+          <div class="relative">
             <img
-              src="/assets/icons/hexagon-genlayer.svg"
+              src="/assets/icons/search-line.svg"
               alt=""
-              class="w-full h-full"
+              class="pointer-events-none absolute left-3 top-1/2 z-10 h-5 w-5 -translate-y-1/2 opacity-70"
             />
-            <img
-              src="/assets/icons/link-m.svg"
-              alt=""
-              class="absolute w-5 h-5 brightness-0 invert"
+            <input
+              id="referral-search"
+              bind:value={searchQuery}
+              type="search"
+              class="relative z-0 block h-[42px] w-full rounded-[8px] border border-white/70 bg-white/82 pl-11 pr-3 text-[14px] text-[#111827] shadow-[0_8px_22px_rgba(31,42,68,0.08)] outline-none backdrop-blur-md placeholder:text-[#7b8798] focus:border-black focus:ring-2 focus:ring-black/10"
+              placeholder="Search by name or address"
             />
           </div>
-          <div
-            class="flex flex-col h-full items-start justify-center whitespace-nowrap z-10"
+          <button
+            type="button"
+            onclick={() => push('/referral-program')}
+            class="inline-flex h-10 items-center justify-center gap-1.5 rounded-[8px] border border-[#dfe4ee] bg-white/82 px-3 text-[13px] font-semibold text-[#111827] shadow-[0_8px_18px_rgba(31,42,68,0.06)] backdrop-blur-md transition hover:-translate-y-0.5 hover:shadow-[0_14px_26px_rgba(31,42,68,0.12)]"
           >
-            <p
-              class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
-            >
-              {totalReferrals}
-            </p>
-            <p
-              class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
-            >
-              Total Referrals
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <!-- Builder Referral Points -->
-      <div
-        class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative"
-      >
-        <div class="flex h-full items-center">
-          <div
-            class="w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
-          >
-            <CategoryIcon category="builder" mode="hexagon" size={48} />
-          </div>
-          <div
-            class="flex flex-col h-full items-start justify-center whitespace-nowrap z-10"
-          >
-            <p
-              class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
-            >
-              {builderReferralPoints}
-            </p>
-            <p
-              class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
-            >
-              Builder Referral Points
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <!-- Validator Referral Points -->
-      <div
-        class="bg-white border border-[#f0f0f0] rounded-[16px] flex items-center p-[24px] h-[92px] w-full relative"
-      >
-        <div class="flex h-full items-center">
-          <div
-            class="w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
-          >
-            <CategoryIcon category="validator" mode="hexagon" size={48} />
-          </div>
-          <div
-            class="flex flex-col h-full items-start justify-center whitespace-nowrap z-10"
-          >
-            <p
-              class="font-semibold text-[32px] leading-[32px] tracking-[-0.96px] text-black"
-            >
-              {validatorReferralPoints}
-            </p>
-            <p
-              class="text-[13px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
-            >
-              Validator Referral Points
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Search + Counter -->
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-3">
-      <p class="text-[13px] text-[#6b6b6b]">
-        Showing {searchQuery ? `${filteredReferrals.length} of ` : ''}{referralData.referrals.length} referrals
-      </p>
-      <div class="relative w-full sm:w-72">
-        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-          <img src="/assets/icons/search-line.svg" alt="" class="w-4 h-4 opacity-60" />
-        </div>
-        <input
-          bind:value={searchQuery}
-          type="search"
-          placeholder="Search by name or address"
-          class="block w-full pl-9 pr-3 py-2 text-[13px] bg-white border border-[#f0f0f0] rounded-[10px] placeholder-[#999] focus:outline-none focus:border-[#1a1c1d] transition-colors"
-        />
-      </div>
-    </div>
-
-    <!-- Referrals List -->
-    <div
-      class="bg-[#fcfcfc] border border-[#f0f0f0] rounded-[16px] p-[16px]"
-    >
-      {#if searchQuery && filteredReferrals.length === 0}
-        <div class="text-center py-8 text-[14px] text-[#999]">
-          No referrals found matching "{searchQuery}"
-        </div>
-      {:else}
-        <div class="flex flex-col gap-[6px]">
-          {#each filteredReferrals as referral}
-            <button
-              onclick={() => push(`/participant/${referral.address}`)}
-              class="flex flex-col sm:flex-row sm:items-center sm:justify-between rounded-[10px] bg-white hover:bg-[#f8f8f8] px-3 py-[14px] transition-colors w-full gap-3 text-left"
-            >
-              <!-- Participant -->
-              <div class="flex items-center gap-[10px] min-w-0 flex-1">
-                <Avatar
-                  user={referralUserObj(referral)}
-                  size="sm"
-                  clickable={false}
-                />
-                <div class="flex flex-col items-start min-w-0">
-                  <span
-                    class="text-[14px] font-medium text-black truncate max-w-[240px]"
-                    style="letter-spacing: 0.2px;"
-                  >
-                    {referral.name || 'Anonymous'}
-                  </span>
-                  <span class="text-[12px] text-[#999] leading-[14px]">
-                    {shortAddress(referral.address)}
-                  </span>
-                </div>
-              </div>
-
-              <!-- Points earned breakdown -->
-              <div class="flex items-center gap-3 flex-shrink-0">
-                <div class="flex items-center gap-[6px] min-w-[120px]">
-                  <CategoryIcon category="builder" mode="hexagon" size={20} />
-                  {#if (referral.builder_contribution_points || 0) > 0}
-                    <div class="flex items-center gap-[4px] text-[12px]">
-                      <span class="text-[#6b6b6b]"
-                        >{(referral.builder_contribution_points || 0).toLocaleString()}</span
-                      >
-                      <span class="text-[#999]">→</span>
-                      <span class="font-medium text-[#ee8521]"
-                        >+{builderEarned(referral)}</span
-                      >
-                    </div>
-                  {:else}
-                    <span class="text-[12px] text-[#cfcfcf]">—</span>
-                  {/if}
-                </div>
-
-                <div class="flex items-center gap-[6px] min-w-[120px]">
-                  <CategoryIcon category="validator" mode="hexagon" size={20} />
-                  {#if (referral.validator_contribution_points || 0) > 0}
-                    <div class="flex items-center gap-[4px] text-[12px]">
-                      <span class="text-[#6b6b6b]"
-                        >{(referral.validator_contribution_points || 0).toLocaleString()}</span
-                      >
-                      <span class="text-[#999]">→</span>
-                      <span class="font-medium text-[#387de8]"
-                        >+{validatorEarned(referral)}</span
-                      >
-                    </div>
-                  {:else}
-                    <span class="text-[12px] text-[#cfcfcf]">—</span>
-                  {/if}
-                </div>
-
-                <span
-                  class="text-[12px] text-[#999] leading-[14px] hidden md:block min-w-[100px] text-right"
-                >
-                  Joined {formatDate(referral.created_at)}
-                </span>
-              </div>
-            </button>
-          {/each}
+            Referral Program
+            <img src="/assets/icons/arrow-right-line.svg" alt="" class="h-4 w-4" />
+          </button>
         </div>
       {/if}
-    </div>
-  {/if}
-</div>
+    </header>
 
-<style>
-  .referrals-page,
-  .referrals-page :global(*) {
-    font-family:
-      "Switzer",
-      -apple-system,
-      BlinkMacSystemFont,
-      "Segoe UI",
-      sans-serif;
-  }
-</style>
+    <section class="rounded-[10px] border border-white/70 bg-white/78 p-5 shadow-[0_18px_55px_rgba(38,48,75,0.15)] backdrop-blur-md sm:p-7 md:p-8">
+      {#if loading}
+        <div class="space-y-8">
+          <div>
+            <div class="mb-4 h-6 w-44 rounded-full bg-[#f2f3f7] animate-pulse"></div>
+            <Podium
+              entries={[]}
+              loading={true}
+              accentColor={pageConfig.accentColor}
+              valueLabel={pageConfig.valueLabel}
+              category={pageConfig.podiumCategory}
+            />
+          </div>
+          <div class="h-[320px] rounded-[8px] border border-[#e8ebf2] bg-white shadow-[0_8px_18px_rgba(31,42,68,0.07)] animate-pulse"></div>
+        </div>
+      {:else if error}
+        <div class="rounded-[8px] border border-red-100 bg-red-50 p-5">
+          <h3 class="text-[14px] font-semibold text-red-800">Error loading referral leaderboard</h3>
+          <p class="mt-1 text-[13px] text-red-700">{error}</p>
+        </div>
+      {:else if totalCount === 0 && !searchQuery}
+        <div class="rounded-[8px] border border-dashed border-[#dfe4ee] bg-white/70 p-10 text-center">
+          <div class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-[12px] bg-[#111827] shadow-[0_8px_18px_rgba(31,42,68,0.12)]">
+            <img src={pageConfig.icon} alt="" class="h-6 w-6 brightness-0 invert" />
+          </div>
+          <h2 class="text-[18px] font-semibold text-black">No referral points yet</h2>
+          <p class="mx-auto mt-2 max-w-md text-[14px] text-[#66708a]">
+            Referrers will appear here once referred users earn eligible builder or validator points.
+          </p>
+        </div>
+      {:else}
+        <div class="space-y-8 md:space-y-10">
+          {#if !isSearching}
+            <section>
+              <Podium
+                entries={podiumEntries}
+                loading={false}
+                accentColor={pageConfig.accentColor}
+                valueLabel={pageConfig.valueLabel}
+                category={pageConfig.podiumCategory}
+              />
+            </section>
+          {/if}
+
+          {#if referrals.length > 0 || isSearching}
+            <section class={!isSearching ? 'border-t border-[#e9ecf3] pt-6 md:pt-8' : ''}>
+              <div class={`overflow-hidden rounded-[8px] border border-[#e8ebf2] bg-white shadow-[0_8px_18px_rgba(31,42,68,0.07)] transition-opacity duration-200 ${pageLoading ? 'opacity-60' : 'opacity-100'}`}>
+                {#if searchQuery && referrals.length === 0}
+                  <div class="p-8 text-center text-[14px] text-[#6b6b6b]">
+                    No referrers found matching "{searchQuery.trim()}"
+                  </div>
+                {:else}
+                <div class="overflow-hidden">
+                  <table class="w-full table-fixed divide-y divide-[#eef1f6]">
+                    <thead class="bg-[#f8fafc]">
+                      <tr>
+                        <th scope="col" class="w-[56px] px-2 py-3 text-left text-[11px] font-semibold uppercase text-[#7b8798] sm:w-[88px] sm:px-6" style="letter-spacing: 0.8px;">
+                          Rank
+                        </th>
+                        <th scope="col" class="px-2 py-3 text-left text-[11px] font-semibold uppercase text-[#7b8798] sm:px-6" style="letter-spacing: 0.8px;">
+                          Referrer
+                        </th>
+                        <th scope="col" class="w-[96px] px-2 py-3 text-right text-[11px] font-semibold uppercase text-[#7b8798] sm:w-[150px] sm:px-6 sm:text-left" style="letter-spacing: 0.8px;">
+                          Points
+                        </th>
+                        <th scope="col" class="hidden w-[220px] px-3 py-3 text-left text-[11px] font-semibold uppercase text-[#7b8798] lg:table-cell lg:px-6" style="letter-spacing: 0.8px;">
+                          Breakdown
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody class="divide-y divide-[#eef1f6] bg-white">
+                      {#each referrals as entry}
+                        <tr class="bg-white transition-colors hover:bg-[#fbfcff]">
+                          <td class="px-2 py-4 align-top sm:px-6">
+                            <span class={`inline-flex h-8 w-8 items-center justify-center rounded-full text-[13px] font-semibold ${getRankClass(entry.rank)}`}>
+                              {entry.rank}
+                            </span>
+                          </td>
+                          <td class="min-w-0 px-2 py-4 align-top sm:px-6">
+                            <div class="flex min-w-0 items-center">
+                              <div class="mr-2 flex-shrink-0 sm:mr-3">
+                                <Avatar user={entry.user_details} size="sm" clickable={true} />
+                              </div>
+                              <div class="min-w-0">
+                                <button
+                                  onclick={() => push(`/participant/${entry.user_details?.address || ''}`)}
+                                  class="block max-w-full truncate text-left text-[14px] font-semibold text-[#111827] transition-colors hover:text-black"
+                                >
+                                  {displayName(entry)}
+                                </button>
+                                <div class="hidden text-[13px] text-[#7b8798] sm:block">
+                                  {entry.user_details?.address || ''}
+                                </div>
+                              </div>
+                            </div>
+                          </td>
+                          <td class="px-2 py-4 text-right align-top sm:px-6 sm:text-left">
+                            <div class="truncate text-[14px] font-semibold text-[#111827]">{entry.total_points}</div>
+                          </td>
+                          <td class="hidden px-3 py-4 align-top lg:table-cell lg:px-6">
+                            <div class="flex flex-wrap gap-2">
+                              <span class="inline-flex items-center rounded-full bg-[#fff5e8] px-2.5 py-1.5 text-[12px] font-semibold text-[#c66c13]">
+                                Builder {entry.referral_builder_points}
+                              </span>
+                              <span class="inline-flex items-center rounded-full bg-[#eef4ff] px-2.5 py-1.5 text-[12px] font-semibold text-[#387de8]">
+                                Validator {entry.referral_validator_points}
+                              </span>
+                            </div>
+                          </td>
+                        </tr>
+                      {/each}
+                    </tbody>
+                  </table>
+                </div>
+                {/if}
+              </div>
+            </section>
+          {/if}
+        </div>
+
+        {#if !isSearching && (currentPage > 1 || hasNextPage)}
+          <div class="mt-6 flex flex-wrap items-center justify-center gap-2">
+            <button
+              onclick={() => goToPage(currentPage - 1)}
+              disabled={currentPage === 1 || loading || pageLoading}
+              class="inline-flex min-h-11 items-center justify-center rounded-[8px] border border-[#dfe4ee] bg-white px-4 text-[13px] font-semibold text-[#111827] shadow-[0_8px_18px_rgba(31,42,68,0.07)] transition hover:-translate-y-0.5 hover:shadow-[0_14px_26px_rgba(31,42,68,0.12)] disabled:translate-y-0 disabled:opacity-45 disabled:shadow-none"
+            >
+              Previous
+            </button>
+
+            {#if paginationPages[1] && paginationPages[1] > 2}
+              <span class="inline-flex min-h-11 min-w-11 items-center justify-center text-[13px] font-semibold text-[#7b8798]">...</span>
+            {/if}
+
+            {#each paginationPages as page}
+              <button
+                onclick={() => goToPage(page)}
+                disabled={page === selectedPage || loading || pageLoading}
+                class={`inline-flex min-h-11 min-w-11 items-center justify-center rounded-[8px] border px-3 text-[13px] font-semibold shadow-[0_8px_18px_rgba(31,42,68,0.06)] transition ${
+                  page === selectedPage
+                    ? 'text-white'
+                    : 'border-[#dfe4ee] bg-white text-[#111827] hover:-translate-y-0.5 hover:shadow-[0_14px_26px_rgba(31,42,68,0.12)]'
+                } disabled:translate-y-0 disabled:shadow-none`}
+                style={page === selectedPage ? `background-color: ${pageConfig.accentColor}; border-color: ${pageConfig.accentColor};` : ''}
+                aria-current={page === selectedPage ? 'page' : undefined}
+              >
+                {page}
+              </button>
+            {/each}
+
+            <button
+              onclick={() => goToPage(currentPage + 1)}
+              disabled={!hasNextPage || loading || pageLoading}
+              class="inline-flex min-h-11 items-center justify-center rounded-[8px] border border-[#dfe4ee] bg-white px-4 text-[13px] font-semibold text-[#111827] shadow-[0_8px_18px_rgba(31,42,68,0.07)] transition hover:-translate-y-0.5 hover:shadow-[0_14px_26px_rgba(31,42,68,0.12)] disabled:translate-y-0 disabled:opacity-45 disabled:shadow-none"
+            >
+              Next
+            </button>
+          </div>
+        {/if}
+      {/if}
+    </section>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Move profile POAPs from a standalone profile section into the Community section.
- Show the Community section for non-creator users only when they have POAPs.
- Add a POAP count metric to the Community metrics row.
- Keep creator-only community content, such as highlights, recent contributions, and the Community Member label, behind the creator role.

## Verification
- `npm run build`
- Browser smoke check on local profile route with the running frontend.
