### PR TITLE
Improve POAP mint link claim errors

### DIFF
--- a/backend/poaps/services.py
+++ b/backend/poaps/services.py
@@ -147,22 +147,50 @@ def claim_with_secret(*, drop_slug, user, secret):
 def claim_with_mint_link(*, token, user):
     if not user or not user.is_authenticated:
         raise InvalidClaimError('Authentication is required.')
+    if not token:
+        raise InvalidClaimError('Mint link token is missing.')
 
     token_digest = hash_token(token)
     with transaction.atomic():
-        mint_link = (
-            PoapMintLink.objects
-            .select_for_update()
-            .select_related('distribution', 'distribution__drop')
-            .get(token_hash=token_digest)
-        )
+        try:
+            mint_link = (
+                PoapMintLink.objects
+                .select_for_update()
+                .select_related('distribution', 'distribution__drop')
+                .get(token_hash=token_digest)
+            )
+        except PoapMintLink.DoesNotExist as exc:
+            raise InvalidClaimError(
+                'Mint link token was not found. Check that the full Claim URL was copied from the admin.'
+            ) from exc
+
         distribution = mint_link.distribution
         drop = PoapDrop.objects.select_for_update().get(pk=distribution.drop_id)
+        now = timezone.now()
+
+        if distribution.method != PoapDistribution.METHOD_MINT_LINK:
+            raise InvalidClaimError('This mint link is not attached to a mint-link distribution.')
+
+        if drop.status == PoapDrop.STATUS_DRAFT:
+            raise ClaimClosedError('This POAP is still in draft and cannot be claimed yet.')
+        if drop.status == PoapDrop.STATUS_ARCHIVED:
+            raise ClaimClosedError('This POAP is archived and is no longer claimable.')
 
         validate_drop_capacity(drop)
-        validate_distribution(distribution)
-        if not mint_link.is_open():
-            raise ClaimClosedError('This mint link is no longer available.')
+
+        if not distribution.active:
+            raise ClaimClosedError('This mint-link distribution is inactive.')
+        if distribution.starts_at and now < distribution.starts_at:
+            raise ClaimClosedError('This mint-link distribution is not open yet.')
+        if distribution.ends_at and now > distribution.ends_at:
+            raise ClaimClosedError('This mint-link distribution has ended.')
+        if distribution.max_claims is not None and distribution.claimed_count >= distribution.max_claims:
+            raise ClaimClosedError('This mint-link distribution has reached its claim limit.')
+
+        if mint_link.expires_at and now > mint_link.expires_at:
+            raise ClaimClosedError('This mint link has expired.')
+        if mint_link.used_count >= mint_link.max_uses:
+            raise ClaimClosedError('This mint link has already been used.')
 
         return _create_claim(
             drop=drop,

--- a/backend/poaps/tests/test_poaps.py
+++ b/backend/poaps/tests/test_poaps.py
@@ -175,6 +175,65 @@ class PoapAPITest(TestCase):
         self.assertEqual(link.used_count, 1)
         self.assertEqual(distribution.claimed_count, 1)
 
+    def test_mint_link_claim_reports_missing_token(self):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post('/api/v1/poaps/claim-link/not-a-real-token/')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data['error'],
+            'Mint link token was not found. Check that the full Claim URL was copied from the admin.',
+        )
+
+    def test_mint_link_claim_reports_inactive_distribution(self):
+        distribution = PoapDistribution.objects.create(
+            drop=self.drop,
+            method=PoapDistribution.METHOD_MINT_LINK,
+            active=False,
+        )
+        [(_link, token)] = generate_mint_links(distribution=distribution, count=1)
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(f'/api/v1/poaps/claim-link/{token}/')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['error'], 'This mint-link distribution is inactive.')
+
+    def test_mint_link_claim_reports_expired_link(self):
+        distribution = PoapDistribution.objects.create(
+            drop=self.drop,
+            method=PoapDistribution.METHOD_MINT_LINK,
+            active=True,
+        )
+        [(_link, token)] = generate_mint_links(
+            distribution=distribution,
+            count=1,
+            expires_at=timezone.now() - timezone.timedelta(minutes=1),
+        )
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(f'/api/v1/poaps/claim-link/{token}/')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['error'], 'This mint link has expired.')
+
+    def test_mint_link_claim_reports_used_link(self):
+        distribution = PoapDistribution.objects.create(
+            drop=self.drop,
+            method=PoapDistribution.METHOD_MINT_LINK,
+            active=True,
+        )
+        [(link, token)] = generate_mint_links(distribution=distribution, count=1)
+        link.used_count = 1
+        link.save(update_fields=['used_count', 'updated_at'])
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(f'/api/v1/poaps/claim-link/{token}/')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['error'], 'This mint link has already been used.')
+
     def test_list_and_profile_poaps_are_query_bounded(self):
         for index in range(15):
             drop = PoapDrop.objects.create(

--- a/backend/poaps/views.py
+++ b/backend/poaps/views.py
@@ -189,10 +189,8 @@ class PoapDropViewSet(viewsets.ReadOnlyModelViewSet):
             claim = claim_with_mint_link(token=token, user=request.user)
         except PoapDrop.DoesNotExist:
             return Response({'error': 'POAP not found.'}, status=status.HTTP_404_NOT_FOUND)
-        except Exception as exc:
-            if hasattr(exc, 'status_code'):
-                return Response({'error': str(exc)}, status=exc.status_code)
-            return Response({'error': 'Invalid mint link.'}, status=status.HTTP_400_BAD_REQUEST)
+        except PoapClaimError as exc:
+            return Response({'error': str(exc)}, status=exc.status_code)
 
         return Response({
             'claim': PoapClaimSerializer(claim).data,


### PR DESCRIPTION
## Summary
- Return specific backend errors for mint-link claim failures instead of a generic invalid-link response.
- Add focused coverage for missing, inactive, expired, and already-used mint links.

## Verification
- env/bin/python manage.py check passes.
- Focused POAP tests are blocked by the existing contributions migration seed issue in contributions/migrations/0037_seed_featured_content.py.