### PR TITLE
Replace profile points metric with top role

### DIFF
--- a/frontend/src/components/profile/RankingsWidget.svelte
+++ b/frontend/src/components/profile/RankingsWidget.svelte
@@ -10,7 +10,6 @@
         builderStats = null,
         validatorStats = null,
         communityStats = null,
-        overallPoints = 0,
         referralPoints = { builder_points: 0, validator_points: 0 },
     } = $props();
 

--- a/frontend/src/lib/profileRole.js
+++ b/frontend/src/lib/profileRole.js
@@ -1,0 +1,158 @@
+const ROLE_ORDER = [
+  {
+    key: "builder",
+    label: "Builder",
+    category: "builder",
+    isActive: (participant) =>
+      participant?.builder || participant?.has_builder_welcome,
+  },
+  {
+    key: "validator",
+    label: "Validator",
+    waitlistLabel: "Validator Waitlist",
+    category: "validator",
+    isActive: (participant) =>
+      participant?.validator || participant?.has_validator_waitlist,
+  },
+  {
+    key: "community",
+    label: "Community",
+    category: "community",
+    isActive: (participant) => participant?.creator,
+  },
+];
+
+function toNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function getRoleLabel(role, participant) {
+  if (
+    role.key === "validator" &&
+    participant?.has_validator_waitlist &&
+    !participant?.validator
+  ) {
+    return role.waitlistLabel;
+  }
+
+  return role.label;
+}
+
+function toRoleBadge(role, participant) {
+  return {
+    key: role.key,
+    label: getRoleLabel(role, participant),
+    category: role.category,
+  };
+}
+
+/**
+ * Derive a profile headline from role-specific activity instead of summing
+ * points across categories with different reward scales.
+ */
+export function getTopRole(
+  participant,
+  { builderStats = {}, validatorStats = {}, communityStats = {} } = {},
+) {
+  const statsByRole = {
+    builder: builderStats,
+    validator: validatorStats,
+    community: communityStats,
+  };
+
+  const activeRoles = ROLE_ORDER.filter((role) => role.isActive(participant));
+
+  const contributionScores = activeRoles.map((role) => ({
+    ...role,
+    label: getRoleLabel(role, participant),
+    score: toNumber(statsByRole[role.key]?.totalContributions),
+  }));
+
+  const bestContributionScore = Math.max(
+    0,
+    ...contributionScores.map((role) => role.score),
+  );
+
+  if (bestContributionScore > 0) {
+    const winners = contributionScores.filter(
+      (role) => role.score === bestContributionScore,
+    );
+
+    if (winners.length > 1) {
+      return {
+        label: "Balanced",
+        category: "genlayer",
+        badges: winners.map((role) => toRoleBadge(role, participant)),
+      };
+    }
+
+    return {
+      label: winners[0].label,
+      category: winners[0].category,
+      badges: [toRoleBadge(winners[0], participant)],
+    };
+  }
+
+  const pointScores = activeRoles.map((role) => ({
+    ...role,
+    label: getRoleLabel(role, participant),
+    score: toNumber(statsByRole[role.key]?.totalPoints),
+  }));
+
+  const bestPointScore = Math.max(0, ...pointScores.map((role) => role.score));
+
+  if (bestPointScore > 0) {
+    const winners = pointScores.filter((role) => role.score === bestPointScore);
+
+    if (winners.length > 1) {
+      return {
+        label: "Balanced",
+        category: "genlayer",
+        badges: winners.map((role) => toRoleBadge(role, participant)),
+      };
+    }
+
+    return {
+      label: winners[0].label,
+      category: winners[0].category,
+      badges: [toRoleBadge(winners[0], participant)],
+    };
+  }
+
+  if (activeRoles.length === 1) {
+    return {
+      label: getRoleLabel(activeRoles[0], participant),
+      category: activeRoles[0].category,
+      badges: [toRoleBadge(activeRoles[0], participant)],
+    };
+  }
+
+  if (activeRoles.length > 1) {
+    return {
+      label: "Multi-role",
+      category: "genlayer",
+      badges: activeRoles.map((role) => toRoleBadge(role, participant)),
+    };
+  }
+
+  if (participant?.steward || participant?.working_groups?.length > 0) {
+    return {
+      label: "Steward",
+      category: "steward",
+      badges: [
+        {
+          key: "steward",
+          label: "Steward",
+          category: "steward",
+        },
+      ],
+    };
+  }
+
+  return {
+    label: "Member",
+    category: "genlayer",
+    badges: [],
+  };
+}

--- a/frontend/src/routes/Profile.svelte
+++ b/frontend/src/routes/Profile.svelte
@@ -24,6 +24,7 @@
   import { getValidatorBalance } from "../lib/blockchain";
   import { showSuccess, showWarning, showError } from "../lib/toastStore";
   import { parseMarkdown } from "../lib/markdownLoader.js";
+  import { getTopRole } from "../lib/profileRole.js";
 
   import ProfileHeader from "../components/profile/ProfileHeader.svelte";
   import RankingsWidget from "../components/profile/RankingsWidget.svelte";
@@ -127,12 +128,16 @@
       !participant.has_builder_welcome,
   );
 
-  let overallPoints = $derived(
-    (builderStats?.totalPoints || 0) +
-      (validatorStats?.totalPoints || 0) +
-      (communityStats?.totalPoints || 0) +
-      (referralPoints?.builder_points || 0) +
-      (referralPoints?.validator_points || 0),
+  let topRole = $derived(
+    getTopRole(participant, {
+      builderStats,
+      validatorStats,
+      communityStats,
+    }),
+  );
+
+  let topRoleStatsLoaded = $derived(
+    builderStatsLoaded && validatorStatsLoaded && communityStatsLoaded,
   );
 
   let hasReferralData = $derived(
@@ -689,11 +694,11 @@
     {#if !isValidatorOnly}
       <div class="mb-10 mt-6 w-full px-0 mx-0">
         <div class="profile-stats-grid flex flex-col md:flex-row gap-4 items-center">
-          <!-- Overall Points Card -->
+          <!-- Top Role Card -->
           <div
             class="profile-stat-card bg-white border border-[#f0f0f0] rounded-[16px] flex items-center justify-between p-[24px] h-[92px] w-full relative overflow-hidden"
           >
-            {#if !contributionStatsLoaded}
+            {#if !topRoleStatsLoaded}
               <div class="flex h-full items-center animate-pulse">
                 <div
                   class="w-[48px] h-[48px] rounded-full bg-gray-200 mr-4 shrink-0"
@@ -706,22 +711,38 @@
             {:else}
               <div class="profile-stat-content flex h-full items-center min-w-0">
                 <div
-                  class="profile-stat-icon w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0"
+                  class="profile-stat-icon w-[48px] h-[48px] relative flex items-center justify-center mr-4 shrink-0 bg-black"
+                  style="clip-path: polygon(50% 0%, 94% 25%, 94% 75%, 50% 100%, 6% 75%, 6% 25%);"
                 >
-                  <CategoryIcon category="genlayer" mode="hexagon" size={48} />
+                  <img
+                    src="/assets/icons/gl-symbol-white.svg"
+                    alt=""
+                    class="w-[24px] h-[24px]"
+                  />
                 </div>
                 <div
-                  class="profile-stat-text flex flex-col h-full items-start justify-center whitespace-nowrap z-10 min-w-0"
+                  class="profile-stat-text flex flex-1 flex-col h-full items-start justify-center z-10 min-w-0"
                 >
-                  <p
-                    class="font-medium text-[32px] leading-[32px] tracking-[-0.96px] text-black"
-                  >
-                    {overallPoints}
-                  </p>
+                  <div class="flex items-center gap-[6px] min-w-0 max-w-full flex-wrap">
+                    <p
+                      class="font-medium text-[22px] md:text-[24px] leading-[24px] md:leading-[26px] text-black min-w-0 max-w-full break-words"
+                    >
+                      {topRole.label}
+                    </p>
+                    {#if topRole.badges?.length}
+                      <div class="flex items-center gap-[3px] shrink-0" aria-label="Top role categories">
+                        {#each topRole.badges as badge (badge.key)}
+                          <span title={badge.label} class="shrink-0">
+                            <CategoryIcon category={badge.category} mode="hexagon" size={22} />
+                          </span>
+                        {/each}
+                      </div>
+                    {/if}
+                  </div>
                   <p
                     class="text-[14px] leading-[15px] tracking-[0.24px] text-[#6b6b6b] mt-1"
                   >
-                    All Points
+                    Top role
                   </p>
                 </div>
               </div>
@@ -829,7 +850,6 @@
           {builderStats}
           {validatorStats}
           {communityStats}
-          {overallPoints}
           {referralPoints}
         />
       </div>

--- a/frontend/src/tests/profileRole.test.js
+++ b/frontend/src/tests/profileRole.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { getTopRole } from "../lib/profileRole.js";
+
+describe("getTopRole", () => {
+  it("uses contribution count instead of summed points", () => {
+    const result = getTopRole(
+      { builder: true, creator: true },
+      {
+        builderStats: { totalContributions: 3, totalPoints: 30 },
+        communityStats: { totalContributions: 8, totalPoints: 10 },
+      },
+    );
+
+    expect(result).toMatchObject({
+      label: "Community",
+      category: "community",
+      badges: [{ category: "community" }],
+    });
+  });
+
+  it("returns Balanced when active roles tie on contributions", () => {
+    const result = getTopRole(
+      { builder: true, creator: true },
+      {
+        builderStats: { totalContributions: 4, totalPoints: 40 },
+        communityStats: { totalContributions: 4, totalPoints: 20 },
+      },
+    );
+
+    expect(result).toMatchObject({
+      label: "Balanced",
+      category: "genlayer",
+      badges: [{ category: "builder" }, { category: "community" }],
+    });
+  });
+
+  it("falls back to the only active role when there is no activity yet", () => {
+    const result = getTopRole(
+      { builder: true },
+      {
+        builderStats: { totalContributions: 0, totalPoints: 0 },
+      },
+    );
+
+    expect(result).toMatchObject({
+      label: "Builder",
+      category: "builder",
+      badges: [{ category: "builder" }],
+    });
+  });
+
+  it("labels validator waitlist users distinctly", () => {
+    const result = getTopRole(
+      { has_validator_waitlist: true },
+      {
+        validatorStats: { totalContributions: 0, totalPoints: 5 },
+      },
+    );
+
+    expect(result).toMatchObject({
+      label: "Validator Waitlist",
+      category: "validator",
+      badges: [{ category: "validator" }],
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "doha-v2",
+  "name": "suva-v1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Replaces the profile All Points card with a top-role metric so builder, validator, and community rewards are not summed across asymmetric point scales. Adds shared top-role derivation logic with category badge metadata for single-role, multi-role, balanced, waitlist, steward, and member states. Updates the profile stat card to use a black GenLayer hexagon and small role-category hexagons while preventing label clipping. Adds focused unit coverage for the top-role calculation.