### PR TITLE
Keep POAP detail background white

### DIFF
--- a/frontend/src/routes/PoapDetail.svelte
+++ b/frontend/src/routes/PoapDetail.svelte
@@ -157,7 +157,7 @@
   });
 </script>
 
-<div class="relative -mx-3 -my-3 overflow-hidden bg-white px-3 py-8 sm:px-5 sm:py-10 md:px-8 md:py-12">
+<div class="relative -mx-3 -my-3 min-h-[calc(100vh-64px)] overflow-hidden bg-white px-3 py-8 sm:px-5 sm:py-10 md:px-8 md:py-12">
   <div
     class="absolute inset-x-0 top-0 h-[320px] pointer-events-none overflow-hidden"
     style="-webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 100%); mask-image: linear-gradient(to bottom, black 0%, transparent 100%);"


### PR DESCRIPTION
## Summary
- Ensure the POAP detail page owns a white minimum-height background so the community shell background does not appear below the content.

## Verification
- npm run build passes with existing warnings.