### PR TITLE
Add POAP wallet recovery flow

### DIFF
--- a/backend/poaps/admin.py
+++ b/backend/poaps/admin.py
@@ -25,6 +25,12 @@ def unused_mint_link_capacity(queryset):
     )['total'] or 0
 
 
+POAP_DISTRIBUTION_ADMIN_METHOD_CHOICES = [
+    (PoapDistribution.METHOD_SECRET, 'Secret phrase'),
+    (PoapDistribution.METHOD_MINT_LINK, 'Mint link'),
+]
+
+
 class PoapDropAdminForm(forms.ModelForm):
     class Meta:
         model = PoapDrop
@@ -59,6 +65,7 @@ class PoapDropAdminForm(forms.ModelForm):
 
 
 class PoapDistributionAdminForm(forms.ModelForm):
+    method = forms.ChoiceField(choices=POAP_DISTRIBUTION_ADMIN_METHOD_CHOICES)
     secret_phrase = forms.CharField(
         required=False,
         help_text='For secret phrase distributions only. Enter a new value to set or rotate the phrase.',
@@ -87,6 +94,13 @@ class PoapDistributionAdminForm(forms.ModelForm):
     class Meta:
         model = PoapDistribution
         fields = '__all__'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        method_choices = list(POAP_DISTRIBUTION_ADMIN_METHOD_CHOICES)
+        if self.instance.pk and self.instance.method == PoapDistribution.METHOD_DISCORD_VOICE:
+            method_choices.append((PoapDistribution.METHOD_DISCORD_VOICE, 'Discord voice'))
+        self.fields['method'].choices = method_choices
 
     def clean(self):
         cleaned_data = super().clean()
@@ -214,7 +228,7 @@ class PoapDropAdmin(CloudinaryUploadMixin, admin.ModelAdmin):
             'fields': ('event_start_at', 'event_end_at'),
         }),
         ('Claiming', {
-            'fields': ('max_claims', 'discord_role_id'),
+            'fields': ('max_claims',),
         }),
         ('Legacy import', {
             'fields': ('legacy_poap_id',),

--- a/backend/poaps/services.py
+++ b/backend/poaps/services.py
@@ -188,22 +188,64 @@ def generate_mint_links(*, distribution, count, max_uses=1, expires_at=None):
     return created
 
 
+def normalize_wallet_address(value):
+    return (value or '').strip().lower()
+
+
+def recover_unmatched_claims_for_wallet(user, wallet_address):
+    result = {
+        'attached_claims': [],
+        'skipped_existing_drop_count': 0,
+    }
+    if not user or not user.pk or not wallet_address:
+        return result
+
+    normalized_wallet = normalize_wallet_address(wallet_address)
+    if not normalized_wallet:
+        return result
+
+    with transaction.atomic():
+        claims = list(
+            PoapClaim.objects
+            .select_for_update()
+            .filter(
+                user__isnull=True,
+                legacy_wallet_address__iexact=normalized_wallet,
+            )
+            .select_related('drop')
+            .order_by('claimed_at', 'pk')
+        )
+        if not claims:
+            return result
+
+        drop_ids = [claim.drop_id for claim in claims]
+        existing_drop_ids = set(
+            PoapClaim.objects
+            .filter(user=user, drop_id__in=drop_ids)
+            .values_list('drop_id', flat=True)
+        )
+
+        for claim in claims:
+            if claim.drop_id in existing_drop_ids:
+                result['skipped_existing_drop_count'] += 1
+                continue
+            claim.user = user
+            claim.save(update_fields=['user', 'updated_at'])
+            result['attached_claims'].append(claim)
+            existing_drop_ids.add(claim.drop_id)
+
+    return result
+
+
+def attach_unmatched_claims_for_wallet(user, wallet_address):
+    return recover_unmatched_claims_for_wallet(user, wallet_address)['attached_claims']
+
+
 def attach_unmatched_claims_for_user(user):
     if not user or not user.pk or not user.address:
         return 0
 
-    attached = 0
-    claims = PoapClaim.objects.filter(
-        user__isnull=True,
-        legacy_wallet_address__iexact=user.address,
-    )
-    for claim in claims.select_related('drop'):
-        if PoapClaim.objects.filter(drop=claim.drop, user=user).exists():
-            continue
-        claim.user = user
-        claim.save(update_fields=['user', 'updated_at'])
-        attached += 1
-    return attached
+    return len(attach_unmatched_claims_for_wallet(user, user.address))
 
 
 def find_user_for_legacy_claim(wallet='', email=''):

--- a/backend/poaps/tests/test_poaps.py
+++ b/backend/poaps/tests/test_poaps.py
@@ -515,6 +515,31 @@ class PoapAPITest(TestCase):
         self.assertFalse(form.is_valid())
         self.assertIn('mint_link_count', form.errors)
 
+    def test_poap_distribution_admin_form_hides_discord_voice_for_new_distributions(self):
+        form = PoapDistributionAdminForm()
+
+        method_choices = [value for value, _label in form.fields['method'].choices]
+
+        self.assertEqual(
+            method_choices,
+            [
+                PoapDistribution.METHOD_SECRET,
+                PoapDistribution.METHOD_MINT_LINK,
+            ],
+        )
+
+    def test_poap_distribution_admin_form_keeps_existing_discord_voice_distribution_editable(self):
+        distribution = PoapDistribution.objects.create(
+            drop=self.drop,
+            method=PoapDistribution.METHOD_DISCORD_VOICE,
+            active=True,
+        )
+        form = PoapDistributionAdminForm(instance=distribution)
+
+        method_choices = [value for value, _label in form.fields['method'].choices]
+
+        self.assertIn(PoapDistribution.METHOD_DISCORD_VOICE, method_choices)
+
     def test_poap_distribution_admin_form_counts_existing_unused_links_against_drop_capacity(self):
         self.drop.max_claims = 10
         self.drop.save(update_fields=['max_claims', 'updated_at'])

--- a/backend/poaps/tests/test_poaps.py
+++ b/backend/poaps/tests/test_poaps.py
@@ -8,9 +8,12 @@ from django.db import IntegrityError, connection, transaction
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
+from eth_account import Account
+from eth_account.messages import encode_defunct
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from ethereum_auth.models import Nonce
 from poaps.admin import PoapDistributionAdminForm, PoapDropAdminForm
 from poaps.models import PoapClaim, PoapDistribution, PoapDrop, PoapImportBatch
 from poaps.services import generate_mint_links, hash_secret
@@ -55,6 +58,31 @@ class PoapAPITest(TestCase):
         }
         defaults.update(kwargs)
         return PoapDistribution.objects.create(**defaults)
+
+    def _recovery_payload(self, account, portal_user=None, nonce_value='recover-nonce'):
+        portal_user = portal_user or self.user
+        Nonce.objects.create(
+            value=nonce_value,
+            expires_at=timezone.now() + timezone.timedelta(minutes=5),
+        )
+        message = (
+            f'localhost wants you to verify a wallet for GenLayer POAP recovery:\n'
+            f'{account.address}\n\n'
+            'This signature only proves ownership of this wallet for attaching legacy POAPs '
+            'to your current portal account. It will not sign you into the portal or change your account.\n\n'
+            f'Portal Account: {portal_user.address}\n'
+            'URI: http://localhost:5173\n'
+            'Version: 1\n'
+            'Chain ID: 1\n'
+            f'Nonce: {nonce_value}\n'
+            f'Issued At: {timezone.now().isoformat()}'
+        )
+        signed = Account.sign_message(encode_defunct(text=message), private_key=account.key)
+        return {
+            'address': account.address,
+            'message': message,
+            'signature': signed.signature.hex(),
+        }
 
     def test_unique_claim_per_user_and_drop(self):
         PoapClaim.objects.create(
@@ -278,6 +306,153 @@ class PoapAPITest(TestCase):
 
         response = self.client.get('/api/v1/poaps/permissions/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_verify_wallet_attaches_unmatched_legacy_claims_without_changing_session(self):
+        account = Account.create()
+        claim = PoapClaim.objects.create(
+            drop=self.drop,
+            claim_method=PoapClaim.CLAIM_LEGACY,
+            source=PoapClaim.SOURCE_LEGACY_IMPORT,
+            legacy_wallet_address=account.address,
+        )
+        session = self.client.session
+        session['ethereum_address'] = self.user.address
+        session['authenticated'] = True
+        session.save()
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            '/api/v1/poaps/verify-wallet/',
+            self._recovery_payload(account),
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['attached_count'], 1)
+        self.assertEqual(response.data['attached_poaps'][0]['drop']['slug'], self.drop.slug)
+        claim.refresh_from_db()
+        self.assertEqual(claim.user, self.user)
+        self.assertEqual(self.client.session['ethereum_address'], self.user.address)
+
+    def test_verify_wallet_rejects_invalid_signature(self):
+        account = Account.create()
+        signer = Account.create()
+        payload = self._recovery_payload(account)
+        payload['signature'] = Account.sign_message(
+            encode_defunct(text=payload['message']),
+            private_key=signer.key,
+        ).signature.hex()
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post('/api/v1/poaps/verify-wallet/', payload, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_verify_wallet_rejects_expired_nonce(self):
+        account = Account.create()
+        nonce_value = 'expired-recovery-nonce'
+        Nonce.objects.create(
+            value=nonce_value,
+            expires_at=timezone.now() - timezone.timedelta(minutes=1),
+        )
+        message = (
+            f'localhost wants you to verify a wallet for GenLayer POAP recovery:\n'
+            f'{account.address}\n\n'
+            'This signature only proves ownership of this wallet for attaching legacy POAPs '
+            'to your current portal account. It will not sign you into the portal or change your account.\n\n'
+            f'Portal Account: {self.user.address}\n'
+            'URI: http://localhost:5173\n'
+            'Version: 1\n'
+            'Chain ID: 1\n'
+            f'Nonce: {nonce_value}\n'
+            f'Issued At: {timezone.now().isoformat()}'
+        )
+        payload = {
+            'address': account.address,
+            'message': message,
+            'signature': Account.sign_message(encode_defunct(text=message), private_key=account.key).signature.hex(),
+        }
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post('/api/v1/poaps/verify-wallet/', payload, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_verify_wallet_blocks_another_users_primary_wallet(self):
+        account = Account.create()
+        self.other_user.address = account.address
+        self.other_user.save(update_fields=['address', 'updated_at'])
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            '/api/v1/poaps/verify-wallet/',
+            self._recovery_payload(account),
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    def test_verify_wallet_blocks_legacy_claims_attached_to_another_user(self):
+        account = Account.create()
+        PoapClaim.objects.create(
+            drop=self.drop,
+            user=self.other_user,
+            claim_method=PoapClaim.CLAIM_LEGACY,
+            source=PoapClaim.SOURCE_LEGACY_IMPORT,
+            legacy_wallet_address=account.address,
+        )
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            '/api/v1/poaps/verify-wallet/',
+            self._recovery_payload(account),
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    def test_verify_wallet_skips_drops_user_already_has(self):
+        account = Account.create()
+        second_drop = PoapDrop.objects.create(
+            title='Second Drop',
+            slug='second-drop',
+            description='Another badge',
+            artwork_url='https://example.com/poap-2.png',
+            event_start_at=timezone.now(),
+            status=PoapDrop.STATUS_ACTIVE,
+        )
+        PoapClaim.objects.create(
+            drop=self.drop,
+            user=self.user,
+            claim_method=PoapClaim.CLAIM_SECRET,
+        )
+        duplicate_claim = PoapClaim.objects.create(
+            drop=self.drop,
+            claim_method=PoapClaim.CLAIM_LEGACY,
+            source=PoapClaim.SOURCE_LEGACY_IMPORT,
+            legacy_wallet_address=account.address,
+        )
+        attachable_claim = PoapClaim.objects.create(
+            drop=second_drop,
+            claim_method=PoapClaim.CLAIM_LEGACY,
+            source=PoapClaim.SOURCE_LEGACY_IMPORT,
+            legacy_wallet_address=account.address,
+        )
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(
+            '/api/v1/poaps/verify-wallet/',
+            self._recovery_payload(account),
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['attached_count'], 1)
+        self.assertEqual(response.data['skipped_existing_drop_count'], 1)
+        duplicate_claim.refresh_from_db()
+        attachable_claim.refresh_from_db()
+        self.assertIsNone(duplicate_claim.user)
+        self.assertEqual(attachable_claim.user, self.user)
 
     def test_poap_drop_admin_form_rejects_lower_max_claims_below_current_claims(self):
         PoapClaim.objects.create(

--- a/backend/poaps/views.py
+++ b/backend/poaps/views.py
@@ -1,10 +1,17 @@
+import re
 from datetime import timezone as datetime_timezone
 
+from django.contrib.auth import get_user_model
 from django.db.models import BooleanField, Count, Exists, F, OuterRef, Prefetch, Q, Value
+from django.db import transaction
 from django.utils import timezone
+from eth_account import Account
+from eth_account.messages import encode_defunct
 from rest_framework import filters, permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
+
+from ethereum_auth.models import Nonce
 
 from .models import PoapClaim, PoapDistribution, PoapDrop
 from .serializers import (
@@ -17,7 +24,27 @@ from .services import (
     PoapClaimError,
     claim_with_mint_link,
     claim_with_secret,
+    normalize_wallet_address,
+    recover_unmatched_claims_for_wallet,
 )
+
+User = get_user_model()
+
+
+def extract_message_field(message, field_name):
+    prefix = f'{field_name}:'
+    for line in (message or '').splitlines():
+        if line.startswith(prefix):
+            return line.split(':', 1)[1].strip()
+    return ''
+
+
+def extract_nonce(message):
+    return extract_message_field(message, 'Nonce')
+
+
+def is_ethereum_address(value):
+    return bool(re.fullmatch(r'0x[a-fA-F0-9]{40}', value or ''))
 
 
 def open_distribution_queryset(at_time=None):
@@ -171,6 +198,129 @@ class PoapDropViewSet(viewsets.ReadOnlyModelViewSet):
             'claim': PoapClaimSerializer(claim).data,
             'drop': PoapDropListSerializer(claim.drop, context={'request': request}).data,
         }, status=status.HTTP_201_CREATED)
+
+    @action(detail=False, methods=['post'], url_path='verify-wallet', permission_classes=[permissions.IsAuthenticated])
+    def verify_wallet(self, request):
+        if not request.user.address:
+            return Response(
+                {'error': 'Your portal account does not have a wallet address.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        wallet_address = normalize_wallet_address(request.data.get('address'))
+        message = request.data.get('message') or ''
+        signature = request.data.get('signature') or ''
+
+        if not wallet_address or not message or not signature:
+            return Response(
+                {'error': 'Address, message, and signature are required.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not is_ethereum_address(wallet_address):
+            return Response({'error': 'Invalid wallet address.'}, status=status.HTTP_400_BAD_REQUEST)
+        if 'GenLayer POAP recovery' not in message or 'will not sign you into the portal' not in message:
+            return Response(
+                {'error': 'Invalid recovery message.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if wallet_address not in message.lower():
+            return Response(
+                {'error': 'Recovery message does not include the wallet being verified.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        portal_account = normalize_wallet_address(extract_message_field(message, 'Portal Account'))
+        if portal_account != normalize_wallet_address(request.user.address):
+            return Response(
+                {'error': 'Recovery message is not for the current portal account.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        nonce_value = extract_nonce(message)
+        if not nonce_value:
+            return Response({'error': 'Invalid message format: No nonce found.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            try:
+                nonce = Nonce.objects.select_for_update().get(value=nonce_value)
+            except Nonce.DoesNotExist:
+                return Response({'error': 'Invalid nonce.'}, status=status.HTTP_400_BAD_REQUEST)
+
+            if not nonce.is_valid():
+                return Response({'error': 'Invalid or expired nonce.'}, status=status.HTTP_400_BAD_REQUEST)
+
+            try:
+                recovered_address = Account.recover_message(
+                    encode_defunct(text=message),
+                    signature=signature,
+                )
+            except Exception:
+                return Response({'error': 'Invalid signature.'}, status=status.HTTP_400_BAD_REQUEST)
+
+            if normalize_wallet_address(recovered_address) != wallet_address:
+                return Response(
+                    {'error': 'Invalid signature: address mismatch.'},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            nonce.mark_as_used()
+
+            if User.objects.filter(address__iexact=wallet_address).exclude(pk=request.user.pk).exists():
+                return Response(
+                    {'error': 'This wallet already belongs to another portal account.'},
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            attached_to_other = (
+                PoapClaim.objects
+                .filter(
+                    legacy_wallet_address__iexact=wallet_address,
+                    user__isnull=False,
+                )
+                .exclude(user=request.user)
+                .exists()
+            )
+            if attached_to_other:
+                return Response(
+                    {'error': 'POAPs for this wallet are already linked to another portal account.'},
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            recovery_result = recover_unmatched_claims_for_wallet(request.user, wallet_address)
+            attached_claims = recovery_result['attached_claims']
+            skipped_existing_drop_count = recovery_result['skipped_existing_drop_count']
+
+            if not attached_claims and (
+                PoapClaim.objects
+                .filter(
+                    legacy_wallet_address__iexact=wallet_address,
+                    user__isnull=False,
+                )
+                .exclude(user=request.user)
+                .exists()
+            ):
+                return Response(
+                    {'error': 'POAPs for this wallet were linked to another portal account.'},
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            already_attached_count = PoapClaim.objects.filter(
+                legacy_wallet_address__iexact=wallet_address,
+                user=request.user,
+            ).count()
+
+        serializer = PoapProfileClaimSerializer(
+            attached_claims,
+            many=True,
+            context={'request': request},
+        )
+        return Response({
+            'verified_address': wallet_address,
+            'attached_count': len(attached_claims),
+            'skipped_existing_drop_count': skipped_existing_drop_count,
+            'already_attached_count': already_attached_count,
+            'attached_poaps': serializer.data,
+        })
 
 
 class UserPoapMixin:

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -106,6 +106,7 @@
   import CommunityPoaps from './routes/CommunityPoaps.svelte';
   import PoapDetail from './routes/PoapDetail.svelte';
   import PoapClaim from './routes/PoapClaim.svelte';
+  import PoapRecovery from './routes/PoapRecovery.svelte';
   import Hackathon from './routes/Hackathon.svelte';
   import HackathonWinners from './routes/HackathonWinners.svelte';
   import Resources from './routes/Resources.svelte';
@@ -134,6 +135,7 @@
     '/community/all-contributions': AllContributions,
     '/community/referrals': Referrals,
     '/community/poaps': CommunityPoaps,
+    '/community/poaps/recover': PoapRecovery,
     '/community/poaps/:slug': PoapDetail,
     '/community/contribution/:id': ContributionPreview,
     '/claim/poap/:token': PoapClaim,

--- a/frontend/src/components/poaps/ProfilePoaps.svelte
+++ b/frontend/src/components/poaps/ProfilePoaps.svelte
@@ -2,6 +2,7 @@
   import { push } from 'svelte-spa-router';
   import { format } from 'date-fns';
   import { poapsAPI } from '../../lib/api.js';
+  import { authState } from '../../lib/auth.js';
   import PoapCollectionWall from './PoapCollectionWall.svelte';
 
   /** @type {{ userId?: string | null, limit?: number }} */
@@ -109,6 +110,12 @@
   );
   let hasMore = $derived(viewAll && count > claims.length);
   let canViewAll = $derived(count > 0);
+  let canRecover = $derived(Boolean(
+    userId &&
+    $authState.isAuthenticated &&
+    $authState.address &&
+    String(userId).toLowerCase() === String($authState.address).toLowerCase()
+  ));
 
   $effect(() => {
     if (userId && userId !== loadedUserId) {
@@ -127,14 +134,24 @@
       <h3 class="text-[20px] font-semibold text-black">POAPs</h3>
       <p class="mt-1 text-[14px] text-[#999]">Collected GenLayer community badges.</p>
     </div>
-    {#if canViewAll}
+    {#if canViewAll || canRecover}
       <div class="flex items-center gap-2">
-        <button
-          class="h-8 rounded-full border border-[#d9d2ff] bg-white px-3 text-[12px] font-semibold text-[#6b5bd6] transition-colors hover:bg-[#f7f4ff]"
-          onclick={viewAll ? showRecentPoaps : showAllPoaps}
-        >
-          {viewAll ? 'Show recent' : 'View all'}
-        </button>
+        {#if canRecover}
+          <button
+            class="h-8 rounded-full border border-[#d9d2ff] bg-white px-3 text-[12px] font-semibold text-[#6b5bd6] transition-colors hover:bg-[#f7f4ff]"
+            onclick={() => push('/community/poaps/recover')}
+          >
+            Recover
+          </button>
+        {/if}
+        {#if canViewAll}
+          <button
+            class="h-8 rounded-full border border-[#d9d2ff] bg-white px-3 text-[12px] font-semibold text-[#6b5bd6] transition-colors hover:bg-[#f7f4ff]"
+            onclick={viewAll ? showRecentPoaps : showAllPoaps}
+          >
+            {viewAll ? 'Show recent' : 'View all'}
+          </button>
+        {/if}
       </div>
     {/if}
   </div>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -307,6 +307,8 @@ export const poapsAPI = {
   claimSecret: (slug, secret) => api.post(`/poaps/${slug}/claim-secret/`, { secret }),
   /** @param {string} token */
   claimLink: (token) => api.post(`/poaps/claim-link/${encodeURIComponent(token)}/`),
+  /** @param {{ address: string, message: string, signature: string }} payload */
+  verifyWallet: (payload) => api.post('/poaps/verify-wallet/', payload),
 };
 
 export default api;

--- a/frontend/src/lib/auth.js
+++ b/frontend/src/lib/auth.js
@@ -90,6 +90,13 @@ const createAuthStore = () => {
 };
 
 const authState = createAuthStore();
+let walletAccountChangeSuppressionCount = 0;
+
+export function setWalletAccountChangeHandlingSuppressed(suppressed) {
+  walletAccountChangeSuppressionCount = suppressed
+    ? walletAccountChangeSuppressionCount + 1
+    : Math.max(0, walletAccountChangeSuppressionCount - 1);
+}
 
 // Create axios instance for auth endpoints with credentials
 const authAxios = axios.create({
@@ -446,6 +453,10 @@ let chainChangedHandler = null;
  * Handle account changes from wallet
  */
 async function handleAccountsChanged(accounts) {
+  if (walletAccountChangeSuppressionCount > 0) {
+    return;
+  }
+
   const state = authState.get();
   
   if (accounts.length === 0) {

--- a/frontend/src/routes/CommunityPoaps.svelte
+++ b/frontend/src/routes/CommunityPoaps.svelte
@@ -1,5 +1,6 @@
 <script>
   import { onMount } from 'svelte';
+  import { push } from 'svelte-spa-router';
   import { poapsAPI } from '../lib/api.js';
   import { showError } from '../lib/toastStore.js';
   import PoapCollectionWall from '../components/poaps/PoapCollectionWall.svelte';
@@ -84,7 +85,7 @@
     <header class="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
       <div class="flex min-w-0 items-start gap-3">
         <div class="mt-1 shrink-0">
-          <CategoryIcon category="community" mode="hexagon" size={44} />
+          <CategoryIcon category="community" mode="hexagon" />
         </div>
         <div class="min-w-0">
           <h1 class="font-display text-[34px] font-semibold leading-none text-black sm:text-[40px] md:text-[46px]" style="letter-spacing: -1px;">POAPs</h1>
@@ -93,6 +94,17 @@
       </div>
 
       <div class="flex w-full flex-col gap-3 xl:w-auto xl:items-end">
+        <button
+          class="inline-flex h-10 items-center justify-center gap-2 rounded-[8px] border border-[#d9d2ff] bg-white px-4 text-[13px] font-semibold text-[#6b5bd6] transition-colors hover:bg-[#f7f4ff] xl:self-end"
+          onclick={() => push('/community/poaps/recover')}
+        >
+          <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path d="M20 12v5a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-5" />
+            <path d="m8 10 4-4 4 4" />
+            <path d="M12 6v10" />
+          </svg>
+          Recover POAPs
+        </button>
         <div class="flex w-full flex-col gap-2 md:flex-row xl:justify-end">
           <label class="relative md:w-[300px]">
             <span class="sr-only">Search POAPs</span>

--- a/frontend/src/routes/PoapRecovery.svelte
+++ b/frontend/src/routes/PoapRecovery.svelte
@@ -1,0 +1,519 @@
+<script>
+  import { ethers } from 'ethers';
+  import { onMount } from 'svelte';
+  import { push } from 'svelte-spa-router';
+  import { getCurrentUser, poapsAPI } from '../lib/api.js';
+  import {
+    authState,
+    getNonce,
+    setWalletAccountChangeHandlingSuppressed,
+    verifyAuth,
+  } from '../lib/auth.js';
+  import { showError, showSuccess } from '../lib/toastStore.js';
+  import SocialLink from '../components/SocialLink.svelte';
+  import CategoryIcon from '../components/portal/CategoryIcon.svelte';
+  import { getCategoryGradientStyle } from '../lib/categoryPresentation.js';
+
+  /** @type {any} */
+  let currentUser = $state(null);
+  let loading = $state(true);
+  let verifying = $state(false);
+  let verifiedAddress = $state('');
+  /** @type {any} */
+  let result = $state(null);
+  let pageError = $state('');
+
+  const poapGradientStyle = getCategoryGradientStyle('community', '#7f52e1');
+
+  let portalAddress = $derived(currentUser?.address || $authState.address || '');
+  let isAuthenticated = $derived(Boolean($authState.isAuthenticated && portalAddress));
+
+  /** @param {string | null | undefined} value */
+  function truncateAddress(value) {
+    if (!value) return '-';
+    return `${value.slice(0, 6)}...${value.slice(-4)}`;
+  }
+
+  function requestLogin() {
+    sessionStorage.setItem('redirectAfterLogin', '/community/poaps/recover');
+    window.setTimeout(() => {
+      const authButton = document.querySelector('[data-auth-button]');
+      if (authButton instanceof HTMLElement) authButton.click();
+    }, 0);
+  }
+
+  async function loadCurrentUser() {
+    loading = true;
+    pageError = '';
+    try {
+      authState.resetVerification();
+      const authenticated = await verifyAuth();
+      if (!authenticated) {
+        currentUser = null;
+        return;
+      }
+      currentUser = await getCurrentUser();
+    } catch (err) {
+      const requestError = /** @type {any} */ (err);
+      pageError = requestError.response?.data?.error || 'Unable to load your portal account.';
+      currentUser = null;
+    } finally {
+      loading = false;
+    }
+  }
+
+  /** @param {any} provider */
+  async function requestRecoveryWallet(provider) {
+    try {
+      await provider.request({
+        method: 'wallet_requestPermissions',
+        params: [{ eth_accounts: {} }],
+      });
+    } catch (err) {
+      const requestError = /** @type {any} */ (err);
+      const unsupportedMethod = requestError?.code === -32601 || /not supported|unsupported/i.test(requestError?.message || '');
+      if (!unsupportedMethod) throw requestError;
+    }
+
+    let accounts = await provider.request({ method: 'eth_accounts' });
+    if (!accounts || accounts.length === 0) {
+      accounts = await provider.request({ method: 'eth_requestAccounts' });
+    }
+    if (!accounts || accounts.length === 0) {
+      throw new Error('No wallet account selected.');
+    }
+    return ethers.getAddress(accounts[0]);
+  }
+
+  /** @param {any} provider */
+  async function getChainId(provider) {
+    try {
+      const chainIdHex = await provider.request({ method: 'eth_chainId' });
+      return chainIdHex ? parseInt(chainIdHex, 16) : 1;
+    } catch {
+      return 1;
+    }
+  }
+
+  /**
+   * @param {string} address
+   * @param {string} nonce
+   * @param {number} chainId
+   */
+  function buildRecoveryMessage(address, nonce, chainId) {
+    const domain = window.location.host;
+    const origin = window.location.origin;
+    return `${domain} wants you to verify a wallet for GenLayer POAP recovery:
+${address}
+
+This signature only proves ownership of this wallet for attaching legacy POAPs to your current portal account. It will not sign you into the portal or change your account.
+
+Portal Account: ${portalAddress}
+URI: ${origin}
+Version: 1
+Chain ID: ${chainId}
+Nonce: ${nonce}
+Issued At: ${new Date().toISOString()}`;
+  }
+
+  /** @param {any} err */
+  function isAuthError(err) {
+    const statusCode = err?.response?.status;
+    return statusCode === 401 || statusCode === 403;
+  }
+
+  async function verifyPoapWallet() {
+    if (!isAuthenticated) {
+      requestLogin();
+      return;
+    }
+    if (!window.ethereum) {
+      showError('No wallet detected. Please install or open your wallet.');
+      return;
+    }
+
+    verifying = true;
+    result = null;
+    pageError = '';
+    setWalletAccountChangeHandlingSuppressed(true);
+
+    try {
+      const provider = window.ethereum;
+      const address = await requestRecoveryWallet(provider);
+      verifiedAddress = address;
+      const nonce = await getNonce();
+      const chainId = await getChainId(provider);
+      const message = buildRecoveryMessage(address, nonce, chainId);
+      const ethersProvider = new ethers.BrowserProvider(provider);
+      const signer = await ethersProvider.getSigner(address);
+      const signature = await signer.signMessage(message);
+
+      const response = await poapsAPI.verifyWallet({
+        address,
+        message,
+        signature,
+      });
+      result = response.data;
+      if (portalAddress) {
+        authState.setAuthenticated(true, portalAddress);
+      }
+      const count = response.data?.attached_count || 0;
+      const skipped = response.data?.skipped_existing_drop_count || 0;
+      showSuccess(
+        count > 0
+          ? `${count} POAP${count === 1 ? '' : 's'} recovered.`
+          : skipped > 0
+            ? 'Wallet verified. Matching POAPs were already on this account.'
+            : 'Wallet verified. No new POAPs found.'
+      );
+    } catch (err) {
+      const requestError = /** @type {any} */ (err);
+      if (isAuthError(requestError)) {
+        authState.setAuthenticated(false, null);
+        authState.resetVerification();
+        requestLogin();
+        return;
+      }
+      const message =
+        requestError.response?.data?.error ||
+        requestError.message ||
+        'Unable to verify this wallet.';
+      showError(message);
+    } finally {
+      verifying = false;
+      window.setTimeout(() => setWalletAccountChangeHandlingSuppressed(false), 600);
+    }
+  }
+
+  /** @param {any} updatedUser */
+  function handleDiscordLinked(updatedUser) {
+    currentUser = updatedUser;
+  }
+
+  onMount(() => {
+    loadCurrentUser();
+  });
+</script>
+
+<div class="relative -mx-3 -my-3 min-h-[calc(100vh-64px)] overflow-hidden bg-white px-3 py-8 sm:px-5 sm:py-10 md:px-8 md:py-12">
+  <div
+    class="absolute inset-x-0 top-0 h-[250px] pointer-events-none overflow-hidden"
+    style="-webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 100%); mask-image: linear-gradient(to bottom, black 0%, transparent 100%);"
+  >
+    <div class="absolute inset-0" style={poapGradientStyle}></div>
+    <div class="absolute inset-0 bg-white/48"></div>
+  </div>
+
+  <div class="relative z-10 mx-auto max-w-[980px] space-y-6">
+    <button class="inline-flex items-center gap-2 text-[14px] font-medium text-[#6b5bd6] hover:text-[#4c3dbd]" onclick={() => push('/community/poaps')}>
+      <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m15 18-6-6 6-6" /></svg>
+      Back to POAPs
+    </button>
+
+    <header class="flex min-w-0 items-start gap-3">
+      <div class="mt-1 shrink-0">
+        <CategoryIcon category="community" mode="hexagon" />
+      </div>
+      <div class="min-w-0">
+        <h1 class="font-display text-[30px] font-semibold leading-none text-black sm:text-[38px] md:text-[44px]" style="letter-spacing: -1px;">Recover POAPs</h1>
+        <p class="mt-2 max-w-[640px] text-[14px] leading-6 text-[#3f4b5f] sm:text-[15px]">
+          Verify another wallet you control to attach legacy GenLayer POAPs to your current portal account.
+        </p>
+      </div>
+    </header>
+
+    {#if loading}
+      <section class="rounded-[14px] border border-white/70 bg-white/86 p-6 shadow-[0_16px_42px_rgba(38,48,75,0.1)] animate-pulse">
+        <div class="h-5 w-44 rounded bg-[#eee8ff]"></div>
+        <div class="mt-5 grid gap-4 md:grid-cols-2">
+          <div class="h-36 rounded-[12px] bg-[#f6f3ff]"></div>
+          <div class="h-36 rounded-[12px] bg-[#f6f3ff]"></div>
+        </div>
+      </section>
+    {:else if pageError}
+      <section class="rounded-[12px] border border-[#f0d2d2] bg-[#fff7f7] p-5 text-[14px] text-[#9f2f2f]">{pageError}</section>
+    {:else if !isAuthenticated}
+      <section class="poap-recovery-card">
+        <div>
+          <p class="poap-kicker">Portal account</p>
+          <h2>Sign in to recover POAPs</h2>
+          <p class="poap-muted">You need to be connected to the portal first. The recovery wallet will only be used to prove ownership.</p>
+        </div>
+        <button class="poap-primary-action" onclick={requestLogin}>Connect portal wallet</button>
+      </section>
+    {:else}
+      <section class="grid gap-4 lg:grid-cols-[minmax(0,1fr)_340px]">
+        <div class="poap-recovery-card">
+          <div class="poap-card-heading">
+            <span class="poap-icon">
+              <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path d="M19 7V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-2" />
+                <path d="M16 12h6" />
+                <path d="m19 9 3 3-3 3" />
+              </svg>
+            </span>
+            <div>
+              <p class="poap-kicker">Current portal wallet</p>
+              <h2>{truncateAddress(portalAddress)}</h2>
+            </div>
+          </div>
+
+          <div class="poap-verify-box">
+            <div>
+              <p class="poap-kicker">Recovery wallet</p>
+              <p class="poap-muted">Select and sign with the wallet that originally collected the POAPs.</p>
+            </div>
+            <button class="poap-primary-action" disabled={verifying} onclick={verifyPoapWallet}>
+              {verifying ? 'Verifying...' : 'Verify POAP wallet'}
+            </button>
+          </div>
+        </div>
+
+        <aside class="poap-recovery-card">
+          <div class="poap-card-heading">
+            <span class="poap-icon discord">
+              <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M20.3 4.4a19.8 19.8 0 0 0-4.9-1.5l-.1.1c-.2.4-.4.8-.6 1.2a18.5 18.5 0 0 0-5.5 0c-.2-.4-.4-.9-.6-1.2l-.1-.1a19.7 19.7 0 0 0-4.9 1.5C.5 9 .1 13.5.5 18l.1.1a19.9 19.9 0 0 0 6 3c.1 0 .1 0 .2-.1.5-.6.9-1.3 1.2-2-.7-.2-1.3-.5-1.9-.9-.1-.1-.1-.1 0-.2l.4-.3h.1a13.2 13.2 0 0 0 12.1 0h.1l.4.3c.1.1.1.2 0 .2-.6.3-1.2.6-1.9.9.4.7.8 1.4 1.2 2 .1.1.1.1.2.1a19.9 19.9 0 0 0 6-3l.1-.1c.5-5.2-.8-9.7-3.5-13.6ZM8.1 15.3c-1.2 0-2.2-1.1-2.2-2.4s1-2.4 2.2-2.4 2.2 1.1 2.2 2.4-1 2.4-2.2 2.4Zm8 0c-1.2 0-2.2-1.1-2.2-2.4s1-2.4 2.2-2.4 2.2 1.1 2.2 2.4-1 2.4-2.2 2.4Z"/>
+              </svg>
+            </span>
+            <div>
+              <p class="poap-kicker">Optional</p>
+              <h2>Discord</h2>
+            </div>
+          </div>
+          <p class="poap-muted">Discord can stay linked for community context, but it does not block wallet recovery.</p>
+          <div class="mt-4">
+            <SocialLink
+              platform="discord"
+              platformLabel="Discord"
+              connection={currentUser?.discord_connection}
+              initiateUrl="/api/auth/discord/"
+              onLinked={handleDiscordLinked}
+              allowUsernameRefresh={true}
+            />
+          </div>
+        </aside>
+      </section>
+
+      {#if result}
+        <section class="poap-result-card">
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p class="poap-kicker">Verified wallet</p>
+              <h2>{truncateAddress(result.verified_address || verifiedAddress)}</h2>
+            </div>
+            <div class="poap-count-pill">
+              <span>{result.attached_count || 0}</span>
+              <span>Recovered</span>
+            </div>
+          </div>
+
+          {#if result.attached_count > 0}
+            <div class="poap-recovered-grid">
+              {#each result.attached_poaps as claim (claim.id)}
+                <button class="poap-recovered-item" type="button" onclick={() => push(`/community/poaps/${claim.drop.slug}`)}>
+                  {#if claim.drop.artwork_url}
+                    <img src={claim.drop.artwork_url} alt="" loading="lazy" />
+                  {:else}
+                    <span>{(claim.drop.title || 'POAP').slice(0, 2).toUpperCase()}</span>
+                  {/if}
+                  <strong>{claim.drop.title}</strong>
+                </button>
+              {/each}
+            </div>
+          {:else if result.skipped_existing_drop_count > 0}
+            <div class="poap-empty-result">
+              Matching POAPs were found for this wallet, but your portal account already has those drops.
+            </div>
+          {:else}
+            <div class="poap-empty-result">
+              No new unmatched POAPs were found for this wallet.
+            </div>
+          {/if}
+        </section>
+      {/if}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .poap-recovery-card,
+  .poap-result-card {
+    background: rgba(255, 255, 255, 0.94);
+    border: 1px solid rgba(127, 82, 225, 0.16);
+    border-radius: 16px;
+    box-shadow: 0 16px 42px rgba(38, 48, 75, 0.08);
+    padding: 22px;
+  }
+
+  .poap-card-heading {
+    align-items: center;
+    display: flex;
+    gap: 12px;
+  }
+
+  .poap-icon {
+    align-items: center;
+    background: #f4ecfd;
+    border: 1px solid #e7ddff;
+    border-radius: 12px;
+    color: #7f52e1;
+    display: inline-flex;
+    height: 42px;
+    justify-content: center;
+    width: 42px;
+  }
+
+  .poap-icon.discord {
+    background: #eef0ff;
+    border-color: #dfe3ff;
+    color: #5865f2;
+  }
+
+  .poap-kicker {
+    color: #7f52e1;
+    font-size: 12px;
+    font-weight: 750;
+    letter-spacing: 0;
+    line-height: 1;
+    margin: 0 0 6px;
+    text-transform: uppercase;
+  }
+
+  h2 {
+    color: #101010;
+    font-size: 20px;
+    font-weight: 750;
+    letter-spacing: 0;
+    line-height: 1.15;
+    margin: 0;
+  }
+
+  .poap-muted {
+    color: #536079;
+    font-size: 14px;
+    line-height: 22px;
+    margin: 8px 0 0;
+  }
+
+  .poap-verify-box {
+    align-items: center;
+    border-top: 1px solid #f0ecff;
+    display: flex;
+    gap: 16px;
+    justify-content: space-between;
+    margin-top: 18px;
+    padding-top: 18px;
+  }
+
+  .poap-primary-action {
+    background: #7f52e1;
+    border: 0;
+    border-radius: 10px;
+    color: #fff;
+    cursor: pointer;
+    flex: 0 0 auto;
+    font-size: 14px;
+    font-weight: 700;
+    height: 42px;
+    padding: 0 16px;
+    transition: background-color 150ms ease, opacity 150ms ease;
+  }
+
+  .poap-primary-action:hover:not(:disabled) {
+    background: #6b43c7;
+  }
+
+  .poap-primary-action:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+
+  .poap-count-pill {
+    align-items: center;
+    background: #f4ecfd;
+    border: 1px solid #e5dcff;
+    border-radius: 999px;
+    color: #5d46bf;
+    display: inline-flex;
+    flex: 0 0 auto;
+    font-size: 12px;
+    font-weight: 800;
+    gap: 8px;
+    padding: 8px 12px;
+    text-transform: uppercase;
+  }
+
+  .poap-count-pill span:first-child {
+    color: #101010;
+    font-size: 18px;
+  }
+
+  .poap-recovered-grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    margin-top: 22px;
+  }
+
+  .poap-recovered-item {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-width: 0;
+    padding: 0;
+    text-align: center;
+  }
+
+  .poap-recovered-item img,
+  .poap-recovered-item > span {
+    align-items: center;
+    background: #f4ecfd;
+    border: 1px solid #e7ddff;
+    border-radius: 999px;
+    display: inline-flex;
+    height: 104px;
+    justify-content: center;
+    object-fit: cover;
+    width: 104px;
+  }
+
+  .poap-recovered-item strong {
+    color: #151329;
+    display: -webkit-box;
+    font-size: 13px;
+    font-weight: 650;
+    line-height: 18px;
+    max-width: 120px;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+  }
+
+  .poap-empty-result {
+    background: #fbfaff;
+    border: 1px solid #f0ecff;
+    border-radius: 12px;
+    color: #6d7282;
+    font-size: 14px;
+    margin-top: 20px;
+    padding: 22px;
+    text-align: center;
+  }
+
+  @media (max-width: 720px) {
+    .poap-verify-box {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .poap-primary-action {
+      width: 100%;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- Add an authenticated POAP recovery view where users can verify another wallet without changing their portal session
- Add a verify-only backend endpoint that attaches unmatched legacy POAP claims for the signed wallet
- Surface duplicate-drop recovery cases clearly when matching legacy claims exist but the portal user already has those POAPs

## Validation
- env/bin/python manage.py check
- npm run build
- Mobile smoke check for /community/poaps/recover at 390x844

## Notes
- Recovery does not create a multi-wallet account system and does not persist the auxiliary wallet.
- Existing repo-wide frontend warnings remain during build.
