### PR TITLE
Schedule Discord role sync on main

### DIFF
--- a/.github/workflows/schedule-sync-discord-roles-main.yml
+++ b/.github/workflows/schedule-sync-discord-roles-main.yml
@@ -1,0 +1,19 @@
+name: Schedule Discord Role Sync on Main
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Discord role sync on main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run sync-discord-roles.yml --ref main

--- a/.github/workflows/sync-discord-roles.yml
+++ b/.github/workflows/sync-discord-roles.yml
@@ -1,8 +1,6 @@
 name: Sync Discord Roles
 
 on:
-  schedule:
-    - cron: '*/15 * * * *'
   workflow_dispatch:
 
 jobs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "suva-v1",
+  "name": "karachi",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Adds a scheduled dispatcher workflow on the default branch that triggers the Discord role sync workflow on main every 15 minutes. Removes the direct schedule from the Discord role sync workflow so dev no longer runs the sync itself. Updates the root package lock name from suva-v1 to karachi. Validated with git diff --check and reviewed the PR diff against origin/dev.